### PR TITLE
[codex] Document natural actions and healing trust controls

### DIFF
--- a/docs/agentic/heal.mdx
+++ b/docs/agentic/heal.mdx
@@ -86,6 +86,28 @@ action preconditions, meets `healing.minimumConfidence`, and leads the next
 eligible candidate by at least `healing.ambiguityMargin`. Ties and low
 confidence preserve the original failure.
 
+## Trust threshold and warnings
+
+`healing.minimumTrustPercentage` is the preferred confidence gate for teams that
+want a human-readable percentage. Leave it at `-1` to keep using
+`healing.minimumConfidence`; set it from `0` to `100` to require that minimum
+trust before any recovered locator can be used.
+
+```properties
+healing.strategy=shaft-heal
+healing.minimumTrustPercentage=85
+```
+
+The deterministic score must pass this gate before optional provider metadata
+is considered. Visual or AI provider scores can rank eligible candidates, but
+they cannot rescue a locator candidate that failed the deterministic trust
+threshold.
+
+When SHAFT accepts a healed locator, it logs a warning and attaches the warning
+to the report. The warning includes the broken locator, healed locator, trust
+percentage, configured threshold, provider status, and evidence summary. Common
+secret-looking tokens are redacted before logging.
+
 ## History and reports
 
 History is local, versioned, checksummed, bounded, retention-limited, and

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -70,6 +70,9 @@ The packaged server supports:
   `mobile_get_accessibility_tree`, context switching, and action tools for
   tapping, typing, swiping, rotation, keyboard, backgrounding, app activation,
   recording, playback, and copy-pasteable Java action blocks;
+- trust-gated natural-language browser, element, and touch execution through
+  `natural_act`, using the active SHAFT driver and the same
+  `driver.act(...)` planner rules;
 - legacy SSE endpoint properties as configuration aliases during migration.
 
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
@@ -101,6 +104,10 @@ See [Mobile and Flutter testing](/docs/testing/mobile) for Appium setup,
 mobile web emulation, native device configuration, MCP screenshots, accessibility
 trees, and record/playback usage.
 
+See [Natural Language Actions](/docs/reference/actions/GUI/Natural_Language_Actions)
+for deterministic `driver.act(...)` patterns, trust thresholds, allowed-action
+filters, and optional planner fallback behavior.
+
 See [SHAFT Pilot](/docs/agentic/pilot) for installation, provider configuration,
 Capture and Doctor examples, privacy defaults, and client-specific MCP setup.
 Maintainers should use the [SHAFT Pilot release runbook](/docs/maintainers/pilot-release)
@@ -115,6 +122,12 @@ as `REMOTE_DRIVER_ADDRESS`.
 
 Browser, filesystem, and GitHub mutations should remain approval-gated in the
 client. Start with a tool allowlist when the client supports one.
+
+`natural_act` temporarily enables natural-language execution for the call and
+restores the previous current-thread settings afterward. MCP clients may pass a
+per-call `minimumTrustPercentage`, `planner`, `aiFallbackEnabled`, and
+`allowedActions`. Argument values are not written to SHAFT logs; only intent
+length, argument count, threshold, planner, and fallback state are logged.
 
 ## What the installer configures
 

--- a/docs/reference/actions/GUI/Browser_Actions.md
+++ b/docs/reference/actions/GUI/Browser_Actions.md
@@ -25,6 +25,9 @@ To close all running driver instances:
 driver.quit();
 ```
 
+For trust-gated natural-language browser, element, and touch workflows, see
+[Natural Language Actions](./Natural_Language_Actions).
+
 ## Navigation
 
 ### Navigate to URL

--- a/docs/reference/actions/GUI/Element_Actions.md
+++ b/docs/reference/actions/GUI/Element_Actions.md
@@ -9,6 +9,10 @@ tags: [web, element, actions, selenium]
 
 To interact with web elements, use `driver.element()` followed by the desired action. All element actions require a `By` locator to identify the target element.
 
+For trust-gated natural-language element workflows such as
+`driver.act("click Save")`, see
+[Natural Language Actions](./Natural_Language_Actions).
+
 ## Typing
 
 ### type()

--- a/docs/reference/actions/GUI/Natural_Language_Actions.md
+++ b/docs/reference/actions/GUI/Natural_Language_Actions.md
@@ -1,0 +1,100 @@
+---
+id: Natural_Language_Actions
+title: Natural Language Actions
+sidebar_label: Natural Language
+description: "Use trust-gated natural-language browser, element, and touch actions through SHAFT Engine."
+keywords: [SHAFT, natural language actions, driver act, browser actions, element actions, touch actions, MCP, AI fallback]
+tags: [web, mobile, actions, mcp, ai]
+---
+
+Natural-language actions let a test express a browser, element, or touch intent
+through `SHAFT.GUI.WebDriver.act(...)`. The engine plans the request, validates
+the plan against the configured trust threshold, and executes it only when the
+plan is trusted enough.
+
+The feature is disabled by default. Enable it only in tests where readable
+workflow intent is more valuable than direct locator calls:
+
+```java title="EnableNaturalActions.java"
+SHAFT.Properties.naturalActions.set()
+    .enabled(true)
+    .minimumTrustPercentage(85)
+    .planner("deterministic")
+    .aiFallbackEnabled(false)
+    .allowedActions("browser,element,touch");
+```
+
+## Basic usage
+
+```java title="NaturalLogin.java"
+String username = "standard_user";
+String password = System.getenv("APP_PASSWORD");
+
+driver.act("Login with valid credentials", username, password);
+```
+
+`act(...)` returns the same `SHAFT.GUI.WebDriver` instance so it can be used in
+fluent flows. Arguments are passed separately from the natural-language intent.
+SHAFT logs argument counts and intent metadata, not raw argument values.
+
+## Deterministic planner
+
+The default planner is local and deterministic. It recognizes a small set of
+high-signal patterns and maps them to existing SHAFT actions:
+
+| Intent pattern | Action |
+| --- | --- |
+| `refresh`, `refresh page`, `reload page` | `driver.browser().refreshCurrentPage()` |
+| `go back`, `navigate back` | `driver.browser().navigateBack()` |
+| `go forward`, `navigate forward` | `driver.browser().navigateForward()` |
+| `open ...` or `navigate to ...` with a URL argument | `driver.browser().navigateToURL(url)` |
+| `Login with valid credentials` with username and password arguments | types username, types password securely, then clicks login/sign in/submit |
+| `click Save` | clicks a semantic clickable element |
+| `type into Email` with one argument | types into a semantic input field |
+| `clear Search` | clears a semantic input field |
+| `tap Continue` | taps a semantic clickable element |
+
+Element and touch plans use SHAFT smart locators under the hood. If no
+deterministic pattern matches, the action fails without changing the page.
+
+## Trust gate
+
+Every plan has a trust score. SHAFT executes the action only when the score is
+greater than or equal to `naturalActions.minimumTrustPercentage`.
+
+```properties title="src/main/resources/properties/custom.properties"
+naturalActions.enabled=true
+naturalActions.minimumTrustPercentage=90
+naturalActions.planner=deterministic
+naturalActions.aiFallback.enabled=false
+naturalActions.allowedActions=browser,element,touch
+```
+
+Use `allowedActions` to narrow what natural actions may do in a test class. For
+example, `allowedActions=browser` allows navigation-style actions but rejects
+element and touch actions before execution.
+
+## Optional planner fallback
+
+Set `naturalActions.planner=auto` and
+`naturalActions.aiFallback.enabled=true` only when an optional planner should be
+allowed after the deterministic planner cannot produce a plan. SHAFT discovers
+additional planners through Java `ServiceLoader`; `shaft-pilot-core` provides a
+Pilot-backed natural-action planner that is also disabled unless
+`pilot.enabled=true`.
+
+Provider-assisted planning is still plan-only. The returned steps must pass the
+same local validation, allowed-action filter, and trust threshold before SHAFT
+touches the browser.
+
+## MCP usage
+
+`shaft-mcp` exposes the same behavior through the `natural_act` tool. The tool
+uses the active SHAFT driver, temporarily enables natural actions for the call,
+and restores the previous natural-action settings afterward. MCP clients can
+also pass per-call trust threshold, planner, AI fallback, and allowed-action
+overrides.
+
+See [Connect shaft-mcp](/docs/agentic/mcp) for transport setup and MCP client
+approval guidance.
+

--- a/docs/reference/actions/GUI/Touch_Actions.md
+++ b/docs/reference/actions/GUI/Touch_Actions.md
@@ -9,6 +9,10 @@ tags: [mobile, touch, actions, appium]
 
 SHAFT provides touch action methods for mobile app automation. Access them through `driver.touch()`.
 
+For trust-gated natural-language touch workflows such as
+`driver.act("tap Continue")`, see
+[Natural Language Actions](./Natural_Language_Actions).
+
 ## Tap Actions
 
 ### tap()

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -683,6 +683,123 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   </TabItem>
 </Tabs>
 
+### Healing
+
+- These properties control optional SHAFT Heal locator recovery through the
+  `shaft-heal` module.
+
+<Tabs groupId="PropertyTypes" queryString="Healing">
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  SHAFT.Properties.healing.set()
+    .strategy("shaft-heal")
+    .minimumTrustPercentage(85)
+    .minimumConfidence(0.75)
+    .ambiguityMargin(0.10)
+    .historyEnabled(true)
+    .historyPath("target/shaft-heal/history.json")
+    .visualEnabled(false)
+    .aiEnabled(false);
+  ```
+
+  </TabItem>
+  <TabItem value="cli-based" label="CLI-based">
+
+  ```powershell
+  mvn test "-Dhealing.strategy=shaft-heal" "-Dhealing.minimumTrustPercentage=85"
+  ```
+
+  </TabItem>
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  healing.strategy=shaft-heal
+  healing.minimumTrustPercentage=85
+  healing.minimumConfidence=0.75
+  healing.ambiguityMargin=0.10
+  healing.evidenceCategories=accessibility,label,test-id,stable-id-name,semantic,dom-fingerprint,native-state,ancestor-context,history
+  healing.testIdAttributes=data-testid,data-test,data-qa
+  healing.history.enabled=true
+  healing.history.path=target/shaft-heal/history.json
+  healing.history.maxEntries=500
+  healing.history.retentionDays=30
+  healing.visual.enabled=false
+  healing.ai.enabled=false
+  healing.sourcePatch.enabled=false
+  ```
+
+  </TabItem>
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name                    | Default Value | Possible Values | Description |
+| -------------------------------- | ------------- | --------------- | ----------- |
+| healing.strategy                 | `disabled`    | `disabled`, `healenium`, `shaft-heal`, `composite` | Selects the locator recovery strategy. |
+| healing.minimumTrustPercentage   | `-1`          | `-1`, `0`-`100` | Preferred human-readable trust gate. `-1` keeps using `healing.minimumConfidence`. |
+| healing.minimumConfidence        | `0.75`        | `0.0`-`1.0`     | Minimum deterministic confidence when no trust percentage override is set. |
+| healing.ambiguityMargin          | `0.10`        | `0.0`-`1.0`     | Required lead over the next eligible candidate. |
+| healing.evidenceCategories       | `accessibility,label,test-id,stable-id-name,semantic,dom-fingerprint,native-state,ancestor-context,history` | comma-separated categories | Deterministic evidence categories allowed for recovery. |
+| healing.testIdAttributes         | `data-testid,data-test,data-qa` | comma-separated attributes | Attributes treated as stable test IDs. |
+| healing.history.enabled          | `true`        | `true`, `false` | Enables bounded local recovery history. |
+| healing.history.path             | `target/shaft-heal/history.json` | path | Local recovery history file. |
+| healing.history.maxEntries       | `500`         | integer | Maximum retained history entries. |
+| healing.history.retentionDays    | `30`          | integer | Maximum history age in days. |
+| healing.visual.enabled           | `false`       | `true`, `false` | Enables optional local visual evidence. |
+| healing.ai.enabled               | `false`       | `true`, `false` | Enables optional provider reranking after deterministic eligibility. |
+| healing.sourcePatch.enabled      | `false`       | `true`, `false` | Reserved consent gate for reviewed source-patch proposals. |
+
+  </TabItem>
+</Tabs>
+
+### Natural Actions
+
+- These properties control trust-gated natural-language browser, element, and
+  touch actions through `SHAFT.GUI.WebDriver.act(...)`.
+
+<Tabs groupId="PropertyTypes" queryString="NaturalActions">
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  SHAFT.Properties.naturalActions.set()
+    .enabled(true)
+    .minimumTrustPercentage(85)
+    .planner("deterministic")
+    .aiFallbackEnabled(false)
+    .allowedActions("browser,element,touch");
+  ```
+
+  </TabItem>
+  <TabItem value="cli-based" label="CLI-based">
+
+  ```powershell
+  mvn test "-DnaturalActions.enabled=true" "-DnaturalActions.minimumTrustPercentage=85"
+  ```
+
+  </TabItem>
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  naturalActions.enabled=false
+  naturalActions.minimumTrustPercentage=85
+  naturalActions.planner=deterministic
+  naturalActions.aiFallback.enabled=false
+  naturalActions.allowedActions=browser,element,touch
+  ```
+
+  </TabItem>
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name                         | Default Value | Possible Values | Description |
+| ------------------------------------- | ------------- | --------------- | ----------- |
+| naturalActions.enabled                | `false`       | `true`, `false` | Enables `driver.act(...)`. Disabled plans fail before execution. |
+| naturalActions.minimumTrustPercentage | `85`          | `0`-`100`       | Minimum plan trust required before execution. |
+| naturalActions.planner                | `deterministic` | `deterministic`, `auto`, or a ServiceLoader planner ID | Selects the natural-action planner. |
+| naturalActions.aiFallback.enabled     | `false`       | `true`, `false` | Allows optional provider-assisted planners after deterministic planning is unavailable. |
+| naturalActions.allowedActions         | `browser,element,touch` | comma-separated `browser`, `element`, `touch` | Restricts which action categories natural actions may execute. |
+
+  </TabItem>
+</Tabs>
+
 ### Paths
 
 <Tabs groupId="PropertyTypes" queryString="Paths">


### PR DESCRIPTION
This PR was created by Codex, not manually by the maintainer whose token opened it.

## Summary
- Adds a Natural Language Actions reference page for `driver.act(...)`, deterministic patterns, trust thresholds, allowed action scopes, optional fallback, and MCP usage.
- Documents SHAFT Heal `healing.minimumTrustPercentage`, warning/report contents, and deterministic threshold behavior.
- Documents MCP `natural_act` behavior and adds new healing/natural action properties to the properties reference.

## Validation
- `npm run test:docs`
- `yarn install --frozen-lockfile`
- `yarn build`