### PR TITLE
[codex] Document MCP runtime workspace

### DIFF
--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -36,6 +36,31 @@ command -v java
 In the examples below, replace `/absolute/path/to/java` and
 `/absolute/path/to/shaft-mcp.jar` with those absolute paths.
 
+## Runtime workspace
+
+Manual configuration uses the same runtime workspace behavior as the installer.
+`shaft-mcp` no longer depends on the MCP client's launch directory for engine
+artifacts.
+
+Set `SHAFT_MCP_WORKSPACE_ROOT` in the MCP server environment to force a stable
+writable root. If it is not set, `shaft-mcp` uses the process current directory
+only when that directory is writable and, on Windows, not under a protected
+system directory. Otherwise it falls back to:
+
+- Windows: `%LOCALAPPDATA%\ShaftHQ\shaft-mcp\work`
+- macOS: `~/Library/Application Support/ShaftHQ/shaft-mcp/work`
+- Linux: `${XDG_DATA_HOME:-~/.local/share}/shafthq/shaft-mcp/work`
+
+During MCP runs, generated Allure results and reports, downloaded properties,
+downloads, videos, services files, dynamic object repository files, test data,
+Extent reports, execution summaries, and performance reports are resolved under
+the runtime root when their SHAFT property paths are relative. Explicit absolute
+path overrides stay absolute. MCP tool names and arguments do not change.
+
+If an older setup fails with `AccessDeniedException` under
+`C:\Windows\system32`, the MCP host launched from a protected Windows directory.
+Set `SHAFT_MCP_WORKSPACE_ROOT` or upgrade and rely on the app-data fallback.
+
 ## Codex CLI and IDE extension
 
 Codex surfaces share `~/.codex/config.toml`. Follow the

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -48,6 +48,32 @@ Then ask your client:
 The model provider remains owned by the client. `shaft-mcp` does not request,
 store, or proxy the client's model credentials.
 
+## Runtime workspace
+
+`shaft-mcp` chooses a writable runtime root for SHAFT engine artifacts. It no
+longer depends on the directory from which the MCP client launched the Java
+process.
+
+Set `SHAFT_MCP_WORKSPACE_ROOT` to force a stable writable root. If it is not
+set, `shaft-mcp` uses the process current directory only when that directory is
+writable and, on Windows, not under a protected system directory. Otherwise it
+falls back to per-user application data:
+
+- Windows: `%LOCALAPPDATA%\ShaftHQ\shaft-mcp\work`
+- macOS: `~/Library/Application Support/ShaftHQ/shaft-mcp/work`
+- Linux: `${XDG_DATA_HOME:-~/.local/share}/shafthq/shaft-mcp/work`
+
+During MCP runs, relative SHAFT artifact paths are resolved under the runtime
+root. This includes generated Allure results and reports, downloaded
+properties, downloads, videos, services files, dynamic object repository files,
+test data, Extent reports, execution summaries, and performance reports.
+Explicit absolute path overrides remain absolute. MCP tool names and arguments
+are unchanged.
+
+If you see an `AccessDeniedException` under `C:\Windows\system32`, the MCP host
+launched from a protected Windows directory. Upgrade to a release with the
+app-data fallback, or set `SHAFT_MCP_WORKSPACE_ROOT` to a writable directory.
+
 ## Build from source
 
 Run from the repository root:


### PR DESCRIPTION
## Summary

- Document the new `shaft-mcp` runtime workspace selection order on the main MCP guide.
- Add the same behavior note to the manual MCP setup guide.
- Call out that MCP tool names and arguments did not change, and add the `C:\Windows\system32` `AccessDeniedException` troubleshooting path.

## Why

ShaftHQ/SHAFT_ENGINE#2912 changed MCP runtime artifact handling so engine artifacts no longer depend on the MCP client launch directory. The user guide now explains how `SHAFT_MCP_WORKSPACE_ROOT`, writable current directories, and app-data fallback paths affect generated reports and supporting files.

## Validation

- `yarn test` passed.
- `yarn build` passed.
- `yarn test:playwright` passed, 34 tests.
- `git diff --check -- docs/agentic/mcp.mdx docs/agentic/mcp-manual.mdx` passed.
- `yarn typecheck` could not run in this environment because the installed TypeScript CLI in `node_modules` throws a syntax error under Node `v26.3.0` before checking project files.