### PR TITLE
[codex] document local shaft-mcp installer

### DIFF
--- a/docs/agentic/examples.md
+++ b/docs/agentic/examples.md
@@ -49,7 +49,7 @@ reviewed change. `doctor propose-fix` creates an isolated worktree and does not
 publish to GitHub. Publishing requires a second command with the exact approval
 token returned by the proposal.
 
-Use the single self-configuring prompt in
+Use the matching application installer in
 [Connect shaft-mcp](/docs/agentic/mcp) instead of editing a client
 configuration manually.
 

--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -1,0 +1,127 @@
+---
+id: mcp-manual
+title: Configure shaft-mcp manually
+description: Download the latest shaft-mcp JAR and configure Codex, Claude, or GitHub Copilot as a local stdio MCP client.
+slug: /agentic/mcp/manual
+sidebar_position: 3
+tags: [mcp, codex, copilot, claude, manual]
+---
+
+# Configure shaft-mcp manually
+
+Use this page when the automatic installer cannot update your MCP client.
+You need Java 25, Maven 3.9+, the selected client, and absolute paths for both
+the Java executable and the JAR.
+
+## Download the newest JAR
+
+Open [`io.github.shafthq:shaft-mcp` on Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-mcp),
+select the newest published version, and download its executable JAR. Store it
+in a stable per-user application-data directory, not in a project checkout or
+temporary directory.
+
+Find the absolute Java 25 executable path:
+
+```powershell
+(Get-Command java).Source
+```
+
+```bash
+command -v java
+```
+
+In the examples below, replace `/absolute/path/to/java` and
+`/absolute/path/to/shaft-mcp.jar` with those absolute paths.
+
+## Codex CLI, App, and IDE extension
+
+Codex surfaces share `~/.codex/config.toml`. Follow the
+[official Codex MCP documentation](https://developers.openai.com/codex/mcp)
+and add:
+
+```toml
+[mcp_servers.shaft-mcp]
+command = "/absolute/path/to/java"
+args = ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+```
+
+Start a new Codex App session after changing the file.
+
+## Claude Code
+
+Follow the [official Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)
+and create the user-scope entry:
+
+```bash
+claude mcp remove shaft-mcp -s user
+claude mcp add -s user shaft-mcp -- "/absolute/path/to/java" -jar "/absolute/path/to/shaft-mcp.jar"
+```
+
+The remove command can report that the server does not exist during first-time
+setup.
+
+## Claude Desktop
+
+Claude Desktop supports local MCP servers on Windows and macOS. Follow
+[Anthropic's local MCP server guide](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+and add this entry to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "shaft-mcp": {
+      "command": "/absolute/path/to/java",
+      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+    }
+  }
+}
+```
+
+The file is under `%APPDATA%\Claude` on Windows and
+`~/Library/Application Support/Claude` on macOS. Merge the `shaft-mcp` member
+into any existing `mcpServers` object, then restart Claude Desktop.
+
+## GitHub Copilot CLI
+
+Follow the
+[official Copilot CLI MCP documentation](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers)
+and add this entry to `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "shaft-mcp": {
+      "type": "local",
+      "command": "/absolute/path/to/java",
+      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+## GitHub Copilot in VS Code
+
+Run **MCP: Open User Configuration** so the server is available across
+workspaces. Follow the
+[official VS Code MCP documentation](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
+and add:
+
+```json
+{
+  "servers": {
+    "shaft-mcp": {
+      "type": "stdio",
+      "command": "/absolute/path/to/java",
+      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+    }
+  }
+}
+```
+
+## Verify and recover
+
+Start a new client session and confirm that `shaft-mcp` exposes its tools. If a
+manual edit fails, restore the configuration backup before trying again. Never
+keep both project-level and per-user entries named `shaft-mcp`; the project
+entry can override the installed user configuration.

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 tags: [mcp, codex, copilot, chatgpt, claude, gemini]
 ---
 
-import {McpSetupPrompt} from '@site/src/components/DocSnippets';
+import {McpApplications} from '@site/src/components/DocSnippets';
 
 # Connect shaft-mcp
 
@@ -17,18 +17,18 @@ automation. It is published to Maven Central as
 canonical `shaft-engine` module. It does not add any dependency to ordinary
 `shaft-engine` consumers.
 
-## Connect in one prompt
+## Applications
 
-Paste this single prompt into Codex Desktop, Claude Desktop, or the GitHub
-Copilot agent in IntelliJ IDEA:
+Choose your MCP client and copy its command. The page detects your operating
+system after it loads and hides desktop applications that are unavailable
+there.
 
-<McpSetupPrompt />
+<McpApplications />
 
-The agent resolves the latest `shaft-mcp` release from Maven Central, downloads
-the executable JAR to an operating-system-appropriate per-user directory,
-writes its own MCP client configuration, reloads it, and verifies the
-connection. You do not need to determine a version, choose a path, or edit a
-configuration file.
+The command resolves `LATEST` from Maven Central, copies the executable JAR to
+versioned per-user application data, verifies it over stdio, and updates the
+selected user configuration without creating a second `shaft-mcp` entry. Run
+the same command later to install a newer release.
 
 The resulting local stdio process lets SHAFT launch the browser on your desktop
 so you can see and interact with the automation session. Do not use the Docker
@@ -106,18 +106,19 @@ as `REMOTE_DRIVER_ADDRESS`.
 Browser, filesystem, and GitHub mutations should remain approval-gated in the
 client. Start with a tool allowlist when the client supports one.
 
-## What the client configures
+## What the installer configures
 
-The desktop agent creates a local stdio server named `shaft-mcp`. Its executable
-is `java`, and its arguments are `-jar` followed by the absolute path of the
-downloaded `shaft-mcp-<version>.jar`. The prompt deliberately delegates path
-selection and configuration-file discovery to the client, making the workflow
-the same on Windows, macOS, and Linux.
+The installer creates a local stdio server named `shaft-mcp`. It records the
+absolute Java 25 executable and the absolute versioned JAR path so GUI clients
+do not depend on their inherited `PATH`.
+
+Configuration is per-user only. If the current project already defines a
+`shaft-mcp` server that would override the user entry, the installer stops
+without editing the project. Every user configuration mutation is backed up,
+verified, and rolled back on failure.
 
 The MCP client remains responsible for tool approvals and model
-authentication. When the client requests permission to download the JAR or
-update its settings, approve that operation and let it finish the remaining
-steps.
+authentication.
 
 Codex also supports direct Streamable HTTP:
 

--- a/docs/agentic/pilot.md
+++ b/docs/agentic/pilot.md
@@ -155,11 +155,10 @@ or proceed without separate explicit approval.
 
 ## MCP clients
 
-For Codex Desktop, Claude Desktop, or GitHub Copilot in IntelliJ IDEA, use the
-single self-configuring prompt in [Connect shaft-mcp](/docs/agentic/mcp). The
-desktop agent resolves the latest Maven Central release, downloads the JAR,
-configures its own local stdio server, reloads the configuration, and verifies
-the connection without requiring you to edit a client configuration file.
+For Codex, Claude, or GitHub Copilot, choose the matching application command
+in [Connect shaft-mcp](/docs/agentic/mcp). The installer resolves the latest
+Maven Central release, verifies the JAR, and updates the per-user local stdio
+configuration without requiring you to edit a client configuration file.
 
 Start Streamable HTTP for clients that need a reachable HTTPS endpoint:
 

--- a/netlify/functions/docs-loader.mjs
+++ b/netlify/functions/docs-loader.mjs
@@ -51,8 +51,13 @@ function normalizeMarkdown(content) {
   return content
     .replace(/\r\n?/gu, '\n')
     .replace(
-      /<McpSetupPrompt\s*\/>/gu,
-      snippets.mcpSetupPrompt,
+      /<McpApplications\s*\/>/gu,
+      snippets.mcpInstaller.applications
+        .map((application) => `${application.name}: \`${snippets.mcpInstaller.commandTemplate.replace(
+          '{agentFlag}',
+          application.flag,
+        )}\``)
+        .join('\n'),
     )
     .replace(/<DoctorCommand\s*\/>/gu, `\`${snippets.doctor}\``)
     .replace(/<HealCommand\s*\/>/gu, `\`${snippets.heal}\``)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@docusaurus/tsconfig": "^3.10.1",
     "@docusaurus/types": "^3.8.1",
     "@playwright/test": "^1.60.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.3"
   },
   "resolutions": {

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,6 +33,7 @@ const sidebars = {
       items: [
         'agentic/overview',
         'agentic/mcp',
+        'agentic/mcp-manual',
         'agentic/pilot',
         'agentic/capture',
         'agentic/doctor',

--- a/src/components/DocSnippets/McpApplications.module.css
+++ b/src/components/DocSnippets/McpApplications.module.css
@@ -1,0 +1,116 @@
+.root {
+  width: 100%;
+  min-width: 0;
+}
+
+.requirements {
+  margin: 0 0 1rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.list {
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 18px;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 16px 44px rgba(8, 29, 52, 0.08);
+}
+
+.row {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(190px, 0.34fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+}
+
+.row + .row {
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.identity > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.identity strong,
+.identity small {
+  overflow-wrap: anywhere;
+}
+
+.identity small {
+  color: var(--ifm-color-emphasis-600);
+}
+
+.icon {
+  display: inline-grid;
+  width: 2.6rem;
+  height: 2.6rem;
+  flex: 0 0 2.6rem;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-primary);
+  font-size: 1.05rem;
+}
+
+.command {
+  display: block;
+  min-width: 0;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  font-size: 0.77rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.copyButton {
+  display: inline-flex;
+  min-width: 5.6rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.manualLink {
+  margin: 1rem 0 0;
+}
+
+@media (max-width: 760px) {
+  .row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .copyButton {
+    width: 100%;
+  }
+}

--- a/src/components/DocSnippets/McpApplications.tsx
+++ b/src/components/DocSnippets/McpApplications.tsx
@@ -1,0 +1,113 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import Link from '@docusaurus/Link';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import type {IconDefinition} from '@fortawesome/fontawesome-svg-core';
+import {faGithub} from '@fortawesome/free-brands-svg-icons';
+import {
+  faBolt,
+  faCheck,
+  faCode,
+  faCopy,
+  faDesktop,
+  faLaptopCode,
+  faTerminal,
+} from '@fortawesome/free-solid-svg-icons';
+import snippets from '@site/src/data/snippets.json';
+import styles from './McpApplications.module.css';
+
+type OperatingSystem = 'windows' | 'macos' | 'linux' | 'unknown';
+
+type Application = {
+  id: string;
+  name: string;
+  detail: string;
+  flag: string;
+  icon: keyof typeof APPLICATION_ICONS;
+  platforms: OperatingSystem[];
+};
+
+const APPLICATION_ICONS: Record<string, IconDefinition> = {
+  terminal: faTerminal,
+  bolt: faBolt,
+  code: faCode,
+  desktop: faDesktop,
+  github: faGithub,
+  'laptop-code': faLaptopCode,
+};
+
+function detectOperatingSystem(): OperatingSystem {
+  const platform = (navigator.platform || navigator.userAgent || '').toLowerCase();
+  if (platform.includes('win')) return 'windows';
+  if (platform.includes('mac')) return 'macos';
+  if (platform.includes('linux') || platform.includes('x11')) return 'linux';
+  return 'unknown';
+}
+
+function commandFor(flag: string): string {
+  return snippets.mcpInstaller.commandTemplate.replace('{agentFlag}', flag);
+}
+
+export function McpApplications(): JSX.Element {
+  const [operatingSystem, setOperatingSystem] = useState<OperatingSystem>('unknown');
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOperatingSystem(detectOperatingSystem());
+  }, []);
+
+  const applications = useMemo(
+    () => (snippets.mcpInstaller.applications as Application[]).filter(
+      (application) => operatingSystem === 'unknown'
+        || application.platforms.includes(operatingSystem),
+    ),
+    [operatingSystem],
+  );
+
+  async function copyCommand(application: Application): Promise<void> {
+    await navigator.clipboard.writeText(commandFor(application.flag));
+    setCopiedId(application.id);
+    globalThis.setTimeout(() => setCopiedId(null), 1800);
+  }
+
+  return (
+    <div className={styles.root} data-detected-os={operatingSystem}>
+      <p className={styles.requirements}>
+        Requires Java 25, Maven 3.9+, and the selected application.
+        The command installs or updates the latest Maven Central release.
+      </p>
+      <div className={styles.list} aria-label="shaft-mcp applications">
+        {applications.map((application) => {
+          const command = commandFor(application.flag);
+          const copied = copiedId === application.id;
+          return (
+            <article className={styles.row} data-application={application.id} key={application.id}>
+              <div className={styles.identity}>
+                <span className={styles.icon} aria-hidden="true">
+                  <FontAwesomeIcon icon={APPLICATION_ICONS[application.icon]} />
+                </span>
+                <span>
+                  <strong>{application.name}</strong>
+                  <small>{application.detail}</small>
+                </span>
+              </div>
+              <code className={styles.command}>{command}</code>
+              <button
+                className={styles.copyButton}
+                type="button"
+                onClick={() => void copyCommand(application)}
+                aria-label={`Copy ${application.name} install command`}
+              >
+                <FontAwesomeIcon icon={copied ? faCheck : faCopy} />
+                <span>{copied ? 'Copied' : 'Copy'}</span>
+              </button>
+            </article>
+          );
+        })}
+      </div>
+      <p className={styles.manualLink}>
+        Need to inspect or edit the configuration yourself?{' '}
+        <Link to="/docs/agentic/mcp/manual">Open the manual configuration guide.</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -4,6 +4,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import releases from '@site/src/data/releases.json';
 import snippets from '@site/src/data/snippets.json';
+export {McpApplications} from './McpApplications';
 
 export function EngineDependencies(): JSX.Element {
   return (
@@ -41,10 +42,6 @@ export function MigrationDependencies(): JSX.Element {
       <EngineDependencies />
     </>
   );
-}
-
-export function McpSetupPrompt(): JSX.Element {
-  return <CodeBlock language="text">{snippets.mcpSetupPrompt}</CodeBlock>;
 }
 
 export function DoctorCommand(): JSX.Element {

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,5 +1,57 @@
 {
-  "mcpSetupPrompt": "Configure shaft-mcp for this desktop client now. Query Maven Central for the latest available version of io.github.shafthq:shaft-mcp, download its executable JAR into a stable per-user application-data directory appropriate for this operating system, and configure this client with a local stdio MCP server named shaft-mcp that runs java -jar with the downloaded JAR's absolute path. Reload the MCP configuration, connect to the server, and verify that its tools are available. Complete every step yourself without asking me to edit configuration files or run commands; request approval only if the client or operating system requires it.",
+  "mcpInstaller": {
+    "commandTemplate": "mvn --batch-mode --no-transfer-progress -U -N org.apache.maven.plugins:maven-dependency-plugin:3.9.0:copy org.codehaus.mojo:exec-maven-plugin:3.6.3:exec '-Dartifact=io.github.shafthq:shaft-mcp:LATEST' '-DoutputDirectory=${java.io.tmpdir}/shaft-mcp-bootstrap' '-Dmdep.stripVersion=true' '-Dmdep.overWriteReleases=true' '-Dexec.executable=java' '-Dexec.args=-jar \"${java.io.tmpdir}/shaft-mcp-bootstrap/shaft-mcp.jar\" install {agentFlag}'",
+    "applications": [
+      {
+        "id": "codex",
+        "name": "Codex CLI / IDE",
+        "detail": "Global Codex configuration",
+        "flag": "--codex",
+        "icon": "terminal",
+        "platforms": ["windows", "macos", "linux"]
+      },
+      {
+        "id": "codex-app",
+        "name": "Codex App",
+        "detail": "Shares the Codex global configuration",
+        "flag": "--codex-app",
+        "icon": "bolt",
+        "platforms": ["windows", "macos"]
+      },
+      {
+        "id": "claude",
+        "name": "Claude Code",
+        "detail": "User-scope MCP server",
+        "flag": "--claude",
+        "icon": "code",
+        "platforms": ["windows", "macos", "linux"]
+      },
+      {
+        "id": "claude-desktop",
+        "name": "Claude Desktop",
+        "detail": "Local desktop MCP server",
+        "flag": "--claude-desktop",
+        "icon": "desktop",
+        "platforms": ["windows", "macos"]
+      },
+      {
+        "id": "copilot",
+        "name": "GitHub Copilot CLI",
+        "detail": "User-level Copilot configuration",
+        "flag": "--copilot",
+        "icon": "github",
+        "platforms": ["windows", "macos", "linux"]
+      },
+      {
+        "id": "copilot-vscode",
+        "name": "GitHub Copilot in VS Code",
+        "detail": "Current VS Code user profile",
+        "flag": "--copilot-vscode",
+        "icon": "laptop-code",
+        "platforms": ["windows", "macos", "linux"]
+      }
+    ]
+  },
   "doctor": "java -jar shaft-mcp-<version>.jar doctor analyze --input allure-results --allowed-root \"$PWD\" --output-dir target/shaft-doctor",
   "heal": "mvn test '-Dhealing.strategy=shaft-heal'"
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -7,8 +7,7 @@
   color: #fff;
 }
 
-.heroGrid,
-.agentGrid {
+.heroGrid {
   display: grid;
   grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
   align-items: center;
@@ -90,7 +89,7 @@
 }
 
 .sectionHeading h2,
-.agentGrid h2,
+.agentIntro h2,
 .finalCta h2 {
   margin: 0.65rem 0 1rem;
   font-size: clamp(2rem, 4vw, 3.4rem);
@@ -99,7 +98,7 @@
 }
 
 .sectionHeading p,
-.agentGrid p {
+.agentIntro p {
   color: var(--ifm-color-emphasis-700);
   font-size: 1.08rem;
 }
@@ -150,28 +149,13 @@
   background: var(--ifm-color-emphasis-100);
 }
 
-.commandCard {
-  padding: 1.4rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 20px;
-  background: #081523;
-  box-shadow: 0 24px 70px rgba(8, 29, 52, 0.16);
+.agentSection {
+  min-width: 0;
 }
 
-.commandCard > span {
-  display: block;
-  margin-bottom: 0.75rem;
-  color: #72d0ff;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.commandCard p {
-  margin: 0.75rem 0 0;
-  color: #c8d6e7;
-  font-size: 0.9rem;
+.agentIntro {
+  max-width: 780px;
+  margin-bottom: 2rem;
 }
 
 .featureLinks {
@@ -184,23 +168,25 @@
 
 .workflow {
   display: grid;
-  grid-template-columns: repeat(9, auto);
+  grid-template-columns: repeat(9, minmax(0, 1fr));
   align-items: center;
   justify-content: space-between;
   gap: 0.8rem;
   padding: 1.25rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 18px;
-  overflow-x: auto;
+  overflow: hidden;
   background: var(--ifm-background-surface-color);
 }
 
 .workflow span {
-  min-width: max-content;
+  min-width: 0;
   padding: 0.75rem 1rem;
   border-radius: 999px;
   background: var(--ifm-color-emphasis-100);
   font-weight: 750;
+  overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .workflow b {
@@ -258,8 +244,7 @@
 }
 
 @media (max-width: 996px) {
-  .heroGrid,
-  .agentGrid {
+  .heroGrid {
     grid-template-columns: 1fr;
   }
 
@@ -270,6 +255,15 @@
 
   .evidenceGrid {
     grid-template-columns: 1fr;
+  }
+
+  .workflow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workflow b {
+    text-align: center;
+    transform: rotate(90deg);
   }
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
-import CodeBlock from '@theme/CodeBlock';
-import snippets from '@site/src/data/snippets.json';
+import {McpApplications} from '@site/src/components/DocSnippets';
 import styles from './index.module.css';
 
 const testSurfaces = [
@@ -97,13 +96,14 @@ function SurfaceSection(): JSX.Element {
 function AgentSection(): JSX.Element {
   return (
     <section className={`${styles.section} ${styles.contrastSection}`}>
-      <div className={`container ${styles.agentGrid}`}>
-        <div>
+      <div className={`container ${styles.agentSection}`}>
+        <div className={styles.agentIntro}>
           <span className={styles.eyebrow}>Agent-ready, deterministic by default</span>
-          <h2>Give Codex or Copilot real automation tools.</h2>
+          <h2>Connect shaft-mcp to your application.</h2>
           <p>
             SHAFT MCP exposes browser, Capture, and Doctor operations while the
-            client retains its own model credentials and approval policy.
+            client retains its own model credentials and approval policy. Run
+            the matching command again at any time to update to the latest release.
           </p>
           <div className={styles.featureLinks}>
             <Link to="/docs/agentic/mcp">MCP setup</Link>
@@ -111,13 +111,7 @@ function AgentSection(): JSX.Element {
             <Link to="/docs/agentic/heal">Recover with Heal</Link>
           </div>
         </div>
-        <div className={styles.commandCard}>
-          <span>Codex · Claude · GitHub Copilot</span>
-          <CodeBlock language="text">
-            {snippets.mcpSetupPrompt}
-          </CodeBlock>
-          <p>Paste this prompt once; your desktop agent downloads, configures, and connects the stdio JAR.</p>
-        </div>
+        <McpApplications />
       </div>
     </section>
   );

--- a/tests/docs-loader.test.js
+++ b/tests/docs-loader.test.js
@@ -27,7 +27,7 @@ assert(
 );
 
 const cases = [
-  ['connect Codex to shaft-mcp', ['Configure shaft-mcp', 'latest available version']],
+  ['connect Codex to shaft-mcp', ['Maven Central', 'Codex MCP documentation']],
   ['run Doctor against Allure results', ['doctor analyze', 'allowed-root']],
   ['enable SHAFT Heal', ['healing.strategy=shaft-heal', 'shaft-heal']],
   ['create a web test', ['SHAFT.GUI.WebDriver', 'navigateToURL']],
@@ -47,11 +47,11 @@ for (const [query, expectedTerms] of cases) {
   }
 }
 
-const mcpSelection = retrieveDocumentation('connect Codex to shaft-mcp');
+const mcpSelection = retrieveDocumentation('shaft-mcp LATEST install --codex');
 assert(
   mcpSelection.some(
     (chunk) => chunk.path === 'agentic/mcp.mdx'
-      && chunk.content.includes('Query Maven Central'),
+      && chunk.content.includes('shaft-mcp:LATEST'),
   ),
   'MCP retrieval must expand shared command components into searchable content.',
 );

--- a/tests/enhanced-instruction.test.js
+++ b/tests/enhanced-instruction.test.js
@@ -6,7 +6,7 @@ const githubContext = getGitHubRepositoryContext();
 const originalSystemInstruction = 'You are AutoBot, a helpful assistant.';
 const enhancedSystemInstruction = `${documentation}\n\n${githubContext}\n\n---\n\n${originalSystemInstruction}`;
 
-if (!documentation?.includes('Query Maven Central for the latest available version')) {
+if (!documentation?.includes('Codex MCP documentation')) {
   throw new Error('Enhanced instruction is missing the requested MCP setup.');
 }
 if (!githubContext.includes('github.com/ShaftHQ/SHAFT_ENGINE')) {

--- a/tests/homepage-performance.test.js
+++ b/tests/homepage-performance.test.js
@@ -14,15 +14,17 @@ function assert(condition, message) {
 assert(index.includes('shaft-automation-hero.png'), 'Homepage must use the optimized branded hero.');
 assert(index.includes('/docs/start/quick-start'), 'Homepage must expose the quick-start CTA.');
 assert(index.includes('/docs/agentic/mcp'), 'Homepage must expose MCP setup.');
-assert(index.includes('snippets.mcpSetupPrompt'), 'Homepage must render the shared MCP setup prompt.');
+assert(index.includes('<McpApplications />'), 'Homepage must render the shared MCP applications.');
 assert(
-  snippets.mcpSetupPrompt.includes('latest available version')
-    && snippets.mcpSetupPrompt.includes('without asking me to edit configuration files or run commands'),
-  'MCP setup prompt must automate latest-version installation and client configuration.',
+  snippets.mcpInstaller.commandTemplate.includes('io.github.shafthq:shaft-mcp:LATEST')
+    && snippets.mcpInstaller.commandTemplate.endsWith("install {agentFlag}'")
+    && snippets.mcpInstaller.applications.length === 6,
+  'MCP installer data must resolve LATEST and expose every supported application.',
 );
 assert(index.includes('Maven Central'), 'Homepage claims must link to evidence.');
 assert(!index.includes('40,000'), 'Homepage must not contain unsupported adoption claims.');
 assert(styles.includes('prefers-reduced-motion: reduce'), 'Homepage must respect reduced motion.');
 assert(styles.includes('@media (max-width: 620px)'), 'Homepage must include a mobile layout.');
+assert(!styles.includes('overflow-x: auto'), 'Homepage must not create a horizontal workflow scroller.');
 
 console.log('Homepage content, evidence, and accessibility checks passed.');

--- a/tests/playwright/site-render.spec.js
+++ b/tests/playwright/site-render.spec.js
@@ -22,6 +22,7 @@ for (const route of [
   '/docs/testing/mobile',
   '/docs/testing/api',
   '/docs/agentic/mcp',
+  '/docs/agentic/mcp/manual',
   '/docs/agentic/doctor',
   '/docs/agentic/heal',
 ]) {
@@ -32,19 +33,33 @@ for (const route of [
   });
 }
 
-test('MCP setup prompt can be copied', async ({page, context}) => {
+test('MCP application command can be copied', async ({page, context}) => {
   await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   await page.goto('/docs/agentic/mcp');
-  const codeBlock = page.locator('pre').filter({hasText: 'Configure shaft-mcp'}).first();
-  await expect(codeBlock).toBeVisible();
-  await codeBlock
-    .locator('xpath=..')
-    .getByRole('button', {name: 'Copy code to clipboard'})
-    .click();
+  await page.getByRole('button', {name: 'Copy Codex CLI / IDE install command'}).click();
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain(
-    'Query Maven Central for the latest available version',
+    'install --codex',
   );
 });
+
+test('Linux hides unsupported desktop applications', async ({page}) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'platform', {get: () => 'Linux x86_64'});
+  });
+  await page.goto('/docs/agentic/mcp');
+  await expect(page.locator('[data-application="codex"]')).toBeVisible();
+  await expect(page.locator('[data-application="claude-desktop"]')).toHaveCount(0);
+  await expect(page.locator('[data-application="codex-app"]')).toHaveCount(0);
+});
+
+for (const route of ['/', '/docs/agentic/mcp', '/docs/agentic/mcp/manual']) {
+  test(`${route} has no page-level horizontal overflow`, async ({page}) => {
+    await page.goto(route);
+    await expect.poll(() => page.evaluate(
+      () => document.documentElement.scrollWidth === document.documentElement.clientWidth,
+    )).toBeTruthy();
+  });
+}
 
 test('dark mode remains readable', async ({page}) => {
   await page.goto('/');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "noEmit": true
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,6 +3312,11 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
+"@types/react-dom@^19.2.3":
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
+  integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
+
 "@types/react-router-config@*", "@types/react-router-config@^5.0.7":
   version "5.0.11"
   resolved "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.11.tgz"
@@ -3346,6 +3351,13 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/react@^19.2.17":
+  version "19.2.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.17.tgz#dccac365baa0f1734ec270ff4b51c89465e8dc7f"
+  integrity sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==
+  dependencies:
+    csstype "^3.2.2"
 
 "@types/retry@0.12.0":
   version "0.12.0"
@@ -4651,6 +4663,11 @@ csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 cytoscape-cose-bilkent@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary

- replace the agent-driven setup prompt with a shared Applications component
- detect the visitor operating system and show supported prefilled installer commands
- add accessible copy controls and responsive application rows
- add `/docs/agentic/mcp/manual` with Maven Central and official client configuration links
- update shared snippets and documentation retrieval content
- remove homepage horizontal overflow at desktop and mobile widths

## Why

shaft-mcp needs a direct, repeatable local-install experience similar to Ollama's Applications view, while retaining exact manual configuration guidance for users who cannot use the automated installer.

## Companion PR

- Engine installer: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2902

## Validation

- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (34 tests)
- desktop and mobile browser checks for OS filtering, copy controls, dark mode, and `scrollWidth === clientWidth`
- `git diff --check`

## Deployment order

Review and preview this PR now, but do not expose the installer command in production until a new installer-enabled shaft-mcp version is available from Maven Central and the public command passes on Windows, macOS, and Linux.