### PR TITLE
Standardize MCP name/coordinate to `shaft-mcp` and replace client commands with a self-configuring prompt

### DIFF
--- a/blog/2026-05-05-release-10.2.20260505.md
+++ b/blog/2026-05-05-release-10.2.20260505.md
@@ -77,7 +77,7 @@ Or update the dependency directly:
 | 📚 Full Documentation | [shafthq.github.io](https://shafthq.github.io/) |
 | 🚀 Getting Started | [Quick-Start Guide](https://shafthq.github.io/) |
 | 📋 JavaDocs | [ShaftHQ JavaDoc](https://shafthq.github.io/SHAFT_ENGINE/) |
-| 🤖 MCP Server | [SHAFT_MCP](https://github.com/ShaftHQ/SHAFT_MCP) |
+| 🤖 MCP Server | [shaft-mcp](https://github.com/ShaftHQ/shaft-mcp) |
 | 🗺️ Roadmap | [GitHub Projects](https://github.com/orgs/ShaftHQ/projects) |
 | 💬 Community | [GitHub Discussions](https://github.com/ShaftHQ/SHAFT_ENGINE/discussions) |
 | 🐛 Report a Bug | [Bug Report](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/new?template=bug_report.md) |

--- a/blog/2026-05-06-release-10.2.20260506.md
+++ b/blog/2026-05-06-release-10.2.20260506.md
@@ -79,7 +79,7 @@ Or update the dependency directly:
 | 📚 Full Documentation | [shafthq.github.io](https://shafthq.github.io/) |
 | 🚀 Getting Started | [Quick-Start Guide](https://shafthq.github.io/) |
 | 📋 JavaDocs | [ShaftHQ JavaDoc](https://shafthq.github.io/SHAFT_ENGINE/) |
-| 🤖 MCP Server | [SHAFT_MCP](https://github.com/ShaftHQ/SHAFT_MCP) |
+| 🤖 MCP Server | [shaft-mcp](https://github.com/ShaftHQ/shaft-mcp) |
 | 🗺️ Roadmap | [GitHub Projects](https://github.com/orgs/ShaftHQ/projects) |
 | 💬 Community | [GitHub Discussions](https://github.com/ShaftHQ/SHAFT_ENGINE/discussions) |
 | 🐛 Report a Bug | [Bug Report](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/new?template=bug_report.md) |

--- a/blog/2026-06-12-release-10.2.20260612.md
+++ b/blog/2026-06-12-release-10.2.20260612.md
@@ -42,7 +42,7 @@ for installation, configuration, privacy, troubleshooting, and usage examples.
 * Change default value of forceBrowserDownload to false by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2846
 * closes #2841 by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2847
 * docs: update agent guidance and maintenance documentation by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2860
-* [codex] Import SHAFT_MCP history into SHAFT_ENGINE by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2861
+* [codex] Import shaft-mcp history into SHAFT_ENGINE by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2861
 * [codex] Integrate shaft-mcp into reactor and release lifecycle by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2862
 * [codex] Add optional SHAFT Pilot AI-provider foundation by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2867
 * [codex] Add deterministic SHAFT Capture recording model by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2868

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -32,13 +32,13 @@ Build the executable MCP JAR, then use its `capture` subcommand:
 
 ```bash
 mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture start \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture status
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture checkpoint \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture status
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture checkpoint \
   --description "Checkout ready"
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture stop
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture stop
 ```
 
 Use `--runtime-dir <path>` on every command to isolate control files. `stop`
@@ -126,7 +126,7 @@ store.stop(Instant.now());
 Generate a test, SHAFT JSON test data, and a deterministic report:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json \
   --output-dir generated-tests
 ```
@@ -168,12 +168,12 @@ AI enrichment is optional and uses two phases:
 
 ```bash
 # Calls the enabled provider only with explicit processing approval.
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json --output-dir generated-tests \
   --ai-preview --allow-local-ai
 
 # Apply the reviewed, fingerprinted preview.
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json --output-dir generated-tests-enriched \
   --apply-enrichment generated-tests/target/shaft-capture/enrichment-preview.json \
   --approve-enrichment --replay

--- a/docs/agentic/doctor.mdx
+++ b/docs/agentic/doctor.mdx
@@ -54,7 +54,7 @@ From an MCP chat:
 The executable MCP JAR exposes Doctor as a local command:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor analyze \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
   --input allure-results \
   --input target/shaft-logs \
   --allowed-root "$PWD" \
@@ -71,7 +71,7 @@ Screenshots and page snapshots are excluded by default. Retain them only with
 explicit approval:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor analyze \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor \
@@ -87,7 +87,7 @@ as incomplete and is never interpreted as successful.
 ## Optional provider advisory
 
 Add `shaft-ai` when invoking `DoctorAnalyzer.analyzeWithAi(...)` directly. The
-executable `SHAFT_MCP` JAR already packages the OpenAI, Anthropic, Gemini, and
+executable `shaft-mcp` JAR already packages the OpenAI, Anthropic, Gemini, and
 Ollama adapters. CLI provider analysis also requires `--ai`; Pilot properties
 must independently enable the provider, processing location, model, and every
 submitted evidence category.
@@ -101,7 +101,7 @@ java \
   -Dpilot.ai.consent.local=true \
   -Dpilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION \
   -Dpilot.ai.ollama.model=<local-model> \
-  -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor analyze \
+  -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor \
@@ -186,7 +186,7 @@ Example `repair-input.json`:
 ```
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor propose-fix \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor propose-fix \
   --repository "$PWD" \
   --base-sha <full-approved-sha> \
   --diagnosis target/shaft-doctor/doctor-report.json \
@@ -217,7 +217,7 @@ create a worktree.
 Publishing is always a later explicit action:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor publish-draft-pr \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor publish-draft-pr \
   --manifest target/shaft-doctor/repairs/repair-proposal-<id>.json \
   --approval-token <token-from-reviewed-proposal> \
   --approve

--- a/docs/agentic/examples.md
+++ b/docs/agentic/examples.md
@@ -10,18 +10,18 @@ tags: [pilot, examples]
 # Pilot examples
 
 These examples contain no credentials and assume the executable
-`SHAFT_MCP-<version>.jar` has been downloaded from Maven Central or built from
+`shaft-mcp-<version>.jar` has been downloaded from Maven Central or built from
 the monorepo.
 
 ## No-AI Capture to TestNG
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar capture start \
+java -jar shaft-mcp-<version>.jar capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar SHAFT_MCP-<version>.jar capture status
-java -jar SHAFT_MCP-<version>.jar capture stop
-java -jar SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp-<version>.jar capture status
+java -jar shaft-mcp-<version>.jar capture stop
+java -jar shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json \
   --output-dir generated-tests --replay
 ```
@@ -29,7 +29,7 @@ java -jar SHAFT_MCP-<version>.jar capture generate \
 ## No-AI Doctor analysis
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar doctor analyze \
+java -jar shaft-mcp-<version>.jar doctor analyze \
   --input allure-results --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
 ```
@@ -49,10 +49,10 @@ reviewed change. `doctor propose-fix` creates an isolated worktree and does not
 publish to GitHub. Publishing requires a second command with the exact approval
 token returned by the proposal.
 
-Download the credential-free MCP configurations:
+Use the single self-configuring prompt in
+[Connect shaft-mcp](/docs/agentic/mcp) instead of editing a client
+configuration manually.
 
-- [Codex TOML](/examples/shaft-pilot/mcp/codex-config.toml)
-- [Claude Desktop JSON](/examples/shaft-pilot/mcp/claude-desktop.json)
-- [Gemini CLI JSON](/examples/shaft-pilot/mcp/gemini-settings.json)
-- [GitHub Copilot / VS Code JSON](/examples/shaft-pilot/mcp/vscode-mcp.json)
+Download the credential-free Doctor example:
+
 - [Doctor chat invocations](/examples/shaft-pilot/mcp/doctor-analyze-invocations.json)

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -1,33 +1,46 @@
 ---
 id: mcp
-title: Connect SHAFT MCP
+title: Connect shaft-mcp
 description: Run SHAFT browser, Capture, and Doctor tools from Codex, Copilot, and other MCP clients.
 slug: /agentic/mcp
 sidebar_position: 2
 tags: [mcp, codex, copilot, chatgpt, claude, gemini]
 ---
 
-import {McpClientCommands} from '@site/src/components/DocSnippets';
+import {McpSetupPrompt} from '@site/src/components/DocSnippets';
 
-# Connect SHAFT MCP
+# Connect shaft-mcp
 
-`io.github.shafthq:SHAFT_MCP` is the executable Model Context Protocol server
-for SHAFT browser automation. It is built in the SHAFT reactor, depends on the
-canonical `shaft-engine` module, and does not add any dependency to ordinary
+`shaft-mcp` is the executable Model Context Protocol server for SHAFT browser
+automation. It is published to Maven Central as
+`io.github.shafthq:shaft-mcp`, built in the SHAFT reactor, and depends on the
+canonical `shaft-engine` module. It does not add any dependency to ordinary
 `shaft-engine` consumers.
 
-## Connect in one command
+## Connect in one prompt
 
-Docker is the shortest cross-platform path:
+Paste this single prompt into Codex Desktop, Claude Desktop, or the GitHub
+Copilot agent in IntelliJ IDEA:
 
-<McpClientCommands />
+<McpSetupPrompt />
+
+The agent resolves the latest `shaft-mcp` release from Maven Central, downloads
+the executable JAR to an operating-system-appropriate per-user directory,
+writes its own MCP client configuration, reloads it, and verifies the
+connection. You do not need to determine a version, choose a path, or edit a
+configuration file.
+
+The resulting local stdio process lets SHAFT launch the browser on your desktop
+so you can see and interact with the automation session. Do not use the Docker
+image for interactive local browser work: its browser runs inside the container
+and is not displayed on your desktop.
 
 Then ask your client:
 
 > Use SHAFT to open `https://example.com`, verify the page title, and summarize
 > the generated test evidence.
 
-The model provider remains owned by the client. SHAFT MCP does not request,
+The model provider remains owned by the client. `shaft-mcp` does not request,
 store, or proxy the client's model credentials.
 
 ## Build from source
@@ -59,13 +72,13 @@ The HTTP port defaults to `8081` and can be overridden with `PORT` or
 The same JAR also provides a local SHAFT Capture CLI:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture start \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture start \
   --url https://example.test --browser chrome --output recordings/example.json
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture status
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture stop
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture status
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture stop
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json --output-dir generated-tests
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor analyze \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
   --input allure-results --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
 ```
@@ -85,7 +98,7 @@ for the deterministic release gate and standalone-repository archival order.
 
 ## Authentication boundary
 
-SHAFT MCP does not require or store OpenAI, Anthropic, Google, Microsoft, or
+`shaft-mcp` does not require or store OpenAI, Anthropic, Google, Microsoft, or
 Ollama credentials. The MCP client authenticates its own model/provider
 session. Configure only browser/Grid settings required by the SHAFT tools, such
 as `REMOTE_DRIVER_ADDRESS`.
@@ -93,38 +106,18 @@ as `REMOTE_DRIVER_ADDRESS`.
 Browser, filesystem, and GitHub mutations should remain approval-gated in the
 client. Start with a tool allowlist when the client supports one.
 
-## Local stdio clients
+## What the client configures
 
-Build the JAR, replace `<version>` with the reactor version, and use the
-absolute JAR path:
+The desktop agent creates a local stdio server named `shaft-mcp`. Its executable
+is `java`, and its arguments are `-jar` followed by the absolute path of the
+downloaded `shaft-mcp-<version>.jar`. The prompt deliberately delegates path
+selection and configuration-file discovery to the client, making the workflow
+the same on Windows, macOS, and Linux.
 
-```json
-{
-  "mcpServers": {
-    "shaft-mcp": {
-      "type": "stdio",
-      "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
-    }
-  }
-}
-```
-
-Client-specific locations:
-
-- **Codex CLI and IDE extension:** add the server with
-  `codex mcp add shaft-mcp -- java -jar /absolute/path/SHAFT_MCP-<version>.jar`,
-  or use `[mcp_servers.shaft-mcp]` in `~/.codex/config.toml`.
-- **Claude Desktop / Claude Code:** use the `mcpServers` stdio entry in the
-  client configuration.
-- **Gemini CLI:** place the server under the top-level `mcpServers` object in
-  Gemini `settings.json`.
-- **GitHub Copilot in an MCP-capable IDE:** use the IDE's MCP server
-  configuration and the same `java -jar` command. Copilot remains the MCP
-  host and uses its own authentication; there is no generic Copilot model API
-  key for SHAFT to request or store.
-- **Generic MCP clients:** configure a stdio server command with newline
-  delimited JSON-RPC over stdin/stdout.
+The MCP client remains responsible for tool approvals and model
+authentication. When the client requests permission to download the JAR or
+update its settings, approve that operation and let it finish the remaining
+steps.
 
 Codex also supports direct Streamable HTTP:
 
@@ -136,10 +129,13 @@ default_tools_approval_mode = "prompt"
 
 ## Remote clients
 
+Containers and Streamable HTTP are intended for remote, shared, or headless
+deployments where a visible desktop browser is not required.
+
 Start the server locally for testing:
 
 ```bash
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar \
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar \
   --spring.profiles.active=http
 ```
 
@@ -156,11 +152,6 @@ Current client references:
 - [Gemini CLI MCP](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
 - [GitHub Copilot MCP](https://docs.github.com/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers)
 
-Download the credential-free
-[Codex](/examples/shaft-pilot/mcp/codex-config.toml),
-[Claude Desktop](/examples/shaft-pilot/mcp/claude-desktop.json),
-[Gemini CLI](/examples/shaft-pilot/mcp/gemini-settings.json), and
-[VS Code with Copilot](/examples/shaft-pilot/mcp/vscode-mcp.json) samples.
 [Doctor invocations](/examples/shaft-pilot/mcp/doctor-analyze-invocations.json)
 cover ChatGPT, Codex, Claude, Gemini, and GitHub Copilot calls to the same
 `doctor_analyze` tool. Client authentication remains outside SHAFT; Copilot is
@@ -168,16 +159,14 @@ not treated as a direct generic API-key provider.
 
 ## Distribution identity
 
-The first monorepo release preserves:
+The distribution uses:
 
-- Maven: `io.github.shafthq:SHAFT_MCP`
+- Maven Central: `io.github.shafthq:shaft-mcp`
 - MCP server name: `shaft-mcp`
 - Canonical OCI image: `ghcr.io/shafthq/shaft-engine-mcp`
-- First-release compatibility image: `ghcr.io/shafthq/shaft-mcp:10.2.20260612`
 - MCP registry name: `io.github.ShaftHQ/shaft-mcp`
 - Java package and existing tool names
 
 `shaft-mcp/server.json` is a release template. The publication workflow
 replaces `@project.version@` from the root reactor version before registry
-validation and publication. Existing users of the historical image can pin
-the compatibility version above; use the canonical image for upgrades.
+validation and publication.

--- a/docs/agentic/pilot.md
+++ b/docs/agentic/pilot.md
@@ -23,7 +23,7 @@ API key, model, or network call.
 | `shaft-capture` | Managed Chrome/Edge recording and deterministic TestNG generation. |
 | `shaft-doctor` | Portable evidence, deterministic diagnosis, and isolated reviewed repair proposals. |
 | `shaft-ai` | Optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. |
-| `SHAFT_MCP` | Executable stdio and Streamable HTTP server plus Capture and Doctor CLI. |
+| `shaft-mcp` | Executable stdio and Streamable HTTP server plus Capture and Doctor CLI. |
 
 Library consumers should import `shaft-bom` and add only the modules they use:
 
@@ -58,12 +58,12 @@ own authentication.
 
 ## Install the executable
 
-Download `io.github.shafthq:SHAFT_MCP:<version>` from Maven Central, or build it
+Download `io.github.shafthq:shaft-mcp:<version>` from Maven Central, or build it
 from the monorepo:
 
 ```bash
 mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
-java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar
+java -jar shaft-mcp/target/shaft-mcp-<version>.jar
 ```
 
 The default process is an MCP stdio server. The same JAR dispatches `capture`
@@ -75,22 +75,22 @@ Start a privacy-filtered recording. This example is headless for CI or scripted
 use; omit `--headless` when a person will drive the browser locally:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar capture start \
+java -jar shaft-mcp-<version>.jar capture start \
   --url https://example.test \
   --browser chrome \
   --output recordings/example.json \
   --headless
-java -jar SHAFT_MCP-<version>.jar capture status
+java -jar shaft-mcp-<version>.jar capture status
 ```
 
 Drive the visible browser or the automation controlling the headless session,
 optionally add a checkpoint, then stop and generate:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar capture checkpoint \
+java -jar shaft-mcp-<version>.jar capture checkpoint \
   --description "Checkout confirmation is visible" --kind ASSERTION
-java -jar SHAFT_MCP-<version>.jar capture stop
-java -jar SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp-<version>.jar capture stop
+java -jar shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json \
   --output-dir generated-tests \
   --package generated.capture \
@@ -109,7 +109,7 @@ compiles, passes, and produces populated Allure result JSON.
 Analyze only explicitly allowed evidence:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar doctor analyze \
+java -jar shaft-mcp-<version>.jar doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
@@ -127,7 +127,7 @@ Create a complete reviewed input based on
 `examples/shaft-pilot/doctor/repair-input.json`, then run:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar doctor propose-fix \
+java -jar shaft-mcp-<version>.jar doctor propose-fix \
   --repository "$PWD" \
   --base-sha <40-character-commit> \
   --diagnosis target/shaft-doctor/doctor-report.json \
@@ -143,7 +143,7 @@ the current branch or write to GitHub. After reviewing the diff and validation
 result, publish only a draft pull request with the exact returned token:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar doctor publish-draft-pr \
+java -jar shaft-mcp-<version>.jar doctor publish-draft-pr \
   --manifest target/shaft-doctor/repairs/repair-proposal-<id>.json \
   --approval-token <exact-token> \
   --approve
@@ -155,16 +155,16 @@ or proceed without separate explicit approval.
 
 ## MCP clients
 
-For local clients, configure `java -jar /absolute/path/SHAFT_MCP-<version>.jar`
-as a stdio server named `shaft-mcp`. Use the
-[Codex configuration](/examples/shaft-pilot/mcp/codex-config.toml),
-[VS Code configuration](/examples/shaft-pilot/mcp/vscode-mcp.json), or the
-other ready-to-edit downloads for Claude and Gemini.
+For Codex Desktop, Claude Desktop, or GitHub Copilot in IntelliJ IDEA, use the
+single self-configuring prompt in [Connect shaft-mcp](/docs/agentic/mcp). The
+desktop agent resolves the latest Maven Central release, downloads the JAR,
+configures its own local stdio server, reloads the configuration, and verifies
+the connection without requiring you to edit a client configuration file.
 
 Start Streamable HTTP for clients that need a reachable HTTPS endpoint:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar --spring.profiles.active=http
+java -jar shaft-mcp-<version>.jar --spring.profiles.active=http
 ```
 
 The endpoint is `/mcp` and the default port is `8081`. ChatGPT developer

--- a/docs/archive/engine/mcp-history-import.md
+++ b/docs/archive/engine/mcp-history-import.md
@@ -14,7 +14,7 @@ The inventory was captured on 2026-06-11 before the import.
 
 | Item | Value |
 | --- | --- |
-| Source repository | `https://github.com/ShaftHQ/SHAFT_MCP` |
+| Source repository | `https://github.com/ShaftHQ/shaft-mcp` |
 | Source default branch | `main` |
 | Source commit | `5fb9e809ba428a85e0eaff415b5b3cbc79aca7ff` |
 | Source tree | `28fa1693ca9af64fb1e9829c2e7984abe2c7016f` |
@@ -41,7 +41,7 @@ would discard the imported ancestry.
 
 ## Source repository state
 
-At inventory time, `ShaftHQ/SHAFT_MCP` was public, active, and unarchived.
+At inventory time, `ShaftHQ/shaft-mcp` was public, active, and unarchived.
 This migration does not archive it or change any source repository setting,
 release, package, deployment, issue, or pull request.
 
@@ -51,9 +51,9 @@ Open pull requests:
 
 | PR | Branch | Title |
 | --- | --- | --- |
-| [#110](https://github.com/ShaftHQ/SHAFT_MCP/pull/110) | `dependabot/maven/io.github.shafthq-SHAFT_ENGINE-10.2.20260610` | Bump `io.github.shafthq:SHAFT_ENGINE` from `10.2.20260506` to `10.2.20260610` |
-| [#113](https://github.com/ShaftHQ/SHAFT_MCP/pull/113) | `dependabot/maven/org.junit.jupiter-junit-jupiter-engine-6.1.0` | Bump `junit-jupiter-engine` from `6.0.3` to `6.1.0` |
-| [#114](https://github.com/ShaftHQ/SHAFT_MCP/pull/114) | `dependabot/maven/org.apache.maven.surefire-surefire-testng-3.5.6` | Bump `surefire-testng` from `3.5.5` to `3.5.6` |
+| [#110](https://github.com/ShaftHQ/shaft-mcp/pull/110) | `dependabot/maven/io.github.shafthq-SHAFT_ENGINE-10.2.20260610` | Bump `io.github.shafthq:SHAFT_ENGINE` from `10.2.20260506` to `10.2.20260610` |
+| [#113](https://github.com/ShaftHQ/shaft-mcp/pull/113) | `dependabot/maven/org.junit.jupiter-junit-jupiter-engine-6.1.0` | Bump `junit-jupiter-engine` from `6.0.3` to `6.1.0` |
+| [#114](https://github.com/ShaftHQ/shaft-mcp/pull/114) | `dependabot/maven/org.apache.maven.surefire-surefire-testng-3.5.6` | Bump `surefire-testng` from `3.5.5` to `3.5.6` |
 
 The fetched source branch inventory also contained `main`, six
 `smithery/patch-*` branches, two `sync-versions-to-*` branches, and the three
@@ -93,9 +93,9 @@ source tags are not pushed by this pull request.
 
 Maven Central:
 
-- Coordinates: `io.github.shafthq:SHAFT_MCP`
+- Coordinates: `io.github.shafthq:shaft-mcp`
 - Metadata:
-  `https://repo1.maven.org/maven2/io/github/shafthq/SHAFT_MCP/maven-metadata.xml`
+  `https://repo1.maven.org/maven2/io/github/shafthq/shaft-mcp/maven-metadata.xml`
 - Published versions: `9.3.20250823`, `9.3.20250824`, `9.3.20250928`,
   `9.4.20251007`, `9.4.20251022`, `9.4.20251028`, `9.4.20251108`,
   `9.4.20251116`, `10.1.20260312`, `10.1.20260315`, `10.1.20260319`,
@@ -141,11 +141,11 @@ Hosted deployments:
 Documentation and repository links:
 
 - Source README:
-  `https://github.com/ShaftHQ/SHAFT_MCP/blob/main/readme.md`
+  `https://github.com/ShaftHQ/shaft-mcp/blob/main/readme.md`
 - Deployment guide:
-  `https://github.com/ShaftHQ/SHAFT_MCP/blob/main/SMITHERY_DEPLOYMENT.md`
+  `https://github.com/ShaftHQ/shaft-mcp/blob/main/SMITHERY_DEPLOYMENT.md`
 - SHAFT documentation: `https://shafthq.github.io/`
-- Source issues: `https://github.com/ShaftHQ/SHAFT_MCP/issues`
+- Source issues: `https://github.com/ShaftHQ/shaft-mcp/issues`
 
 ## Secrets and variables
 

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -31,7 +31,7 @@ flowchart TB
     Consumer -.->|optional| BrowserStack["shaft-browserstack<br/>BrowserStack Java SDK"]
     Consumer -.->|optional| Video["shaft-video<br/>local desktop recording"]
     Consumer -.->|optional| Visual["shaft-visual<br/>OpenCV + Eyes + Shutterbug"]
-    Agent -.-> MCP["SHAFT_MCP<br/>executable MCP server"]
+    Agent -.-> MCP["shaft-mcp<br/>executable MCP server"]
 
     BrowserStack --> Engine
     Video --> Engine
@@ -66,7 +66,7 @@ flowchart TB
 | `shaft-browserstack` | JAR            | BrowserStack SDK interception and `browserstack.yml` orchestration. Direct BrowserStack sessions stay in `shaft-engine`. |
 | `shaft-video`        | JAR            | Local non-headless desktop recording. Appium-native recording stays in `shaft-engine`.                                   |
 | `shaft-visual`       | JAR            | Reference-image assertions and image-based lookup through OpenCV, Eyes, and Shutterbug.                                  |
-| `SHAFT_MCP`          | executable JAR | Optional MCP server and CLI exposing browser automation, managed capture, Doctor analysis, and packaged direct adapters.  |
+| `shaft-mcp`          | executable JAR | Optional MCP server and CLI exposing browser automation, managed capture, Doctor analysis, and packaged direct adapters.  |
 | `shaft-bom`          | POM            | Aligns all SHAFT artifact versions; adds no runtime classes.                                                             |
 | `SHAFT_ENGINE`       | relocation POM | Temporary legacy-coordinate bridge to `shaft-engine`; adds no optional providers.                                        |
 

--- a/docs/maintainers/mcp-deployment.md
+++ b/docs/maintainers/mcp-deployment.md
@@ -26,7 +26,7 @@ Connect an MCP client to `http://localhost:8081/mcp`.
 
 ## Publication flow
 
-1. The Maven Central workflow publishes `io.github.shafthq:SHAFT_MCP` with the
+1. The Maven Central workflow publishes `io.github.shafthq:shaft-mcp` with the
    complete reactor.
 2. `publish-shaft-mcp.yml` pushes
    `ghcr.io/shafthq/shaft-engine-mcp:<version>` and `latest`.

--- a/docs/maintainers/pilot-release.md
+++ b/docs/maintainers/pilot-release.md
@@ -17,7 +17,7 @@ to an unverified artifact.
 | Area | Required release evidence |
 | --- | --- |
 | Runtime | JDK 25 and Maven 3.9 or newer. |
-| Modules | `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, and `SHAFT_MCP` tests plus full reactor package. |
+| Modules | `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, and `shaft-mcp` tests plus full reactor package. |
 | No-AI path | `pilot.ai.enabled=false`, provider `none`, Capture generation/replay, Doctor diagnosis, and MCP tools pass without credentials. |
 | Browsers | Headless Chrome and Edge record the representative local fixture; generated Chrome replay compiles, passes, and populates Allure. |
 | Doctor | Product, test, locator, data, timing, environment, infrastructure, unknown, empty, and retry evidence fixtures pass. |
@@ -26,7 +26,7 @@ to an unverified artifact.
 | Containers | The release Docker image starts in HTTP mode and completes MCP initialization. |
 | External agents | ChatGPT, Codex, Claude, Gemini, and GitHub Copilot setup is documented with current client limitations and credential ownership. |
 | Publication | Maven Central artifacts, sources, JavaDocs, signatures, BOM, executable JAR, aggregate SBOM, GHCR image, MCP registry metadata, and GitHub release use one version. |
-| Migration | The preserved `io.github.shafthq:SHAFT_MCP` coordinate and `shaft-mcp` server ID resolve. `ghcr.io/shafthq/shaft-mcp:10.2.20260612` remains a tested compatibility image, while `ghcr.io/shafthq/shaft-engine-mcp` is published by the monorepo for current and future releases. |
+| Migration | The preserved `io.github.shafthq:shaft-mcp` coordinate and `shaft-mcp` server ID resolve. `ghcr.io/shafthq/shaft-mcp:10.2.20260612` remains a tested compatibility image, while `ghcr.io/shafthq/shaft-engine-mcp` is published by the monorepo for current and future releases. |
 
 Live paid-provider smoke tests are optional. Run them only with explicit
 approval and credentials in the provider-native environment variable. Their
@@ -91,7 +91,7 @@ JAR, stdio, and packaged/container Streamable HTTP were verified.
 
 ## Standalone repository migration
 
-Do not archive `ShaftHQ/SHAFT_MCP` until every distribution check above passes.
+Do not archive `ShaftHQ/shaft-mcp` until every distribution check above passes.
 Then:
 
 1. Replace its README introduction with a prominent notice that development,
@@ -118,7 +118,7 @@ check leaves the old repository unarchived.
   release. Publish a newer version for corrections.
 - If GHCR, registry, hosted MCP, JavaDocs, or release creation fails, repair
   only that downstream channel and keep the verified Maven version.
-- If migration verification fails, leave `ShaftHQ/SHAFT_MCP` writable and
+- If migration verification fails, leave `ShaftHQ/shaft-mcp` writable and
   restore its normal automation until the canonical path is confirmed.
 - If a secret canary appears in a recording, report, generated test, image,
   log, example, or packaged artifact, stop publication, remove the output,

--- a/docs/maintainers/publication.md
+++ b/docs/maintainers/publication.md
@@ -24,7 +24,7 @@ SHAFT publishes the complete reactor as one Maven Central deployment. Publicatio
 | `io.github.shafthq:shaft-browserstack` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-video` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-visual` | JAR | sources, JavaDocs, signatures |
-| `io.github.shafthq:SHAFT_MCP` | executable JAR | sources, JavaDocs, signatures |
+| `io.github.shafthq:shaft-mcp` | executable JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-bom` | POM | signature |
 | `io.github.shafthq:SHAFT_ENGINE` | relocation POM | signature |
 

--- a/docs/maintainers/reactor.md
+++ b/docs/maintainers/reactor.md
@@ -16,7 +16,7 @@ relocation artifact that points consumers to the canonical JAR.
 
 - The root `pom.xml` is the `io.github.shafthq:shaft-parent` aggregator and build parent. It owns shared version properties, dependency management, and plugin management.
 - `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
-- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, `shaft-heal`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
+- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, `shaft-heal`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `shaft-mcp` versions without adding dependencies by itself.
 - `shaft-pilot-core/pom.xml` builds provider-neutral Pilot contracts, security controls, configuration snapshots, and deterministic fallback. It depends on `shaft-engine`; the engine has no reverse dependency.
 - `shaft-capture/pom.xml` builds managed Chrome/Edge recording, versioned contracts, deterministic privacy classification, Java/TestNG generation, compile/replay validation, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
 - `shaft-doctor/pom.xml` builds allowlisted local evidence collection, redacted portable bundles, deterministic failure rules, JSON/Markdown reports, provider-neutral optional advisory integration, and isolated approval-gated repair proposals. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
@@ -101,7 +101,7 @@ Build and test outputs are module-local. Important locations include:
 - Optional BrowserStack SDK JAR: `shaft-browserstack/target/shaft-browserstack-<version>.jar`
 - Optional desktop video JAR: `shaft-video/target/shaft-video-<version>.jar`
 - Optional visual-processing JAR: `shaft-visual/target/shaft-visual-<version>.jar`
-- MCP executable JAR: `shaft-mcp/target/SHAFT_MCP-<version>.jar`
+- MCP executable JAR: `shaft-mcp/target/shaft-mcp-<version>.jar`
 - Surefire reports: `<module>/target/surefire-reports/`
 - Aggregate JaCoCo report: `target/jacoco/`
 - Per-module JaCoCo execution data: `<module>/target/jacoco.exec`

--- a/docs/start/quick-start.md
+++ b/docs/start/quick-start.md
@@ -325,14 +325,14 @@ Use the [module selection and migration guide](/docs/start/upgrade)
 for the complete method matrix.
 
 For a no-AI browser-recording workflow, build or download the executable
-`SHAFT_MCP` JAR and run:
+`shaft-mcp` JAR and run:
 
 ```bash
-java -jar SHAFT_MCP-<version>.jar capture start \
+java -jar shaft-mcp-<version>.jar capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar SHAFT_MCP-<version>.jar capture stop
-java -jar SHAFT_MCP-<version>.jar capture generate \
+java -jar shaft-mcp-<version>.jar capture stop
+java -jar shaft-mcp-<version>.jar capture generate \
   --session recordings/example.json \
   --output-dir generated-tests --replay
 ```

--- a/netlify/functions/docs-loader.mjs
+++ b/netlify/functions/docs-loader.mjs
@@ -51,8 +51,8 @@ function normalizeMarkdown(content) {
   return content
     .replace(/\r\n?/gu, '\n')
     .replace(
-      /<McpClientCommands\s*\/>/gu,
-      `### Codex\n\n\`${snippets.codexMcp}\`\n\n### GitHub Copilot / VS Code\n\n\`${snippets.copilotMcp}\``,
+      /<McpSetupPrompt\s*\/>/gu,
+      snippets.mcpSetupPrompt,
     )
     .replace(/<DoctorCommand\s*\/>/gu, `\`${snippets.doctor}\``)
     .replace(/<HealCommand\s*\/>/gu, `\`${snippets.heal}\``)

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -43,21 +43,8 @@ export function MigrationDependencies(): JSX.Element {
   );
 }
 
-export function McpClientCommands(): JSX.Element {
-  return (
-    <Tabs groupId="mcp-client">
-      <TabItem value="codex" label="Codex" default>
-        <CodeBlock language="bash">
-          {snippets.codexMcp}
-        </CodeBlock>
-      </TabItem>
-      <TabItem value="copilot" label="GitHub Copilot / VS Code">
-        <CodeBlock language="bash">
-          {snippets.copilotMcp}
-        </CodeBlock>
-      </TabItem>
-    </Tabs>
-  );
+export function McpSetupPrompt(): JSX.Element {
+  return <CodeBlock language="text">{snippets.mcpSetupPrompt}</CodeBlock>;
 }
 
 export function DoctorCommand(): JSX.Element {

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,6 +1,5 @@
 {
-  "codexMcp": "codex mcp add shaft-mcp -- docker run --rm -i ghcr.io/shafthq/shaft-engine-mcp:latest",
-  "copilotMcp": "code --add-mcp '{\"name\":\"shaft-mcp\",\"command\":\"docker\",\"args\":[\"run\",\"--rm\",\"-i\",\"ghcr.io/shafthq/shaft-engine-mcp:latest\"]}'",
-  "doctor": "java -jar SHAFT_MCP-<version>.jar doctor analyze --input allure-results --allowed-root \"$PWD\" --output-dir target/shaft-doctor",
+  "mcpSetupPrompt": "Configure shaft-mcp for this desktop client now. Query Maven Central for the latest available version of io.github.shafthq:shaft-mcp, download its executable JAR into a stable per-user application-data directory appropriate for this operating system, and configure this client with a local stdio MCP server named shaft-mcp that runs java -jar with the downloaded JAR's absolute path. Reload the MCP configuration, connect to the server, and verify that its tools are available. Complete every step yourself without asking me to edit configuration files or run commands; request approval only if the client or operating system requires it.",
+  "doctor": "java -jar shaft-mcp-<version>.jar doctor analyze --input allure-results --allowed-root \"$PWD\" --output-dir target/shaft-doctor",
   "heal": "mvn test '-Dhealing.strategy=shaft-heal'"
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import CodeBlock from '@theme/CodeBlock';
+import snippets from '@site/src/data/snippets.json';
 import styles from './index.module.css';
 
 const testSurfaces = [
@@ -111,11 +112,11 @@ function AgentSection(): JSX.Element {
           </div>
         </div>
         <div className={styles.commandCard}>
-          <span>Codex</span>
-          <CodeBlock language="bash">
-            {'codex mcp add shaft-mcp -- docker run --rm -i ghcr.io/shafthq/shaft-engine-mcp:latest'}
+          <span>Codex · Claude · GitHub Copilot</span>
+          <CodeBlock language="text">
+            {snippets.mcpSetupPrompt}
           </CodeBlock>
-          <p>Then ask: “Use SHAFT to open example.com and verify the page title.”</p>
+          <p>Paste this prompt once; your desktop agent downloads, configures, and connects the stdio JAR.</p>
         </div>
       </div>
     </section>

--- a/static/examples/shaft-pilot/mcp/claude-desktop.json
+++ b/static/examples/shaft-pilot/mcp/claude-desktop.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "shaft-mcp": {
-      "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
-    }
-  }
-}

--- a/static/examples/shaft-pilot/mcp/codex-config.toml
+++ b/static/examples/shaft-pilot/mcp/codex-config.toml
@@ -1,4 +1,0 @@
-[mcp_servers.shaft-mcp]
-command = "java"
-args = ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
-default_tools_approval_mode = "prompt"

--- a/static/examples/shaft-pilot/mcp/gemini-settings.json
+++ b/static/examples/shaft-pilot/mcp/gemini-settings.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "shaft-mcp": {
-      "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
-    }
-  }
-}

--- a/static/examples/shaft-pilot/mcp/vscode-mcp.json
+++ b/static/examples/shaft-pilot/mcp/vscode-mcp.json
@@ -1,9 +1,0 @@
-{
-  "servers": {
-    "shaft-mcp": {
-      "type": "stdio",
-      "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
-    }
-  }
-}

--- a/tests/docs-loader.test.js
+++ b/tests/docs-loader.test.js
@@ -27,7 +27,7 @@ assert(
 );
 
 const cases = [
-  ['connect Codex to SHAFT MCP', ['codex mcp add', 'shaft-engine-mcp']],
+  ['connect Codex to shaft-mcp', ['Configure shaft-mcp', 'latest available version']],
   ['run Doctor against Allure results', ['doctor analyze', 'allowed-root']],
   ['enable SHAFT Heal', ['healing.strategy=shaft-heal', 'shaft-heal']],
   ['create a web test', ['SHAFT.GUI.WebDriver', 'navigateToURL']],
@@ -47,11 +47,11 @@ for (const [query, expectedTerms] of cases) {
   }
 }
 
-const mcpSelection = retrieveDocumentation('connect Codex to SHAFT MCP');
+const mcpSelection = retrieveDocumentation('connect Codex to shaft-mcp');
 assert(
   mcpSelection.some(
     (chunk) => chunk.path === 'agentic/mcp.mdx'
-      && chunk.content.includes('shaft-engine-mcp'),
+      && chunk.content.includes('Query Maven Central'),
   ),
   'MCP retrieval must expand shared command components into searchable content.',
 );

--- a/tests/enhanced-instruction.test.js
+++ b/tests/enhanced-instruction.test.js
@@ -1,12 +1,12 @@
 import {loadDocumentation, getGitHubRepositoryContext} from '../netlify/functions/docs-loader.mjs';
 import {MAX_SYSTEM_INSTRUCTION_LENGTH} from '../netlify/functions/constants.mjs';
 
-const documentation = loadDocumentation('How do I connect Codex to SHAFT MCP?');
+const documentation = loadDocumentation('How do I connect Codex to shaft-mcp?');
 const githubContext = getGitHubRepositoryContext();
 const originalSystemInstruction = 'You are AutoBot, a helpful assistant.';
 const enhancedSystemInstruction = `${documentation}\n\n${githubContext}\n\n---\n\n${originalSystemInstruction}`;
 
-if (!documentation?.includes('codex mcp add')) {
+if (!documentation?.includes('Query Maven Central for the latest available version')) {
   throw new Error('Enhanced instruction is missing the requested MCP setup.');
 }
 if (!githubContext.includes('github.com/ShaftHQ/SHAFT_ENGINE')) {

--- a/tests/homepage-performance.test.js
+++ b/tests/homepage-performance.test.js
@@ -3,6 +3,9 @@ const path = require('path');
 
 const index = fs.readFileSync(path.join(__dirname, '..', 'src', 'pages', 'index.tsx'), 'utf8');
 const styles = fs.readFileSync(path.join(__dirname, '..', 'src', 'pages', 'index.module.css'), 'utf8');
+const snippets = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'src', 'data', 'snippets.json'), 'utf8'),
+);
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -11,7 +14,12 @@ function assert(condition, message) {
 assert(index.includes('shaft-automation-hero.png'), 'Homepage must use the optimized branded hero.');
 assert(index.includes('/docs/start/quick-start'), 'Homepage must expose the quick-start CTA.');
 assert(index.includes('/docs/agentic/mcp'), 'Homepage must expose MCP setup.');
-assert(index.includes('codex mcp add shaft-mcp'), 'Homepage must include an executable MCP command.');
+assert(index.includes('snippets.mcpSetupPrompt'), 'Homepage must render the shared MCP setup prompt.');
+assert(
+  snippets.mcpSetupPrompt.includes('latest available version')
+    && snippets.mcpSetupPrompt.includes('without asking me to edit configuration files or run commands'),
+  'MCP setup prompt must automate latest-version installation and client configuration.',
+);
 assert(index.includes('Maven Central'), 'Homepage claims must link to evidence.');
 assert(!index.includes('40,000'), 'Homepage must not contain unsupported adoption claims.');
 assert(styles.includes('prefers-reduced-motion: reduce'), 'Homepage must respect reduced motion.');

--- a/tests/playwright/site-render.spec.js
+++ b/tests/playwright/site-render.spec.js
@@ -32,17 +32,17 @@ for (const route of [
   });
 }
 
-test('MCP command can be copied', async ({page, context}) => {
+test('MCP setup prompt can be copied', async ({page, context}) => {
   await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   await page.goto('/docs/agentic/mcp');
-  const codeBlock = page.locator('pre').filter({hasText: 'codex mcp add shaft-mcp'}).first();
+  const codeBlock = page.locator('pre').filter({hasText: 'Configure shaft-mcp'}).first();
   await expect(codeBlock).toBeVisible();
   await codeBlock
     .locator('xpath=..')
     .getByRole('button', {name: 'Copy code to clipboard'})
     .click();
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain(
-    'codex mcp add shaft-mcp',
+    'Query Maven Central for the latest available version',
   );
 });
 


### PR DESCRIPTION
### Motivation

- Normalize the MCP distribution identity and CLI examples from legacy `SHAFT_MCP`/`SHAFT_MCP-<version>.jar` to the canonical `shaft-mcp`/`shaft-mcp-<version>.jar` artifact and repository name. 
- Replace brittle per-client example commands/config files with a single self-configuring desktop prompt so agents can download and configure a local stdio MCP server automatically. 
- Keep documentation, release notes, and automation consistent with the new artifact coordinate and server name across the site and examples.

### Description

- Updated documentation and blog release notes to use `shaft-mcp` artifact coordinates, Maven coordinates, JAR names, repository links, image names, and MCP server IDs. 
- Reworked the docs UI snippet system by replacing the `McpClientCommands` component with `McpSetupPrompt`, adding `snippets.mcpSetupPrompt` to `src/data/snippets.json`, and rendering it on the homepage and MCP pages. 
- Adjusted `netlify/functions/docs-loader.mjs` to expand the new `<McpSetupPrompt />` snippet and removed many static per-client example files under `static/examples/shaft-pilot/mcp`. 
- Updated tests and test fixtures to expect the new prompt and names by modifying `tests/docs-loader.test.js`, `tests/enhanced-instruction.test.js`, `tests/homepage-performance.test.js`, and `tests/playwright/site-render.spec.js` accordingly.

### Testing

- Ran the documentation indexing and retrieval checks in `tests/docs-loader.test.js`, and the updated cases passed. 
- Ran the enhanced instruction length and content checks in `tests/enhanced-instruction.test.js`, and they passed. 
- Executed homepage content and snippet assertions in `tests/homepage-performance.test.js`, and they passed. 
- Executed Playwright site render and clipboard-copy checks in `tests/playwright/site-render.spec.js`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb27bffa88320b44cb18619448eb9)