### PR TITLE
[codex] Document standalone MCP install commands

### DIFF
--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -10,8 +10,8 @@ tags: [mcp, codex, copilot, claude, manual]
 # Configure shaft-mcp manually
 
 Use this page when the automatic installer cannot update your MCP client.
-You need Java 25, Maven 3.9+, the selected client, and absolute paths for both
-the Java executable and the JAR.
+You need Java 25, the selected client, and absolute paths for both the Java
+executable and the JAR.
 
 ## Download the newest JAR
 

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -25,10 +25,12 @@ there.
 
 <McpApplications />
 
-The command resolves `LATEST` from Maven Central, copies the executable JAR to
-versioned per-user application data, verifies it over stdio, and updates the
-selected user configuration without creating a second `shaft-mcp` entry. Run
-the same command later to install a newer release.
+The command downloads a repository-hosted bootstrap script, resolves
+`io.github.shafthq:shaft-mcp:LATEST` from Maven Central without requiring a
+local project, copies the executable JAR to versioned per-user application
+data, verifies it over stdio, and updates the selected user configuration
+without creating a second `shaft-mcp` entry. Run the same command later to
+install a newer release.
 
 The resulting local stdio process lets SHAFT launch the browser on your desktop
 so you can see and interact with the automation session. Do not use the Docker
@@ -118,9 +120,13 @@ client. Start with a tool allowlist when the client supports one.
 
 ## What the installer configures
 
-The installer creates a local stdio server named `shaft-mcp`. It records the
-absolute Java 25 executable and the absolute versioned JAR path so GUI clients
-do not depend on their inherited `PATH`.
+The bootstrap script uses the local Java 25 and Maven 3.9+ when available. If
+either is missing, it installs a per-user cached Java 25 runtime or Maven
+3.9.12 during the same command and then invokes the packaged installer.
+
+The packaged installer creates a local stdio server named `shaft-mcp`. It
+records the absolute Java 25 executable and the absolute versioned JAR path so
+GUI clients do not depend on their inherited `PATH`.
 
 Configuration is per-user only. If the current project already defines a
 `shaft-mcp` server that would override the user entry, the installer stops

--- a/netlify/functions/docs-loader.mjs
+++ b/netlify/functions/docs-loader.mjs
@@ -12,6 +12,7 @@ const currentDir = dirname(fileURLToPath(import.meta.url));
 const snippets = JSON.parse(
   readFileSync(join(currentDir, '..', '..', 'src', 'data', 'snippets.json'), 'utf-8'),
 );
+const MCP_COMMAND_SYSTEMS = ['windows', 'macos', 'linux'];
 const MAX_RETRIEVAL_CHARACTERS = 80_000;
 const MAX_RETRIEVAL_CHUNKS = 8;
 const EXCLUDED_DIRECTORIES = new Set(['archive', 'maintainers']);
@@ -53,10 +54,11 @@ function normalizeMarkdown(content) {
     .replace(
       /<McpApplications\s*\/>/gu,
       snippets.mcpInstaller.applications
-        .map((application) => `${application.name}: \`${snippets.mcpInstaller.commandTemplate.replace(
-          '{agentFlag}',
-          application.flag,
-        )}\``)
+        .flatMap((application) => MCP_COMMAND_SYSTEMS
+          .filter((system) => application.platforms.includes(system))
+          .map((system) => `${application.name} (${system}): \`${snippets.mcpInstaller.commandTemplates[system]
+            .replace('{agentFlag}', application.flag)
+            .replace('{client}', application.id)}\``))
         .join('\n'),
     )
     .replace(/<DoctorCommand\s*\/>/gu, `\`${snippets.doctor}\``)

--- a/src/components/DocSnippets/McpApplications.tsx
+++ b/src/components/DocSnippets/McpApplications.tsx
@@ -26,6 +26,8 @@ type Application = {
   platforms: OperatingSystem[];
 };
 
+type CommandTemplates = Record<Exclude<OperatingSystem, 'unknown'>, string>;
+
 const APPLICATION_ICONS: Record<string, IconDefinition> = {
   terminal: faTerminal,
   bolt: faBolt,
@@ -43,8 +45,16 @@ function detectOperatingSystem(): OperatingSystem {
   return 'unknown';
 }
 
-function commandFor(flag: string): string {
-  return snippets.mcpInstaller.commandTemplate.replace('{agentFlag}', flag);
+function commandFor(application: Application, operatingSystem: OperatingSystem): string {
+  const commands = snippets.mcpInstaller.commandTemplates as CommandTemplates;
+  const template = operatingSystem === 'windows'
+    ? commands.windows
+    : operatingSystem === 'macos'
+      ? commands.macos
+      : commands.linux;
+  return template
+    .replace('{agentFlag}', application.flag)
+    .replace('{client}', application.id);
 }
 
 export function McpApplications(): JSX.Element {
@@ -64,7 +74,7 @@ export function McpApplications(): JSX.Element {
   );
 
   async function copyCommand(application: Application): Promise<void> {
-    await navigator.clipboard.writeText(commandFor(application.flag));
+    await navigator.clipboard.writeText(commandFor(application, operatingSystem));
     setCopiedId(application.id);
     globalThis.setTimeout(() => setCopiedId(null), 1800);
   }
@@ -72,12 +82,12 @@ export function McpApplications(): JSX.Element {
   return (
     <div className={styles.root} data-detected-os={operatingSystem}>
       <p className={styles.requirements}>
-        Requires Java 25, Maven 3.9+, and the selected application.
-        The command installs or updates the latest Maven Central release.
+        Requires the selected application and network access.
+        The command installs Java 25 and Maven 3.9.12 when they are missing.
       </p>
       <div className={styles.list} aria-label="shaft-mcp applications">
         {applications.map((application) => {
-          const command = commandFor(application.flag);
+          const command = commandFor(application, operatingSystem);
           const copied = copiedId === application.id;
           return (
             <article className={styles.row} data-application={application.id} key={application.id}>

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,6 +1,10 @@
 {
   "mcpInstaller": {
-    "commandTemplate": "mvn --batch-mode --no-transfer-progress -U -N org.apache.maven.plugins:maven-dependency-plugin:3.9.0:copy org.codehaus.mojo:exec-maven-plugin:3.6.3:exec '-Dartifact=io.github.shafthq:shaft-mcp:LATEST' '-DoutputDirectory=${java.io.tmpdir}/shaft-mcp-bootstrap' '-Dmdep.stripVersion=true' '-Dmdep.overWriteReleases=true' '-Dexec.executable=java' '-Dexec.args=-jar \"${java.io.tmpdir}/shaft-mcp-bootstrap/shaft-mcp.jar\" install {agentFlag}'",
+    "commandTemplates": {
+      "windows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.ps1 | iex; Install-ShaftMcp -Client {client}\"",
+      "macos": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag}",
+      "linux": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag}"
+    },
     "applications": [
       {
         "id": "codex",

--- a/tests/docs-loader.test.js
+++ b/tests/docs-loader.test.js
@@ -51,7 +51,9 @@ const mcpSelection = retrieveDocumentation('shaft-mcp LATEST install --codex');
 assert(
   mcpSelection.some(
     (chunk) => chunk.path === 'agentic/mcp.mdx'
-      && chunk.content.includes('shaft-mcp:LATEST'),
+      && chunk.content.includes('install-shaft-mcp.sh')
+      && chunk.content.includes('Install-ShaftMcp')
+      && chunk.content.includes('io.github.shafthq:shaft-mcp:LATEST'),
   ),
   'MCP retrieval must expand shared command components into searchable content.',
 );

--- a/tests/homepage-performance.test.js
+++ b/tests/homepage-performance.test.js
@@ -16,10 +16,11 @@ assert(index.includes('/docs/start/quick-start'), 'Homepage must expose the quic
 assert(index.includes('/docs/agentic/mcp'), 'Homepage must expose MCP setup.');
 assert(index.includes('<McpApplications />'), 'Homepage must render the shared MCP applications.');
 assert(
-  snippets.mcpInstaller.commandTemplate.includes('io.github.shafthq:shaft-mcp:LATEST')
-    && snippets.mcpInstaller.commandTemplate.endsWith("install {agentFlag}'")
+  snippets.mcpInstaller.commandTemplates.windows.includes('Install-ShaftMcp -Client {client}')
+    && snippets.mcpInstaller.commandTemplates.macos.includes('install-shaft-mcp.sh')
+    && snippets.mcpInstaller.commandTemplates.linux.includes('sh -s -- {agentFlag}')
     && snippets.mcpInstaller.applications.length === 6,
-  'MCP installer data must resolve LATEST and expose every supported application.',
+  'MCP installer data must expose OS-specific standalone commands for every supported application.',
 );
 assert(index.includes('Maven Central'), 'Homepage claims must link to evidence.');
 assert(!index.includes('40,000'), 'Homepage must not contain unsupported adoption claims.');


### PR DESCRIPTION
## Summary

Updates the public MCP guide to use OS-specific standalone installer commands instead of the previous Maven goal chain.

## Why

The old shared command depended on shell-specific quoting and Maven goal chaining that could fail outside an existing Maven project. The guide now points users to repository-hosted bootstrap scripts that resolve `io.github.shafthq:shaft-mcp:LATEST` without requiring a local project.

## User Impact

Users get separate Windows PowerShell and macOS/Linux commands. The page explains that the bootstrap uses existing Java 25 and Maven 3.9+ when available, or installs per-user cached copies during execution.

## Validation

- `npm run test:homepage`
- `npm run test:docs`
- `npm run typecheck`
- `npm run build`
- `git diff --check`