### PR TITLE
[codex] Document lean assertion reporting

### DIFF
--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -12,6 +12,11 @@ tags: [reporting, allure, screenshots, evidence]
 SHAFT records test actions as structured Allure steps and attaches the evidence
 needed to understand failures.
 
+Generated element assertions keep the Allure step text concise: the locator is
+reported once as a step parameter, while internal element reads used to evaluate
+the assertion are kept in the debug execution log instead of repeated child
+steps.
+
 ```mermaid
 flowchart LR
     Action["Test action"] --> Step["Allure step"]


### PR DESCRIPTION
## Summary
- Document that generated element assertion reports keep locators as Allure parameters instead of repeating them in the step text.
- Note that internal assertion element reads are retained in the debug execution log instead of visible child steps.

## Validation
- `git diff --cached --check`
