### PR TITLE
[codex] Document Allure 3 realtime monitoring

### DIFF
--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -420,6 +420,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   boolean generateArchive = SHAFT.Properties.allure.generateArchive();
   String customLogo = SHAFT.Properties.allure.customLogo();
   String customTitle = SHAFT.Properties.allure.customTitle();
+  boolean realtimeMonitoring = SHAFT.Properties.allure.realtimeMonitoring();
   boolean singleFile = SHAFT.Properties.allure.singleFile();
   String reportLanguage = SHAFT.Properties.allure.reportLanguage();
   boolean open = SHAFT.Properties.allure.open();
@@ -434,6 +435,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
     .generateArchive(false)
     .customLogo("https://example.com/logo.png")
     .customTitle("My Test Suite Report")
+    .realtimeMonitoring(false)
     .singleFile(true)
     .reportLanguage("en")
     .open(false)
@@ -452,6 +454,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   allure.generateArchive=false
   allure.customLogo=https://example.com/logo.png
   allure.customTitle=My Test Suite Report
+  allure.realtimeMonitoring=false
   allure.singleFile=true
   allure.reportLanguage=en
   allure.open=false
@@ -470,6 +473,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | allure.generateArchive        | `false`                                                                                                                                          | `true`, `false`                                              | • Generate a self-contained ZIP archive of the Allure report after test execution. Useful for sharing or archiving in CI pipelines. *(previously: `generateAllureReportArchive`)* |
 | allure.customLogo             | *(SHAFT default logo URL)*                                                                                                                       | URL or local file path                                       | • URL or local path to a custom logo image to replace the default SHAFT logo in the Allure report.                                                                  |
 | allure.customTitle            | `Test run report`                                                                                                                                | Any string                                                   | • Custom title displayed in the header of the generated Allure report.                                                                                              |
+| allure.realtimeMonitoring     | `false`                                                                                                                                          | `true`, `false`                                              | • Enables SHAFT-managed Allure 3 native real-time monitoring via `allure watch` while tests run. Ignored for Allure 2 or when the Allure CLI cannot be resolved.    |
 | allure.singleFile             | `true`                                                                                                                                           | `true`, `false`                                              | • Controls the Allure 3 Awesome plugin `singleFile` option. When `true`, the report is generated as a self-contained HTML file.                                      |
 | allure.reportLanguage         | `en`                                                                                                                                             | Language code, such as `en`, `fr`, or `ru`                   | • Controls the Allure 3 Awesome plugin `reportLanguage` option used by the generated report UI.                                                                     |
 | allure.open                   | `false`                                                                                                                                          | `true`, `false`                                              | • Controls the Allure 3 Awesome plugin `open` option passed to Allure CLI report generation.                                                                        |

--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -185,6 +185,36 @@ SHAFT.Properties.allure.set()
   </TabItem>
 </Tabs>
 
+### Monitor Allure 3 Results While Tests Run
+
+When `allure.realtimeMonitoring=true` and SHAFT resolves an Allure 3 CLI, SHAFT starts native `allure watch` against `allure-results` while tests run. The watch process is stopped before final report generation and archiving. This is disabled by default, and is ignored when Allure 2 compatibility mode is active or the Allure CLI cannot be resolved.
+
+<Tabs groupId="configMethod">
+  <TabItem value="file" label="File-based">
+
+```properties title="src/main/resources/properties/custom.properties"
+allure.realtimeMonitoring=true
+```
+
+  </TabItem>
+  <TabItem value="cli" label="CLI-based">
+
+```bash
+mvn test -Dallure.realtimeMonitoring=true
+```
+
+  </TabItem>
+  <TabItem value="code" label="Code-based">
+
+```java
+import com.shaft.driver.SHAFT;
+
+SHAFT.Properties.allure.set().realtimeMonitoring(true);
+```
+
+  </TabItem>
+</Tabs>
+
 Common `allure.groupBy` presets include:
 
 | Preset | Value | Best For |
@@ -436,6 +466,7 @@ Key properties quick reference:
 | `allure.cleanResultsDirectory` | `true` | Clean Allure results directory before each run |
 | `allure.customTitle` | `Test run report` | Custom title in the Allure report header |
 | `allure.customLogo` | *(SHAFT default logo)* | Custom logo URL for the Allure report |
+| `allure.realtimeMonitoring` | `false` | Start native Allure 3 `allure watch` while tests run |
 | `allure.singleFile` | `true` | Generate an Allure 3 Awesome report as a self-contained HTML file |
 | `allure.reportLanguage` | `en` | Language code used by the Allure 3 Awesome report UI |
 | `allure.open` | `false` | Pass the browser-open flag to Allure 3 report generation |


### PR DESCRIPTION
## Summary
- Document `allure.realtimeMonitoring` as native Allure 3 live monitoring through `allure watch`.
- Add the property to the reporting guide and properties reference.
- Remove no historical release-blog entries.

## Validation
- `rg -n "reporting\.realtimeReport|realtimeReport|RealtimeReporter|realtime/dashboard" docs -S` returned no active docs references.
- `npm run test:docs` passed.
- `npm run build` passed.
