### PR TITLE
Add Swagger/OpenAPI contract validation docs and blog

### DIFF
--- a/blog/2025-03-27-swagger-validation.md
+++ b/blog/2025-03-27-swagger-validation.md
@@ -1,0 +1,89 @@
+---
+slug: swagger-contract-validation
+title: New Feature Announcement - Swagger Contract Validation
+authors: [kyrillos]
+tags: [shaft_engine, swagger, openapi, contract_testing]
+---
+
+# 🚀 SHAFT_Engine Now Supports Swagger/OpenAPI Contract Validation!
+
+<a href="https://github.com/ShaftHQ/SHAFT_ENGINE" target="_blank">
+  <img src="https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/master/src/main/resources/images/shaft.png" alt="SHAFT_Engine" height="50px" />
+</a>
+
+### Say goodbye to manual schema checks—contract testing is now automated and built right into SHAFT!
+
+---
+
+## 🛡️ What is Contract Validation?
+
+**Contract testing** ensures your API requests and responses follow the defined structure (contract), helping prevent:
+- Unexpected field changes
+- Data type mismatches
+- Missing or extra fields
+- Runtime errors in API consumers
+
+With the latest release, SHAFT now integrates Swagger/OpenAPI schema validation for all API tests. It will **fail your test automatically** if the request or response doesn’t match the OpenAPI spec you provide. 🔥
+
+---
+
+## 🔧 How to Enable It
+
+### 📂 Via `custom.properties`
+
+```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+swagger.validation.enabled=true
+swagger.validation.url=https://petstore.swagger.io/v2/swagger.json
+```
+
+### 🧪 Or via Code
+
+```java showLineNumbers
+SHAFT.Properties.api.set().swaggerValidationEnabled(true);
+SHAFT.Properties.api.set().swaggerValidationUrl("https://petstore.swagger.io/v2/swagger.json");
+```
+
+You can toggle validation dynamically per test or test class.
+
+---
+
+## ✅ What Gets Validated?
+
+- Request structure (body, headers, parameters)
+- Response structure (status, body schema)
+- Alignment with your OpenAPI/Swagger definition
+
+---
+
+## 📄 Sample Test
+
+```java showLineNumbers
+@Test
+public void testCreateUserWithContractValidation() {
+    SHAFT.API api = new SHAFT.API("https://petstore.swagger.io/v2");
+
+    String invalidPayload = "[{\"id\":\"INVALID_ID\"}]";
+
+    api.post("/user/createWithList")
+       .setRequestBody(invalidPayload)
+       .setContentType("application/json")
+       .perform();
+
+    api.assertThatResponse().statusCode().isEqualTo(400).perform();
+}
+```
+
+> SHAFT will automatically validate the above request and response against the Swagger schema. ❌ If anything is off, your test will fail and report the contract violation.
+
+---
+
+## 🧐 Why It Matters
+
+| Benefit              | Description                                                  |
+|---------------------|--------------------------------------------------------------|
+| 🧪 Test reliability  | Ensure tests align with backend changes                     |
+| 🔁 Catch regressions | CI/CD-ready contract enforcement                            |
+| ❌ Reduce flakiness  | Eliminate schema mismatch failures                          |
+| 🔍 API governance    | Hold your APIs to their contract                            |
+
+---

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -27,3 +27,9 @@ agamy:
   title: SHAFT_Engine maintainer
   url: https://github.com/MustafaAgamy
   image_url: https://github.com/MustafaAgamy.png
+
+kyrillos:
+  name: Kyrillos Nageh
+  title: SHAFT_Engine maintainer
+  url: https://github.com/KyrillosNageh
+  image_url: https://github.com/KyrillosNageh.png

--- a/docs/Basic_Config/basicConfig3.md
+++ b/docs/Basic_Config/basicConfig3.md
@@ -21,6 +21,21 @@ apiSocketTimeout=30
 apiConnectionTimeout=30		
 apiConnectionManagerTimeout=30
 ```
+---
+
+## Swagger / OpenAPI Contract Validation
+
+You can enable automatic schema validation of API requests and responses using a Swagger/OpenAPI specification file.
+
+SHAFT uses the `OpenApiValidationFilter` to ensure that your API communication complies with the defined contract.
+
+```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+# Enables/disables Swagger schema validation feature
+swagger.validation.enabled=true
+
+# Path or URL to your Swagger/OpenAPI schema file
+swagger.validation.url=https://petstore.swagger.io/v2/swagger.json
+```
 
 :::tip[**Tip**]
     You can learn more about the different **[property types]** and the **[full list of supported properties]** by visiting the related pages.

--- a/docs/Properties/PropertiesList.mdx
+++ b/docs/Properties/PropertiesList.mdx
@@ -252,6 +252,42 @@ You can use these tab groups to navigate and get information about how to manage
   </TabItem>
 </Tabs>
 
+### API
+
+This section lists all configurable properties related to Swagger/OpenAPI contract validation for SHAFT API testing.
+
+<Tabs groupId="PropertyTypes" queryString="API">
+
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  // Enable or disable Swagger schema validation
+  SHAFT.Properties.api.set().swaggerValidationEnabled(true);
+  SHAFT.Properties.api.set().swaggerValidationEnabled(false);
+  ```
+  </TabItem>
+
+<TabItem value="cli-based" label="CLI-based">*(Work In Progress)*</TabItem>
+
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  swagger.validation.enabled=true
+  swagger.validation.url=https://petstore.swagger.io/v2/swagger.json
+  ```
+  </TabItem>
+
+  <TabItem value="defaults" label="Default Values">
+
+  | Property Name                 | Default Value | Description                                                                 |
+  |------------------------------|----------------|-----------------------------------------------------------------------------|
+  | `swagger.validation.enabled` | `false`        | Enables or disables Swagger/OpenAPI contract validation for API testing.   |
+  | `swagger.validation.url`     | *(empty)*      | URL or file path to the OpenAPI schema for validation.                     |
+
+  </TabItem>
+
+</Tabs>
+
 ### Flags
 
 - These set of properties control generic platform flags, like the number of test retry attemps, atomaximization of web browser window, and any other built-in checks or workarounds that aim to stabelize your test execution.


### PR DESCRIPTION
This PR introduces documentation and a blog post for the new Swagger/OpenAPI contract validation feature in SHAFT.

🔧 Documentation Updates:
Added API section in PropertiesList.mdx and basicConfig3.md for:

swagger.validation.enabled

swagger.validation.url

Explained how to enable contract validation via:

custom.properties file

SHAFT fluent Java API

📝 Blog Post:
Title: New Feature Announcement - Swagger Contract Validation

Author: Kyrillos Nageh

Date: March 27, 2025

Includes:

What is Contract Validation?

How to enable it

What gets validated

Example test

Benefits and use cases

Resource links

👤 Author Info:
Added KyrillosNageh to authors.yml