### PR TITLE
[codex] Document async engine log attachments

### DIFF
--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -28,3 +28,15 @@ flowchart LR
 Use [reporting configuration](/docs/reference/reporting) and
 [custom report messages](/docs/reference/reporting/Custom_Report_Messages) for
 detailed controls.
+
+## Execution logs
+
+SHAFT writes the engine execution log through asynchronous Log4j2 appenders so
+normal test actions do not wait on file I/O. The console shows the concise
+INFO-level story, while diagnostic entries and engine internals are written at
+DEBUG level to the log file.
+
+Set `reporting.attachFullLog=true` when you want the full engine log attached to
+the Allure report after execution. The attachment is streamed from a temporary
+deduplicated snapshot so the live `target/logs/log4j.log` file remains available
+for retry diagnostics, local investigation, and CI artifact collection.

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -396,7 +396,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | cleanSummaryReportsDirectoryBeforeExecution   | `true`        | `true`, `false` | • Clean summary reports directory before execution.      |
 | openExecutionSummaryReportAfterExecution      | `false`       | `true`, `false` | • Open execution summary report after test execution.    |
 | disableLogging                                | `true`        | `true`, `false` | • Disable all logging output.                            |
-| attachFullLog                                 | `false`       | `true`, `false` | • Attach the full log file to the Allure report after test execution. |
+| attachFullLog                                 | `false`       | `true`, `false` | • Attach a streamed, deduplicated snapshot of the full engine log to the Allure report after test execution without deleting the live log file. |
 
   </TabItem>
 </Tabs>
@@ -1023,14 +1023,19 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   appender.console.layout.pattern=%highlight{[%p]}{FATAL=red blink, ERROR=red bold, WARN=yellow bold, INFO=fg_#0060a8 bold, DEBUG=fg_#43b02a bold, TRACE=black} %style{%m }%style{| %-logger}{bright_black} %style{- %-thread}{bright_black} %style{- %d{hh:mm:ss a}}{bright_black} %n
   appender.console.filter.threshold.type=ThresholdFilter
   appender.console.filter.threshold.level=info
-  appender.file.type=File
+  property.logFilePath=${sys:shaft.log.file:-target/logs/log4j.log}
+  appender.file.type=RollingFile
   appender.file.name=LOGFILE
-  appender.file.fileName=target/logs/log4j.log
+  appender.file.fileName=${logFilePath}
+  appender.file.filePattern=${logFilePath}.%i
   appender.file.layout.type=PatternLayout
   appender.file.layout.pattern=[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
   appender.file.filter.threshold.type=ThresholdFilter
   appender.file.filter.threshold.level=debug
-  rootLogger=debug, STDOUT, LOGFILE
+  appender.asyncFile.type=Async
+  appender.asyncFile.name=ASYNC_LOGFILE
+  appender.asyncFile.appenderRef.file.ref=LOGFILE
+  rootLogger=info, STDOUT, ASYNC_LOGFILE
   logger.app.name=org.apache.http.impl.client
   logger.app.level=WARN
   ```
@@ -1045,6 +1050,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | appender.file.fileName                  | `target/logs/log4j.log`                                                                                                                                                                |                                          |                                                                                                                                  |
 | appender.file.layout.pattern            | `[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n`                                                                                                                           |                                          |                                                                                                                                  |
 | appender.file.filter.threshold.level    | `debug`                                                                                                                                                                                | `fatal, error, warn, info, debug, trace` |                                                                                                                                  |
+| rootLogger                              | `info, ASYNC_STDOUT, ASYNC_LOGFILE, ASYNC_REPORT_PORTAL`                                                                                                                              |                                          | Uses asynchronous appenders for console, file, and ReportPortal logging.                                                         |
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Document the logging refresh from `ShaftHQ/SHAFT_ENGINE#2917`:

- Add reporting guidance for async engine logging and full-log Allure attachments.
- Clarify that `reporting.attachFullLog=true` attaches a streamed, deduplicated snapshot without deleting the live log file.
- Update the Log4j sample/defaults to show the async file appender and async root logger configuration.

## Validation

- `npm run test:docs` passed.
- `git diff --cached --check` passed.

## Companion PR

Engine implementation: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2917