### PR TITLE
[codex] Document deterministic AI test lifecycle artifacts

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -144,13 +144,16 @@ generated-tests/
   src/test/java/generated/capture/<SessionName>Test.java
   src/test/resources/testDataFiles/<session-name>-test.json
   target/shaft-capture/generation-report.json
+  target/shaft-capture/capture-review.json
 ```
 
 Generation selects locators in the accessibility, label, test-ID, stable
 ID/name, CSS, then XPath family. The report records the score contribution from
 uniqueness, visibility, interactability, semantic match, volatility,
 frame/shadow context, and replay evidence, plus ranked fallbacks. Stable
-user-provided locators can outrank volatile semantic evidence.
+user-provided locators can outrank volatile semantic evidence. The review file
+summarizes deterministic readiness, blockers, risks, and next suggestions; MCP
+generation results expose the same path as `reviewPath`.
 
 Ordinary values are copied from the recording's external JSON into the
 generated test-data file. Secret and sensitive references become required

--- a/docs/agentic/doctor.mdx
+++ b/docs/agentic/doctor.mdx
@@ -30,6 +30,12 @@ Each analysis writes:
   `Finding` records, confidence, uncertainty, and `Remediation` actions, plus
   a separately identified advisory when provider analysis is requested;
 - `doctor-report.md`: a portable human-readable report and evidence index;
+- `doctor-triage.json` and `doctor-triage.md`: deterministic counts for
+  failing attempts, retry-hidden failures, recurring signatures, primary
+  signature, summary, and cited evidence IDs;
+- `execution-intelligence.json` and `execution-intelligence.md`: a compact
+  execution trend summary with primary cause, confidence, hidden retry count,
+  and recurring failure count;
 - `artifacts/`: approved binary evidence such as screenshots.
 
 Reports contain no original absolute machine paths. Evidence IDs and bundle
@@ -40,8 +46,9 @@ analysis of identical inputs is byte stable.
 
 <DoctorCommand />
 
-The command writes `doctor-evidence.json`, `doctor-report.json`, and
-`doctor-report.md` under `target/shaft-doctor`.
+The command writes `doctor-evidence.json`, `doctor-report.json`,
+`doctor-report.md`, `doctor-triage.*`, and `execution-intelligence.*` under
+`target/shaft-doctor`.
 
 From an MCP chat:
 

--- a/docs/agentic/heal.mdx
+++ b/docs/agentic/heal.mdx
@@ -152,6 +152,7 @@ AI reranking is also disabled by default:
 
 ```properties
 healing.ai.enabled=false
+healing.ai.trigger=ambiguous
 ```
 
 AI uses the provider-neutral controls from `shaft-pilot-core`. Add `shaft-ai`
@@ -159,7 +160,10 @@ only for direct OpenAI, Anthropic, Gemini, or Ollama calls, and configure the
 Pilot approval, evidence, budget, timeout, and provider properties separately.
 Only minimized candidate records are eligible for transfer. Provider output may
 rerank supplied candidate IDs but cannot invent an element or override
-deterministic acceptance.
+deterministic acceptance. The default trigger keeps AI fallback deterministic
+first: reranking runs only for ambiguous or below-threshold candidate sets. Use
+`never`, `below-threshold`, or `always` when a stricter or broader trigger is
+needed.
 
 ## Source changes and limits
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -730,6 +730,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   healing.history.retentionDays=30
   healing.visual.enabled=false
   healing.ai.enabled=false
+  healing.ai.trigger=ambiguous
   healing.sourcePatch.enabled=false
   ```
 
@@ -750,6 +751,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | healing.history.retentionDays    | `30`          | integer | Maximum history age in days. |
 | healing.visual.enabled           | `false`       | `true`, `false` | Enables optional local visual evidence. |
 | healing.ai.enabled               | `false`       | `true`, `false` | Enables optional provider reranking after deterministic eligibility. |
+| healing.ai.trigger               | `ambiguous`   | `never`, `ambiguous`, `below-threshold`, `always` | Controls when enabled AI reranking runs after deterministic scoring. |
 | healing.sourcePatch.enabled      | `false`       | `true`, `false` | Reserved consent gate for reviewed source-patch proposals. |
 
   </TabItem>


### PR DESCRIPTION
## Summary
- Document `capture-review.json` and MCP `reviewPath` for Capture generation.
- Document Doctor `doctor-triage.*` and `execution-intelligence.*` outputs.
- Document the deterministic-first `healing.ai.trigger=ambiguous` default and property reference.

## Validation
- `git diff --cached --check`
- `git diff --check`

## Remaining blocker
- Docs Graphify semantic refresh is not complete. `graphify update .` is code-only and refused to overwrite the existing docs graph because the rebuilt graph had fewer nodes. No semantic backend keys were configured (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` were absent), so I did not force an incomplete graph update.