### PR TITLE
[codex] Update typed action reporting docs

### DIFF
--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -19,9 +19,9 @@ steps.
 
 Text-entry element actions keep the Allure timeline readable by showing a
 single-line preview of the value being typed in the step title. Long or
-multiline values are capped in the title, while the locator, typed text, and
-resolved element name remain available in the step parameters and details.
-Secure typing stays masked in both the title and parameters.
+multiline values are capped in the title. The step metadata keeps the locator
+and includes the resolved element name only when the engine captures one.
+Secure typing stays masked.
 
 ```mermaid
 flowchart LR

--- a/docs/reference/actions/GUI/Element_Actions.md
+++ b/docs/reference/actions/GUI/Element_Actions.md
@@ -16,9 +16,9 @@ For trust-gated natural-language element workflows such as
 ## Typing
 
 Typing actions show the value being entered in the Allure step title. SHAFT
-caps long or multiline values in the title so reports stay readable, and keeps
-the full typed value, locator, and resolved element name in the step parameters
-and details. Secure typing remains masked.
+caps long or multiline values in the title so reports stay readable, keeps the
+locator in step metadata, and adds the resolved element name only when the
+engine captures one. Secure typing remains masked.
 
 ### type()
 


### PR DESCRIPTION
## Summary
- remove stale docs language claiming typed text remains in Allure parameters/details
- document that type-step metadata keeps `locator` and only includes `element name` when SHAFT captures one
- keep secure typing docs aligned with masked report behavior

## Validation
- `git diff --check`

## Notes
- Companion engine PR: ShaftHQ/SHAFT_ENGINE#2951
- Graphify refresh was attempted with `graphify . --update --no-viz` and blocked because no LLM API key is configured for semantic extraction.