### PR TITLE
[codex] Document SHAFT MCP mobile support

### DIFF
--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -11,8 +11,8 @@ import {McpApplications} from '@site/src/components/DocSnippets';
 
 # Connect shaft-mcp
 
-`shaft-mcp` is the executable Model Context Protocol server for SHAFT browser
-automation. It is published to Maven Central as
+`shaft-mcp` is the executable Model Context Protocol server for SHAFT browser,
+mobile, Capture, and Doctor automation. It is published to Maven Central as
 `io.github.shafthq:shaft-mcp`, built in the SHAFT reactor, and depends on the
 canonical `shaft-engine` module. It does not add any dependency to ordinary
 `shaft-engine` consumers.
@@ -64,6 +64,12 @@ The packaged server supports:
 - deterministic diagnosis through `doctor_analyze`, restricted to explicit
   input paths and allowed roots, with an optional separately identified
   provider advisory when Pilot AI is explicitly enabled;
+- mobile web emulation and native Android/iOS execution through
+  `mobile_initialize_web_emulation` and `mobile_initialize_native`;
+- mobile inspection through `mobile_take_screenshot`,
+  `mobile_get_accessibility_tree`, context switching, and action tools for
+  tapping, typing, swiping, rotation, keyboard, backgrounding, app activation,
+  recording, playback, and copy-pasteable Java action blocks;
 - legacy SSE endpoint properties as configuration aliases during migration.
 
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
@@ -90,6 +96,10 @@ recovery details.
 See [SHAFT Doctor](/docs/agentic/doctor) for evidence categories, allowlisted path
 handling, deterministic rules, redaction, offline bundle analysis, optional
 provider advisories, and safe fallback behavior.
+
+See [Mobile and Flutter testing](/docs/testing/mobile) for Appium setup,
+mobile web emulation, native device configuration, MCP screenshots, accessibility
+trees, and record/playback usage.
 
 See [SHAFT Pilot](/docs/agentic/pilot) for installation, provider configuration,
 Capture and Doctor examples, privacy defaults, and client-specific MCP setup.

--- a/docs/reference/configuration/basicConfig2.md
+++ b/docs/reference/configuration/basicConfig2.md
@@ -68,6 +68,9 @@ mobile_platformVersion=17.0
 
 # UDID required for real device
 mobile_udid=00008110-001A23456789AB01
+
+# Optional: launch an already-installed iOS app by bundle identifier
+mobile_bundleId=com.example.ios.myApp
 ```
 
 ---
@@ -107,6 +110,17 @@ mobile_browserName=Chrome
 mobile_deviceName=Pixel_7_API_34
 baseURL=https://m.example.com
 ```
+
+---
+
+## SHAFT MCP Mobile Automation
+
+`shaft-mcp` can start mobile sessions through the same SHAFT Engine setup:
+
+- `mobile_initialize_web_emulation` runs a resized desktop browser in mobile compatibility mode.
+- `mobile_initialize_native` starts an Appium-backed Android or iOS native session using the configured Appium server and device name, UDID, app, app package/activity, or iOS bundle ID.
+- `mobile_take_screenshot` captures the current mobile screen, and `mobile_get_accessibility_tree` returns the active Appium page source/accessibility XML so the MCP client can understand the screen before acting.
+- `mobile_record_start`, `mobile_record_stop`, `mobile_replay_recording`, and `mobile_recording_code_blocks` support record/playback and copy-pasteable SHAFT action snippets.
 
 ---
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -208,6 +208,7 @@ You can use these tab groups to navigate and get information about how to manage
   String app = SHAFT.Properties.mobile.app();
   String appPackage = SHAFT.Properties.mobile.appPackage();
   String appActivity = SHAFT.Properties.mobile.appActivity();
+  String bundleId = SHAFT.Properties.mobile.bundleId();
 
   /** set **/
   SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
@@ -219,7 +220,8 @@ You can use these tab groups to navigate and get information about how to manage
     .browserVersion("")
     .app("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk")
     .appPackage("")
-    .appActivity("");
+    .appActivity("")
+    .bundleId("");
   ```
 
   </TabItem>
@@ -243,6 +245,7 @@ You can use these tab groups to navigate and get information about how to manage
   mobile_app=src/test/resources/testDataFiles/apps/ApiDemos-debug.apk
   mobile_appPackage=
   mobile_appActivity=
+  mobile_bundleId=
   ```
   
   </TabItem>
@@ -259,6 +262,7 @@ You can use these tab groups to navigate and get information about how to manage
 | mobile_app                   | ` `            | `relativePath/to/myApp.apk`, `absolutePath/to/myApp.apk`, `http://myapp.com/app.ipa` | • You can add any property from the <a href="https://appium.io/docs/en/2.0/guides/caps/">List of Appium Capabilities</a> directly to your .property files or via CLI arguments, just make sure to add `mobile_` as a prefix.                                                                                                                                                                                                                                   |
 | mobile_appPackage            | ` `            | example: `com.example.android.myApp`                                                 | • You can add any property from the <a href="https://appium.io/docs/en/2.0/guides/caps/">List of Appium Capabilities</a> directly to your .property files or via CLI arguments, just make sure to add `mobile_` as a prefix.                                                                                                                                                                                                                                   |
 | mobile_appActivity           | ` `            | example: `.MainActivity`                                                             | • You can add any property from the <a href="https://appium.io/docs/en/2.0/guides/caps/">List of Appium Capabilities</a> directly to your .property files or via CLI arguments, just make sure to add `mobile_` as a prefix.                                                                                                                                                                                                                                   |
+| mobile_bundleId              | ` `            | example: `com.example.ios.myApp`                                                     | • iOS bundle identifier for launching an already installed app without providing `mobile_app`.<br/>• You can add any property from the <a href="https://appium.io/docs/en/2.0/guides/caps/">List of Appium Capabilities</a> directly to your .property files or via CLI arguments, just make sure to add `mobile_` as a prefix. |
 
   </TabItem>
 </Tabs>

--- a/docs/testing/mobile.md
+++ b/docs/testing/mobile.md
@@ -35,6 +35,18 @@ flowchart LR
     SHAFT --> Report["Allure evidence"]
 ```
 
+## SHAFT MCP mobile automation
+
+`shaft-mcp` can drive mobile sessions when an MCP client needs browser-style automation over Android or iOS targets:
+
+- Use `mobile_initialize_web_emulation` for mobile web checks in a resized desktop browser.
+- Use `mobile_initialize_native` for Appium-backed native Android or iOS execution. Configure `executionAddress`, `targetOperatingSystem`, `mobile_automationName`, `mobile_deviceName`, and either `mobile_app`, Android `mobile_appPackage`/`mobile_appActivity`, or iOS `mobile_bundleId`.
+- Use `mobile_get_contexts`, `mobile_switch_context`, `mobile_take_screenshot`, and `mobile_get_accessibility_tree` to inspect the live device screen before deciding what action to take.
+- Use `mobile_tap`, `mobile_type`, `mobile_swipe_by_offset`, `mobile_swipe_element_into_view`, `mobile_tap_coordinates`, rotation, keyboard, background, and app activation tools to perform actions through SHAFT Engine touch/mobile APIs.
+- Use `mobile_record_start`, `mobile_record_stop`, `mobile_replay_recording`, and `mobile_recording_code_blocks` to record, replay, and generate Java snippets that can be pasted into a SHAFT test or page object.
+
+For native execution, start Appium and connect the emulator or real device before initializing the MCP mobile session.
+
 ## Flutter applications
 
 SHAFT Engine now supports automated testing of Flutter applications using the Appium Flutter Driver. This integration allows you to seamlessly test Flutter apps on both Android and iOS platforms.


### PR DESCRIPTION
## Summary

- Documents SHAFT MCP mobile web emulation and native Android/iOS execution.
- Adds the mobile screenshot and accessibility-tree inspection tools to the MCP guide.
- Documents `mobile_bundleId` for installed iOS app launch flows and updates the mobile testing guide with record/playback/code-block usage.

## Validation

- `yarn install --frozen-lockfile`
- `yarn build`

Companion docs for ShaftHQ/SHAFT_ENGINE#2888 and ShaftHQ/SHAFT_ENGINE#2905.