### PR TITLE
Make the project generator the canonical SHAFT setup path

### DIFF
--- a/docs/start/installation.mdx
+++ b/docs/start/installation.mdx
@@ -1,13 +1,13 @@
 ---
 id: installation
 title: Install SHAFT
-description: Generate a project or add modular SHAFT dependencies to an existing Maven build.
+description: Generate a new SHAFT project or upgrade an existing automation project.
 slug: /start/installation
 sidebar_position: 2
 tags: [installation, maven, java-25]
 ---
 
-import {EngineDependencies, ProjectCommand, ReleaseFacts} from '@site/src/components/DocSnippets';
+import {ReleaseFacts} from '@site/src/components/DocSnippets';
 
 # Install SHAFT
 
@@ -15,33 +15,37 @@ import {EngineDependencies, ProjectCommand, ReleaseFacts} from '@site/src/compon
 
 <ReleaseFacts />
 
-## Generate a project
+## Create a new project
 
-<ProjectCommand />
+The **SHAFT Project Generator is the only recommended way to create a new
+project**. Choose the test runner and testing surfaces you need, then download
+the ready-to-run project.
 
-The generated project includes a test runner, configuration, sample test, and
-reporting setup. Run it with:
+<iframe
+  src="https://shafthq.github.io/SHAFT_ENGINE/shaft-engine/resources/"
+  width="100%"
+  height="800px"
+  style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '8px'}}
+  title="SHAFT Project Generator"
+></iframe>
 
-```bash
-cd shaft-demo
-mvn test
-```
+:::tip Generator not visible?
+Open the [SHAFT Project Generator in a new tab](https://shafthq.github.io/SHAFT_ENGINE/shaft-engine/resources/).
+:::
 
-## Add SHAFT to an existing project
+The generated project includes the selected test runner, configuration, sample
+tests, reporting setup, and optional CI files.
 
-Import the BOM once, then add the required engine without a separate version:
+## Upgrade an existing project
 
-<EngineDependencies />
+Do not recreate or manually reconfigure an existing automation project. Use the
+[automated upgrade tool](/docs/start/upgrade) for:
 
-Add optional modules only when the matching capability is used. See the
-[module map](/docs/features/modules) before adding providers.
+- Selenium projects
+- Appium projects
+- REST Assured projects
+- Projects using an older SHAFT version
 
-## Verify the installation
-
-```bash
-mvn test-compile
-```
-
-For an existing uppercase `SHAFT_ENGINE` dependency, use the
-[automated upgrade guide](/docs/start/upgrade) instead of mixing legacy and
-modular artifacts.
+The upgrader detects the project type, applies the modular SHAFT dependencies,
+validates the result with Maven, and rolls back its changes if compilation
+fails.

--- a/docs/start/overview.mdx
+++ b/docs/start/overview.mdx
@@ -8,7 +8,7 @@ tags: [overview, web, mobile, api, cli, database]
 ---
 
 import Link from '@docusaurus/Link';
-import {ProjectCommand, ReleaseFacts} from '@site/src/components/DocSnippets';
+import {ReleaseFacts} from '@site/src/components/DocSnippets';
 
 # One engine. Every test surface.
 
@@ -39,12 +39,8 @@ flowchart LR
 
 ## Start in 90 seconds
 
-<ProjectCommand />
-
-```bash
-cd shaft-demo
-mvn test
-```
+Use the [SHAFT Project Generator](/docs/start/installation) to choose your test
+runner and testing surfaces, then download a ready-to-run project.
 
 <ReleaseFacts />
 
@@ -64,9 +60,9 @@ a [Google Open Source Peer Bonus](https://opensource.googleblog.com/2023/05/goog
 
 | Goal | Go directly to |
 |---|---|
-| Create or install a project | [Installation](/docs/start/installation) |
+| Create a new project | [Project Generator](/docs/start/installation) |
 | Run the first test | [Quick start](/docs/start/quick-start) |
 | Connect an AI coding agent | [SHAFT MCP](/docs/agentic/mcp) |
 | Diagnose a failed run | [SHAFT Doctor](/docs/agentic/doctor) |
 | Recover a changed locator | [SHAFT Heal](/docs/agentic/heal) |
-| Upgrade a legacy project | [Upgrade guide](/docs/start/upgrade) |
+| Upgrade a Selenium, Appium, REST Assured, or older SHAFT project | [Automated upgrade tool](/docs/start/upgrade) |

--- a/docs/start/quick-start.md
+++ b/docs/start/quick-start.md
@@ -9,31 +9,26 @@ tags: [quick-start, example]
 
 # Quick start
 
-Get started with SHAFT Engine in minutes! Choose the option that best fits your needs.
+Get started with SHAFT Engine in minutes. The correct path depends on whether
+you are creating a project or upgrading one.
 
-## Option 1: Project Generator (NEW! 🎉)
+## Create a new project
 
 > [!TIP]
-> Recommended for quickly creating new projects with a user-friendly interface.
+> The SHAFT Project Generator is the only recommended way to create a new
+> project.
 
 - The fastest way to create a new SHAFT project with your preferred test runner and platform.
-- Visit the [SHAFT Project Generator](/docs/start/installation) to generate your project in seconds.
+- Use the embedded [SHAFT Project Generator](/docs/start/installation) to generate your project in seconds.
 - Choose your test runner (TestNG, JUnit, or Cucumber), select your platform (Web, Mobile, or API), and download a ready-to-use project.
 - Optionally includes GitHub Actions workflow and Dependabot configuration.
 
-## Option 2: Maven Archetype
+## Upgrade an existing project
 
 > [!TIP]
-> Recommended for new local sandbox projects using command line.
-
-- The easiest and most straightforward way to create a new project that uses SHAFT.
-- Use the [installation command](/docs/start/installation) to generate a configured project.
-
-## Option 3: Upgrade an Existing Project
-
-> [!TIP]
-> This is the recommended route for native Selenium, Appium, REST Assured, and
-> legacy `SHAFT_ENGINE` Maven projects using TestNG or JUnit.
+> The automated upgrade tool is the only recommended way to migrate Selenium,
+> Appium, REST Assured, or older SHAFT projects to the latest modular SHAFT
+> release.
 
 Run the transactional `upgrade_to_modular_shaft.py` script from the
 [upgrade guide](/docs/start/upgrade)
@@ -53,18 +48,9 @@ Read the complete
 [automated upgrade and rollback guide](/docs/start/upgrade) before
 running it on a production repository.
 
-### Manual setup reference
+## Create your first tests
 
-### Step 1: Initial Setup
-
-- Create a new Java/Maven project using the latest version from IntelliJ IDEA, Eclipse, or your favorite IDE.
-- Copy the highlighted contents of
-  this [pom.xml](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml#L10-L121) file into yours
-  inside the ```<project>``` tag.
-
-### Step 2: Creating Tests
-
-#### 2.1. TestNG
+### TestNG
 
 - Create a new Package ```testPackage``` under ```src/test/java```
 - Create a new Java class ```TestClass``` under your newly created `testPackage`.
@@ -128,7 +114,7 @@ public void afterMethod(){
 }
 ```
 
-#### 2.2. JUnit5
+### JUnit 5
 
 - Create a new Package ```testPackage``` under ```src/test/java```
 - Create a new Java class ```TestClass``` under your newly created `testPackage`.
@@ -192,7 +178,7 @@ public void afterEach(){
 }
 ```
 
-#### 2.3. Cucumber
+### Cucumber
 
 - Create the following directory structure: ```src/test/java/cucumberTestRunner``` and ```src/test/java/customCucumberSteps```
 - Create a new Java class ```CucumberTests.java``` under `cucumberTestRunner`.
@@ -277,7 +263,7 @@ Feature: Search functionality
 > <br/>- After saving the changes, remember to delete any old runs you may have triggered by mistake before adding the needed config.
 
 
-### Step 3: Managing Test Data
+### Manage test data
 - Create the following file ```src/test/resources/testDataFiles/simpleJSON.json```.
 - Copy the below code snippet into your newly created json file.
 ```json
@@ -288,7 +274,7 @@ Feature: Search functionality
 }
 ```
 
-### Step 4: Running Tests
+### Run tests
 - Run your ```TestClass.java``` either from the side menu or by pressing the run button.
 - On the first test run: 
   - SHAFT will create a new folder ```src/main/resources/properties``` and generate some default properties files.

--- a/docs/start/upgrade.mdx
+++ b/docs/start/upgrade.mdx
@@ -11,7 +11,7 @@ import {MigrationDependencies} from '@site/src/components/DocSnippets';
 
 # Upgrade to modular SHAFT
 
-The preferred upgrade route is the transactional
+The only recommended upgrade route is the transactional
 `shaft-upgrader` module and its
 [`upgrade_to_modular_shaft.py`](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/shaft-upgrader/upgrade_to_modular_shaft.py)
 script. It upgrades:
@@ -32,9 +32,10 @@ replaces the old Maven coordinate, imports the BOM, scans source and
 configuration for optional capabilities, compiles the result, and rolls back
 every changed file if compilation does not pass.
 
-The manual dependency reference remains below for review and troubleshooting.
+The manual dependency reference remains below only for reviewing the automated
+result and troubleshooting; it is not an alternative migration path.
 
-## Preferred automated upgrade
+## Automated upgrade
 
 ### What the script guarantees
 

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -5,18 +5,6 @@ import TabItem from '@theme/TabItem';
 import releases from '@site/src/data/releases.json';
 import snippets from '@site/src/data/snippets.json';
 
-const projectCommand = `mvn archetype:generate \\
-  "-DarchetypeGroupId=io.github.shafthq" \\
-  "-DarchetypeArtifactId=testng-archetype" \\
-  "-DarchetypeVersion=${releases.archetypeVersion}" \\
-  "-DinteractiveMode=false" \\
-  "-DgroupId=com.example" \\
-  "-DartifactId=shaft-demo"`;
-
-export function ProjectCommand(): JSX.Element {
-  return <CodeBlock language="bash">{projectCommand}</CodeBlock>;
-}
-
 export function EngineDependencies(): JSX.Element {
   return (
     <CodeBlock language="xml">{`<dependencyManagement>

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -1,6 +1,5 @@
 {
   "engineVersion": "10.2.20260612",
-  "archetypeVersion": "10.1.20260331",
   "javaVersion": "25",
   "mavenVersion": "3.9"
 }


### PR DESCRIPTION
### Motivation

- Ensure the interactive SHAFT Project Generator is the single recommended path for creating new projects and remove the Maven TestNG archetype as an alternative. 
- Direct existing Selenium, Appium, REST Assured, or legacy SHAFT projects to the transactional automated upgrader as the only supported migration route. 
- Reduce fragmentation and the risk of mixed/legacy dependency patterns by centralizing generation and migration tooling.

### Description

- Restored and embedded the historical project generator iframe at `/docs/start/installation` and made the embedded generator the only recommended new-project flow. 
- Removed the Maven archetype command and the `ProjectCommand` component from `src/components/DocSnippets` and removed `archetypeVersion` from `src/data/releases.json`. 
- Updated copy across `docs/start/installation.mdx`, `docs/start/quick-start.md`, and `docs/start/overview.mdx` to point new-project guidance to the Project Generator and to point upgrade guidance to the automated upgrader. 
- Clarified upgrade guidance in `docs/start/upgrade.mdx` so the transactional `shaft-upgrader` is the only recommended upgrade path and left manual dependency references only for review/troubleshooting.

### Testing

- Ran `yarn test` and all documentation loader and validation checks passed. 
- Ran `yarn typecheck` and `yarn build` with successful site build output. 
- Installed Playwright browsers and dependencies then ran `yarn test:playwright`, which completed with all 24 Playwright site-render tests passing. 
- Verified the embedded generator URL returns HTTP 200 and inspected the served installation page with a headless Chromium screenshot to confirm the iframe is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db3d01dd08320afc97e5d855067f7)