### PR TITLE
[codex] Document failure screenshot evidence

### DIFF
--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -477,4 +477,4 @@ Key properties quick reference:
 | `videoParams_scope` | `DriverSession` | Scope of video recording |
 | `createAnimatedGif` | `false` | Create an animated GIF; retries can enable it automatically |
 | `animatedGif_frameDelay` | `500` | Delay between GIF frames (milliseconds) |
-| `screenshotParams_whenToTakeAScreenshot` | `ValidationPointsOnly` | When to attach screenshots; the default attaches validation checkpoints only |
+| `screenshotParams_whenToTakeAScreenshot` | `ValidationPointsOnly` | When to attach screenshots; failed element actions always attach evidence, highlight found elements red, and fall back to a page screenshot when the locator is missing |


### PR DESCRIPTION
## Summary
- Document that failed element actions always attach screenshot evidence.
- Clarify that found elements are highlighted red and missing locators fall back to a page screenshot.

## Related
- Code PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2952

## Validation
- Refreshed graphify for the docs worktree; generated graphify output was left out of the commit per repository rules.
- Documentation-only change; no docs site build run.
