### PR TITLE
[codex] Document thin MCP artifacts

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -28,17 +28,23 @@ prompt, and preload-script signals when available. A JavaScript listener
 drained through ordinary WebDriver provides deterministic interaction capture
 and remains the compatibility fallback.
 
-Build the executable MCP JAR, then use its `capture` subcommand:
+Build the thin MCP JAR and runtime dependency directory, then use its `capture`
+subcommand. Use `;` instead of `:` in `MCP_CP` on Windows:
 
 ```bash
-mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture start \
+mvn -pl shaft-mcp -am install -DskipTests -Dgpg.skip
+mvn -pl shaft-mcp dependency:copy-dependencies -DincludeScope=runtime \
+  '-DoutputDirectory=${maven.multiModuleProjectDirectory}/shaft-mcp/target/dependency' \
+  -DskipTests -Dgpg.skip
+MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"
+MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
+java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture status
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture checkpoint \
+java -cp "$MCP_CP" "$MCP_MAIN" capture status
+java -cp "$MCP_CP" "$MCP_MAIN" capture checkpoint \
   --description "Checkout ready"
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture stop
+java -cp "$MCP_CP" "$MCP_MAIN" capture stop
 ```
 
 Use `--runtime-dir <path>` on every command to isolate control files. `stop`
@@ -126,7 +132,7 @@ store.stop(Instant.now());
 Generate a test, SHAFT JSON test data, and a deterministic report:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json \
   --output-dir generated-tests
 ```
@@ -168,12 +174,12 @@ AI enrichment is optional and uses two phases:
 
 ```bash
 # Calls the enabled provider only with explicit processing approval.
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json --output-dir generated-tests \
   --ai-preview --allow-local-ai
 
 # Apply the reviewed, fingerprinted preview.
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json --output-dir generated-tests-enriched \
   --apply-enrichment generated-tests/target/shaft-capture/enrichment-preview.json \
   --approve-enrichment --replay

--- a/docs/agentic/doctor.mdx
+++ b/docs/agentic/doctor.mdx
@@ -51,10 +51,13 @@ From an MCP chat:
 
 ## CLI reference
 
-The executable MCP JAR exposes Doctor as a local command:
+The MCP main class exposes Doctor as a local command. Use `;` instead of `:` in
+`MCP_CP` on Windows:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
+MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"
+MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
+java -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results \
   --input target/shaft-logs \
   --allowed-root "$PWD" \
@@ -71,7 +74,7 @@ Screenshots and page snapshots are excluded by default. Retain them only with
 explicit approval:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor \
@@ -87,7 +90,7 @@ as incomplete and is never interpreted as successful.
 ## Optional provider advisory
 
 Add `shaft-ai` when invoking `DoctorAnalyzer.analyzeWithAi(...)` directly. The
-executable `shaft-mcp` JAR already packages the OpenAI, Anthropic, Gemini, and
+`shaft-mcp` runtime classpath includes the OpenAI, Anthropic, Gemini, and
 Ollama adapters. CLI provider analysis also requires `--ai`; Pilot properties
 must independently enable the provider, processing location, model, and every
 submitted evidence category.
@@ -101,7 +104,7 @@ java \
   -Dpilot.ai.consent.local=true \
   -Dpilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION \
   -Dpilot.ai.ollama.model=<local-model> \
-  -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
+  -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor \
@@ -186,7 +189,7 @@ Example `repair-input.json`:
 ```
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor propose-fix \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor propose-fix \
   --repository "$PWD" \
   --base-sha <full-approved-sha> \
   --diagnosis target/shaft-doctor/doctor-report.json \
@@ -217,7 +220,7 @@ create a worktree.
 Publishing is always a later explicit action:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor publish-draft-pr \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor publish-draft-pr \
   --manifest target/shaft-doctor/repairs/repair-proposal-<id>.json \
   --approval-token <token-from-reviewed-proposal> \
   --approve

--- a/docs/agentic/examples.md
+++ b/docs/agentic/examples.md
@@ -9,19 +9,19 @@ tags: [pilot, examples]
 
 # Pilot examples
 
-These examples contain no credentials and assume the executable
-`shaft-mcp-<version>.jar` has been downloaded from Maven Central or built from
-the monorepo.
+These examples contain no credentials and assume the thin `shaft-mcp` JAR and
+runtime dependencies are on `MCP_CP`, with `MCP_MAIN` set to
+`com.shaft.mcp.ShaftMcpApplication`.
 
 ## No-AI Capture to TestNG
 
 ```bash
-java -jar shaft-mcp-<version>.jar capture start \
+java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar shaft-mcp-<version>.jar capture status
-java -jar shaft-mcp-<version>.jar capture stop
-java -jar shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture status
+java -cp "$MCP_CP" "$MCP_MAIN" capture stop
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json \
   --output-dir generated-tests --replay
 ```
@@ -29,7 +29,7 @@ java -jar shaft-mcp-<version>.jar capture generate \
 ## No-AI Doctor analysis
 
 ```bash
-java -jar shaft-mcp-<version>.jar doctor analyze \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
 ```

--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -1,7 +1,7 @@
 ---
 id: mcp-manual
 title: Configure shaft-mcp manually
-description: Download the latest shaft-mcp JAR and configure Codex, Claude, or GitHub Copilot as a local stdio MCP client.
+description: Configure Codex, Claude, or GitHub Copilot with a local shaft-mcp Java argfile.
 slug: /agentic/mcp/manual
 sidebar_position: 3
 tags: [mcp, codex, copilot, claude, manual]
@@ -13,15 +13,15 @@ Use this page when the [standalone installer](/docs/agentic/mcp) cannot update
 your MCP client. The automatic path is preferred: it bootstraps Python and Java
 only when needed, downloads `shaft-mcp` directly from Maven Central, verifies
 checksums, probes stdio, and writes the selected client configuration. Manual
-setup requires Java 25, the selected client, and absolute paths for both the
-Java executable and the JAR.
+setup requires Java 25, the selected client, the thin JAR, its runtime
+dependencies, and absolute paths for both the Java executable and an argfile.
 
-## Download the newest JAR
+## Prepare the JAR, dependencies, and argfile
 
 Open [`io.github.shafthq:shaft-mcp` on Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-mcp),
-select the newest published version, and download its executable JAR. Store it
-in a stable per-user application-data directory, not in a project checkout or
-temporary directory.
+select the newest published version, and download its thin JAR plus runtime
+dependencies. Store them in a stable per-user application-data directory, not
+in a project checkout or temporary directory.
 
 Find the absolute Java 25 executable path:
 
@@ -33,8 +33,17 @@ Find the absolute Java 25 executable path:
 command -v java
 ```
 
-In the examples below, replace `/absolute/path/to/java` and
-`/absolute/path/to/shaft-mcp.jar` with those absolute paths.
+Create `/absolute/path/to/shaft-mcp.args`:
+
+```text
+-cp
+"/absolute/path/to/shaft-mcp.jar:/absolute/path/to/lib/*"
+com.shaft.mcp.ShaftMcpApplication
+```
+
+Use `;` instead of `:` in the classpath on Windows. In the examples below,
+replace `/absolute/path/to/java` and `/absolute/path/to/shaft-mcp.args` with
+those absolute paths.
 
 ## Runtime workspace
 
@@ -70,7 +79,7 @@ and add:
 ```toml
 [mcp_servers.shaft-mcp]
 command = "/absolute/path/to/java"
-args = ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+args = ["@/absolute/path/to/shaft-mcp.args"]
 ```
 
 Start a new Codex session after changing the file.
@@ -82,7 +91,7 @@ and create the user-scope entry:
 
 ```bash
 claude mcp remove shaft-mcp -s user
-claude mcp add -s user shaft-mcp -- "/absolute/path/to/java" -jar "/absolute/path/to/shaft-mcp.jar"
+claude mcp add -s user shaft-mcp -- "/absolute/path/to/java" "@/absolute/path/to/shaft-mcp.args"
 ```
 
 The remove command can report that the server does not exist during first-time
@@ -99,7 +108,7 @@ and add this entry to `claude_desktop_config.json`:
   "mcpServers": {
     "shaft-mcp": {
       "command": "/absolute/path/to/java",
-      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+      "args": ["@/absolute/path/to/shaft-mcp.args"]
     }
   }
 }
@@ -121,7 +130,7 @@ and add this entry to `~/.copilot/mcp-config.json`:
     "shaft-mcp": {
       "type": "local",
       "command": "/absolute/path/to/java",
-      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"],
+      "args": ["@/absolute/path/to/shaft-mcp.args"],
       "tools": ["*"]
     }
   }
@@ -141,7 +150,7 @@ and add this entry to the `servers` object:
     "shaft-mcp": {
       "type": "stdio",
       "command": "/absolute/path/to/java",
-      "args": ["-jar", "/absolute/path/to/shaft-mcp.jar"]
+      "args": ["@/absolute/path/to/shaft-mcp.args"]
     }
   }
 }

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -11,11 +11,11 @@ import {McpApplications} from '@site/src/components/DocSnippets';
 
 # Connect shaft-mcp
 
-`shaft-mcp` is the executable Model Context Protocol server for SHAFT browser,
+`shaft-mcp` is the Model Context Protocol server for SHAFT browser,
 mobile, Capture, and Doctor automation. It is published to Maven Central as
-`io.github.shafthq:shaft-mcp`, built in the SHAFT reactor, and depends on the
-canonical `shaft-engine` module. It does not add any dependency to ordinary
-`shaft-engine` consumers.
+the thin `io.github.shafthq:shaft-mcp` JAR, built in the SHAFT reactor, and
+depends on the canonical `shaft-engine` module. It does not add any dependency
+to ordinary `shaft-engine` consumers.
 
 ## Applications
 
@@ -29,11 +29,12 @@ The command downloads a repository-hosted bootstrap script. The bootstrapper
 uses Python 3.9+ when available, or installs a checksum-verified portable Python
 runtime in the per-user SHAFT cache when Python is missing. The shared Python
 installer then resolves `io.github.shafthq:shaft-mcp:LATEST` from Maven Central
-without requiring a local project, verifies the JAR checksum, copies the
-executable JAR to versioned per-user application data, verifies it over stdio,
-and updates the selected user configuration without creating a second
-`shaft-mcp` entry. Run the same command later to install a newer release. If you
-run the script without a target, it prompts you to choose a supported client.
+without requiring a local project, verifies checksums, downloads the thin JAR
+and its runtime dependencies to versioned per-user application data, writes a
+Java argfile, verifies it over stdio, and updates the selected user
+configuration without creating a second `shaft-mcp` entry. Run the same command
+later to install a newer release. If you run the script without a target, it
+prompts you to choose a supported client.
 
 The resulting local stdio process lets SHAFT launch the browser on your desktop
 so you can see and interact with the automation session. Do not use the Docker
@@ -80,7 +81,10 @@ Run from the repository root:
 
 ```bash
 mvn -pl shaft-mcp -am test
-mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
+mvn -pl shaft-mcp -am install -DskipTests -Dgpg.skip
+mvn -pl shaft-mcp dependency:copy-dependencies -DincludeScope=runtime \
+  '-DoutputDirectory=${maven.multiModuleProjectDirectory}/shaft-mcp/target/dependency' \
+  -DskipTests -Dgpg.skip
 python3 scripts/ci/validate_shaft_mcp_transports.py
 ```
 
@@ -109,16 +113,20 @@ The packaged server supports:
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
 `--server.port`.
 
-The same JAR also provides a local SHAFT Capture CLI:
+The same main class also provides local SHAFT Capture and Doctor CLIs. Use `;`
+instead of `:` in `MCP_CP` on Windows:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture start \
+MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"
+MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
+
+java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test --browser chrome --output recordings/example.json
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture status
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture stop
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture status
+java -cp "$MCP_CP" "$MCP_MAIN" capture stop
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json --output-dir generated-tests
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar doctor analyze \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
 ```
@@ -166,13 +174,14 @@ The bootstrap script uses Python 3.9+ when available. If Python is missing, it
 installs a checksum-verified portable Python runtime under the per-user SHAFT
 cache. The shared Python installer then uses the local Java 25 when available.
 If Java 25 is missing, it installs a per-user cached Java 25 runtime during the
-same command. It downloads the released `shaft-mcp` JAR directly from Maven
-Central, verifies the SHA-256 checksum, probes the server over stdio, and writes
-the selected client configuration itself.
+same command. It downloads the released thin `shaft-mcp` JAR and runtime
+dependencies directly from Maven Central, verifies checksums, writes a Java
+argfile, probes the server over stdio, and writes the selected client
+configuration itself.
 
 The script creates a local stdio server named `shaft-mcp`. It records the
-absolute Java 25 executable and the absolute versioned JAR path so GUI clients
-do not depend on their inherited `PATH`.
+absolute Java 25 executable and the absolute versioned argfile path so GUI
+clients do not depend on their inherited `PATH`.
 
 `claude` configures Claude Code. `claude-desktop` configures Claude Desktop on
 Windows or macOS and requires restarting Claude Desktop. GitHub Copilot for
@@ -203,8 +212,7 @@ deployments where a visible desktop browser is not required.
 Start the server locally for testing:
 
 ```bash
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar \
-  --spring.profiles.active=http
+java -cp "$MCP_CP" "$MCP_MAIN" --spring.profiles.active=http
 ```
 
 Use the HTTPS `/mcp` URL for ChatGPT developer mode/apps, the Claude API MCP

--- a/docs/agentic/pilot.md
+++ b/docs/agentic/pilot.md
@@ -56,18 +56,24 @@ Add `shaft-ai` only for direct provider calls. External ChatGPT, Codex,
 Claude, Gemini, and GitHub Copilot clients use SHAFT through MCP and keep their
 own authentication.
 
-## Install the executable
+## Install the MCP server
 
-Download `io.github.shafthq:shaft-mcp:<version>` from Maven Central, or build it
-from the monorepo:
+Use [Connect shaft-mcp](/docs/agentic/mcp) for normal installation. To build
+and run from the monorepo:
 
 ```bash
-mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
-java -jar shaft-mcp/target/shaft-mcp-<version>.jar
+mvn -pl shaft-mcp -am install -DskipTests -Dgpg.skip
+mvn -pl shaft-mcp dependency:copy-dependencies -DincludeScope=runtime \
+  '-DoutputDirectory=${maven.multiModuleProjectDirectory}/shaft-mcp/target/dependency' \
+  -DskipTests -Dgpg.skip
+MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"
+MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
+java -cp "$MCP_CP" "$MCP_MAIN"
 ```
 
-The default process is an MCP stdio server. The same JAR dispatches `capture`
-and `doctor` subcommands.
+Use `;` instead of `:` in `MCP_CP` on Windows. The default process is an MCP
+stdio server. The same main class dispatches `capture` and `doctor`
+subcommands.
 
 ## Capture example
 
@@ -75,22 +81,22 @@ Start a privacy-filtered recording. This example is headless for CI or scripted
 use; omit `--headless` when a person will drive the browser locally:
 
 ```bash
-java -jar shaft-mcp-<version>.jar capture start \
+java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test \
   --browser chrome \
   --output recordings/example.json \
   --headless
-java -jar shaft-mcp-<version>.jar capture status
+java -cp "$MCP_CP" "$MCP_MAIN" capture status
 ```
 
 Drive the visible browser or the automation controlling the headless session,
 optionally add a checkpoint, then stop and generate:
 
 ```bash
-java -jar shaft-mcp-<version>.jar capture checkpoint \
+java -cp "$MCP_CP" "$MCP_MAIN" capture checkpoint \
   --description "Checkout confirmation is visible" --kind ASSERTION
-java -jar shaft-mcp-<version>.jar capture stop
-java -jar shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture stop
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json \
   --output-dir generated-tests \
   --package generated.capture \
@@ -109,7 +115,7 @@ compiles, passes, and produces populated Allure result JSON.
 Analyze only explicitly allowed evidence:
 
 ```bash
-java -jar shaft-mcp-<version>.jar doctor analyze \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor analyze \
   --input allure-results \
   --allowed-root "$PWD" \
   --output-dir target/shaft-doctor
@@ -127,7 +133,7 @@ Create a complete reviewed input based on
 `examples/shaft-pilot/doctor/repair-input.json`, then run:
 
 ```bash
-java -jar shaft-mcp-<version>.jar doctor propose-fix \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor propose-fix \
   --repository "$PWD" \
   --base-sha <40-character-commit> \
   --diagnosis target/shaft-doctor/doctor-report.json \
@@ -143,7 +149,7 @@ the current branch or write to GitHub. After reviewing the diff and validation
 result, publish only a draft pull request with the exact returned token:
 
 ```bash
-java -jar shaft-mcp-<version>.jar doctor publish-draft-pr \
+java -cp "$MCP_CP" "$MCP_MAIN" doctor publish-draft-pr \
   --manifest target/shaft-doctor/repairs/repair-proposal-<id>.json \
   --approval-token <exact-token> \
   --approve
@@ -163,7 +169,7 @@ configuration without requiring you to edit a client configuration file.
 Start Streamable HTTP for clients that need a reachable HTTPS endpoint:
 
 ```bash
-java -jar shaft-mcp-<version>.jar --spring.profiles.active=http
+java -cp "$MCP_CP" "$MCP_MAIN" --spring.profiles.active=http
 ```
 
 The endpoint is `/mcp` and the default port is `8081`. ChatGPT developer
@@ -229,7 +235,7 @@ output.
 
 | Symptom | Resolution |
 | --- | --- |
-| MCP process exits or prints non-protocol output | Use Java 25, run the packaged JAR directly, and keep stdio logs on stderr. |
+| MCP process exits or prints non-protocol output | Use Java 25, launch with the installer-generated argfile or thin classpath, and keep stdio logs on stderr. |
 | HTTP client cannot connect | Start with `--spring.profiles.active=http`, expose port `8081`, and use `/mcp`. |
 | Capture cannot start | Confirm Chrome or Edge is installed, no prior Capture session owns the runtime directory, and use `--headless` in CI. |
 | Generated test does not replay | Read `generation-report.json`; fix missing external data or an unsupported/ambiguous locator before regenerating. |

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -66,7 +66,7 @@ flowchart TB
 | `shaft-browserstack` | JAR            | BrowserStack SDK interception and `browserstack.yml` orchestration. Direct BrowserStack sessions stay in `shaft-engine`. |
 | `shaft-video`        | JAR            | Local non-headless desktop recording. Appium-native recording stays in `shaft-engine`.                                   |
 | `shaft-visual`       | JAR            | Reference-image assertions and image-based lookup through OpenCV, Eyes, and Shutterbug.                                  |
-| `shaft-mcp`          | executable JAR | Optional MCP server and CLI exposing browser automation, managed capture, Doctor analysis, and packaged direct adapters.  |
+| `shaft-mcp`          | thin JAR | Optional MCP server and CLI exposing browser automation, managed capture, Doctor analysis, and packaged direct adapters.  |
 | `shaft-bom`          | POM            | Aligns all SHAFT artifact versions; adds no runtime classes.                                                             |
 | `SHAFT_ENGINE`       | relocation POM | Temporary legacy-coordinate bridge to `shaft-engine`; adds no optional providers.                                        |
 

--- a/docs/maintainers/pilot-release.md
+++ b/docs/maintainers/pilot-release.md
@@ -25,7 +25,7 @@ to an unverified artifact.
 | MCP transports | Packaged stdio and Streamable HTTP `/mcp` initialization and tool discovery pass. |
 | Containers | The release Docker image starts in HTTP mode and completes MCP initialization. |
 | External agents | ChatGPT, Codex, Claude, Gemini, and GitHub Copilot setup is documented with current client limitations and credential ownership. |
-| Publication | Maven Central artifacts, sources, JavaDocs, signatures, BOM, executable JAR, aggregate SBOM, GHCR image, MCP registry metadata, and GitHub release use one version. |
+| Publication | Maven Central artifacts, sources, JavaDocs, signatures, BOM, thin MCP JAR, aggregate SBOM, GHCR image, MCP registry metadata, and GitHub release use one version. |
 | Migration | The preserved `io.github.shafthq:shaft-mcp` coordinate and `shaft-mcp` server ID resolve. `ghcr.io/shafthq/shaft-mcp:10.2.20260612` remains a tested compatibility image, while `ghcr.io/shafthq/shaft-engine-mcp` is published by the monorepo for current and future releases. |
 
 Live paid-provider smoke tests are optional. Run them only with explicit

--- a/docs/maintainers/publication.md
+++ b/docs/maintainers/publication.md
@@ -24,7 +24,7 @@ SHAFT publishes the complete reactor as one Maven Central deployment. Publicatio
 | `io.github.shafthq:shaft-browserstack` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-video` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-visual` | JAR | sources, JavaDocs, signatures |
-| `io.github.shafthq:shaft-mcp` | executable JAR | sources, JavaDocs, signatures |
+| `io.github.shafthq:shaft-mcp` | thin JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-bom` | POM | signature |
 | `io.github.shafthq:SHAFT_ENGINE` | relocation POM | signature |
 
@@ -59,8 +59,8 @@ classes outside the BrowserStack SDK's documented shaded JAR, and writes a
 CycloneDX SBOM. `shaft-heal` is validated by its own compile, test, JavaDocs,
 and publication-output checks. The `pilot-core` fixture compiles against
 provider-neutral contracts while banning `shaft-ai`; the separate `mcp`
-fixture resolves and copies the preserved executable coordinate without adding
-it to ordinary engine consumers.
+fixture resolves the preserved MCP coordinate and its runtime dependencies
+without adding it to ordinary engine consumers.
 
 For a signed staging rehearsal, import a disposable GPG key into an isolated `GNUPGHOME`, run the reactor without `-Dgpg.skip`, and add `--require-signatures` to both validator commands. The aggregate CycloneDX artifact is attached before the shared `maven-gpg-plugin` `verify` execution so it is signed like every POM, JAR, sources JAR, and JavaDocs JAR. Never use release credentials for a local rehearsal.
 

--- a/docs/maintainers/reactor.md
+++ b/docs/maintainers/reactor.md
@@ -83,7 +83,7 @@ mvn -pl shaft-visual -am test -Dtest=ImageProcessingActionsUnitTest
 mvn -pl shaft-heal -am test
 mvn -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai -am test
 mvn -pl shaft-mcp -am test -Dtest=ShaftMcpApplicationTests
-mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
+mvn -pl shaft-mcp -am install -DskipTests -Dgpg.skip
 python3 scripts/ci/validate_shaft_mcp_transports.py
 mvn -pl shaft-engine -am test
 mvn clean install -DskipTests -Dgpg.skip
@@ -101,7 +101,7 @@ Build and test outputs are module-local. Important locations include:
 - Optional BrowserStack SDK JAR: `shaft-browserstack/target/shaft-browserstack-<version>.jar`
 - Optional desktop video JAR: `shaft-video/target/shaft-video-<version>.jar`
 - Optional visual-processing JAR: `shaft-visual/target/shaft-visual-<version>.jar`
-- MCP executable JAR: `shaft-mcp/target/shaft-mcp-<version>.jar`
+- MCP thin JAR: `shaft-mcp/target/shaft-mcp-<version>.jar`
 - Surefire reports: `<module>/target/surefire-reports/`
 - Aggregate JaCoCo report: `target/jacoco/`
 - Per-module JaCoCo execution data: `<module>/target/jacoco.exec`

--- a/docs/maintainers/reactor.md
+++ b/docs/maintainers/reactor.md
@@ -130,8 +130,8 @@ Workflow commands run from the repository root and select only the modules requi
 
 | Workflow | Reactor policy |
 | --- | --- |
-| `e2eTests.yml` | Engine jobs use `-pl shaft-engine -am`; BrowserStack jobs use `-pl shaft-browserstack -am`; focused visual and desktop-video jobs use their respective optional modules. |
-| `e2eLocalTests.yml`, `e2eLambdaTestTests.yml`, `e2eMoonTests.yml` | Use `-pl shaft-engine -am`; Appium and ordinary browser jobs do not resolve `shaft-video`. |
+| `e2eTests.yml` | Engine and grid jobs use `-pl shaft-engine -am`; BrowserStack jobs use `-pl shaft-browserstack -am`; focused visual and desktop-video jobs use their respective optional modules; Moon runs from the engine module with the JUnit profile. |
+| `e2eLocalTests.yml`, `lambdatestTests.yml` | Local browser, local Cucumber, and LambdaTest jobs use `-pl shaft-engine -am`; ordinary browser/provider jobs do not resolve `shaft-video`. |
 | `coverage-readiness.yml` | Runs focused engine tests, builds `report-aggregate`, gates `target/jacoco/jacoco.csv`, and uploads only `target/jacoco/jacoco.xml` to Codecov. |
 | `code-quality-scan.yml`, `codeql-analysis.yml`, `copilot-setup-steps.yml` | Select the code-bearing engine, optional integrations, and MCP module explicitly; BOM and relocation-only modules are excluded from compilation/analysis. |
 | `shaft-mcp.yml` | Runs manually and daily at 01:00 UTC with local E2E workflows; packages the executable and smokes stdio plus Streamable HTTP. |

--- a/docs/start/quick-start.md
+++ b/docs/start/quick-start.md
@@ -324,15 +324,16 @@ required. See the [SHAFT Heal guide](/docs/agentic/heal).
 Use the [module selection and migration guide](/docs/start/upgrade)
 for the complete method matrix.
 
-For a no-AI browser-recording workflow, build or download the executable
-`shaft-mcp` JAR and run:
+For a no-AI browser-recording workflow, use the `shaft-mcp` installer or put the
+thin JAR and runtime dependencies on `MCP_CP`, then run:
 
 ```bash
-java -jar shaft-mcp-<version>.jar capture start \
+MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
+java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test --browser chrome \
   --output recordings/example.json --headless
-java -jar shaft-mcp-<version>.jar capture stop
-java -jar shaft-mcp-<version>.jar capture generate \
+java -cp "$MCP_CP" "$MCP_MAIN" capture stop
+java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
   --session recordings/example.json \
   --output-dir generated-tests --replay
 ```

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -48,6 +48,6 @@
       }
     ]
   },
-  "doctor": "java -jar shaft-mcp-<version>.jar doctor analyze --input allure-results --allowed-root \"$PWD\" --output-dir target/shaft-doctor",
+  "doctor": "java -cp \"$MCP_CP\" com.shaft.mcp.ShaftMcpApplication doctor analyze --input allure-results --allowed-root \"$PWD\" --output-dir target/shaft-doctor",
   "heal": "mvn test '-Dhealing.strategy=shaft-heal'"
 }


### PR DESCRIPTION
## Summary
- Document that `shaft-mcp` is now published as a thin Maven Central JAR.
- Update manual and local launch examples to use a Java argfile/classpath instead of `java -jar`.
- Update maintainer publication notes and snippets for runtime dependency setup.

Core PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2925

## Validation
- `npm run test:docs`
- `npm run test:homepage`
- `npm run typecheck`
- `npm run build`
