### PR TITLE
[codex] Document capture codegen workbench

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -71,6 +71,25 @@ The same lifecycle is exposed by the `capture_start`, `capture_start_codegen`,
 `capture_generate`; `capture_codegen_features` returns the feature map. Status
 contains safe metadata and counts, never typed values.
 
+When recording in a visible browser, SHAFT injects a compact Capture panel into
+the managed Chrome/Edge session. The panel lists captured actions in plain
+English while the user clicks, types, selects, uploads, or navigates. Its
+controls pause or resume action capture, add a user checkpoint, edit the visible
+action text by recording an edit checkpoint, and stop the recording. Pressing
+stop from the panel requests a normal SHAFT stop, closes the managed browser,
+and leaves the session in `COMPLETED` status for generation.
+
+For agent-driven MCP flows, the intended handoff is: call `capture_start` or
+`capture_start_codegen`, let the user interact with the visible browser, wait
+for either `capture_stop` or a browser-panel stop to complete, then call
+`capture_code_blocks`. The agent should show the generated result and ask
+whether the user wants the complete Java snippet or wants the agent to insert
+the code into the current repository. Snippet mode uses the returned Java
+full-class block, including imports, locator fields, setup, SHAFT actions, and
+teardown. Insertion mode should inspect the repository and move locators and
+actions into existing Page Object classes when that pattern already exists, or
+create the smallest matching page/test classes when it does not.
+
 All process arguments and filesystem paths are built with Java APIs
 (`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
 separator is assumed; restrictive POSIX permissions are applied when supported

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -21,12 +21,12 @@ redacted representation after the separate Pilot approval checks succeed.
 
 ## Managed browser recording
 
-The recorder launches a fresh SHAFT-managed Chrome or Edge session. Firefox is
-rejected with an explicit unsupported-browser message until equivalent event
-coverage is available. WebDriver BiDi supplies navigation, browsing-context,
-prompt, and preload-script signals when available. A JavaScript listener
-drained through ordinary WebDriver provides deterministic interaction capture
-and remains the compatibility fallback.
+The recorder launches a fresh SHAFT-managed Chrome, Chromium, or Edge session.
+Firefox and WebKit are rejected with explicit unsupported-browser messages
+until equivalent event coverage is available. WebDriver BiDi supplies
+navigation, browsing-context, prompt, and preload-script signals when
+available. A JavaScript listener drained through ordinary WebDriver provides
+deterministic interaction capture and remains the compatibility fallback.
 
 Build the thin MCP JAR and runtime dependency directory, then use its `capture`
 subcommand. Use `;` instead of `:` in `MCP_CP` on Windows:
@@ -40,7 +40,9 @@ MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"
 MCP_MAIN="com.shaft.mcp.ShaftMcpApplication"
 java -cp "$MCP_CP" "$MCP_MAIN" capture start \
   --url https://example.test --browser chrome \
-  --output recordings/example.json --headless
+  --output recordings/example.json --headless \
+  --viewport-size 1280,720 \
+  --test-id-attribute data-testid
 java -cp "$MCP_CP" "$MCP_MAIN" capture status
 java -cp "$MCP_CP" "$MCP_MAIN" capture checkpoint \
   --description "Checkout ready"
@@ -51,10 +53,22 @@ Use `--runtime-dir <path>` on every command to isolate control files. `stop`
 also accepts `--discard`. Only one recorder may own a runtime directory at a
 time. The daemon control endpoint is bound to loopback, requires a generated
 bearer token, and removes its token and descriptor at shutdown. Browser
-profiles are temporary and removed after normal stop or interruption.
+profiles are temporary and removed after normal stop or interruption unless
+`--user-data-dir <path>` is supplied.
 
-The same lifecycle is exposed by the `capture_start`, `capture_status`, and
-`capture_stop` MCP tools. Generation is exposed by `capture_generate`. Status
+`capture start` also accepts Playwright-codegen-shaped options where SHAFT can
+map them safely: `--viewport-size`, `--test-id-attribute`, `--lang`,
+`--user-agent`, `--user-data-dir`, `--proxy-server`, `--proxy-bypass`,
+`--ignore-https-errors`, and `--timeout`. Other Playwright options such as
+`--target`, `--device`, `--color-scheme`, `--geolocation`, `--timezone`,
+`--load-storage`, `--save-storage`, `--save-har`, and `--save-har-glob` are
+retained as metadata and warnings when they cannot be enforced portably through
+Selenium. Use `capture features` to list the current Playwright codegen feature
+map.
+
+The same lifecycle is exposed by the `capture_start`, `capture_start_codegen`,
+`capture_status`, and `capture_stop` MCP tools. Generation is exposed by
+`capture_generate`; `capture_codegen_features` returns the feature map. Status
 contains safe metadata and counts, never typed values.
 
 All process arguments and filesystem paths are built with Java APIs
@@ -145,6 +159,7 @@ generated-tests/
   src/test/resources/testDataFiles/<session-name>-test.json
   target/shaft-capture/generation-report.json
   target/shaft-capture/capture-review.json
+  target/shaft-capture/capture-workbench.html
 ```
 
 Generation selects locators in the accessibility, label, test-ID, stable
@@ -153,7 +168,10 @@ uniqueness, visibility, interactability, semantic match, volatility,
 frame/shadow context, and replay evidence, plus ranked fallbacks. Stable
 user-provided locators can outrank volatile semantic evidence. The review file
 summarizes deterministic readiness, blockers, risks, and next suggestions; MCP
-generation results expose the same path as `reviewPath`.
+generation results expose the same path as `reviewPath`. The workbench HTML is
+a local review UI for building record/checkpoint commands, editing generated
+source through the browser file picker or download fallback, and reviewing the
+Playwright codegen feature map beside the generated code.
 
 Ordinary values are copied from the recording's external JSON into the
 generated test-data file. Secret and sensitive references become required
@@ -173,7 +191,7 @@ class in an isolated process and require populated, passing Allure result
 files. Existing source, data, report, or preview files are never replaced
 unless `--overwrite` is supplied.
 
-AI enrichment is optional and uses two phases:
+AI enrichment is optional and uses two phases for native CLI users:
 
 ```bash
 # Calls the enabled provider only with explicit processing approval.
@@ -193,6 +211,13 @@ cannot replace deterministic locators. Preview output is schema-validated and
 privacy-scanned; apply rejects stale fingerprints, invalid identifiers,
 unknown events, and assertions that contradict captured state. Accepted
 changes are compiled and replayed again.
+
+When an MCP client calls Capture or Doctor AI-enabled tools, SHAFT treats that
+tool call as the agent approval boundary for sharing the already redacted local
+evidence with the calling agent. If no configured provider/API key is available,
+MCP results still include agent handoff blocks so the MCP client can use its own
+LLM and repository context. Native terminal commands keep the explicit provider
+and `--allow-local-ai` or `--allow-remote-ai` approval requirements.
 
 Run the focused suite with:
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - shafthq.github.io  (2026-06-19)
 
 ## Corpus Check
-- 204 files · ~224,928 words
+- 204 files · ~225,311 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -10,7 +10,7 @@
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `1097e943`
+- Built from commit: `94ee0304`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4517,7 +4517,7 @@
       "label": "Format",
       "file_type": "document",
       "source_file": "docs/agentic/capture.md",
-      "source_location": "L65",
+      "source_location": "L98",
       "_origin": "ast",
       "id": "agentic_capture_format",
       "community": 94,
@@ -4527,7 +4527,7 @@
       "label": "Privacy boundary",
       "file_type": "document",
       "source_file": "docs/agentic/capture.md",
-      "source_location": "L92",
+      "source_location": "L125",
       "_origin": "ast",
       "id": "agentic_capture_privacy_boundary",
       "community": 94,
@@ -4537,7 +4537,7 @@
       "label": "Lifecycle",
       "file_type": "document",
       "source_file": "docs/agentic/capture.md",
-      "source_location": "L109",
+      "source_location": "L142",
       "_origin": "ast",
       "id": "agentic_capture_lifecycle",
       "community": 94,
@@ -4547,7 +4547,7 @@
       "label": "Deterministic TestNG generation",
       "file_type": "document",
       "source_file": "docs/agentic/capture.md",
-      "source_location": "L130",
+      "source_location": "L163",
       "_origin": "ast",
       "id": "agentic_capture_deterministic_testng_generation",
       "community": 94,
@@ -40136,5 +40136,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "1097e9431fb2e2f6b25ffe259de1c5e62ab7bbad"
+  "built_at_commit": "94ee0304f2d2632dfd7bfd26eb110d4c605c9de5"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -360,8 +360,8 @@
     "semantic_hash": "487656e0a23181cb1ba53136a6045cfd"
   },
   "docs/agentic/capture.md": {
-    "mtime": 1781788265.040473,
-    "ast_hash": "920f1d12e4450016f0e71289d5ae5610",
+    "mtime": 1781877570.644359,
+    "ast_hash": "0546bd69e7c49d194ae1dc440a0e78ea",
     "semantic_hash": ""
   },
   "docs/agentic/doctor.mdx": {
@@ -380,13 +380,13 @@
     "semantic_hash": ""
   },
   "docs/agentic/mcp-manual.mdx": {
-    "mtime": 1781849144.6689613,
-    "ast_hash": "ceb74203f7a96336a17db4654e40c20a",
+    "mtime": 1781867468.7904787,
+    "ast_hash": "96777f19b2a38c2c43325928c5f24852",
     "semantic_hash": ""
   },
   "docs/agentic/mcp.mdx": {
-    "mtime": 1781849126.5195496,
-    "ast_hash": "2986733b4ae44a27f7692e60bfb16b2b",
+    "mtime": 1781867468.7968178,
+    "ast_hash": "90003797377d085380829f3ffff4be6b",
     "semantic_hash": ""
   },
   "docs/agentic/overview.mdx": {
@@ -525,8 +525,8 @@
     "semantic_hash": "7d7fc0a07beff5b9eae4461e82f38070"
   },
   "docs/features/reporting.md": {
-    "mtime": 1781847943.260084,
-    "ast_hash": "a1845dda986460486931dac6421664fd",
+    "mtime": 1781867468.7982132,
+    "ast_hash": "ff4b70eff2e34e31f8659e562233762e",
     "semantic_hash": ""
   },
   "docs/features/technology.md": {
@@ -680,8 +680,8 @@
     "semantic_hash": "65368bb85030a6d0a3ba2715d8a048f2"
   },
   "docs/reference/actions/GUI/Element_Actions.md": {
-    "mtime": 1781847950.0445101,
-    "ast_hash": "cb3104c90c20378496e2f9cc8ba796ed",
+    "mtime": 1781867468.8002217,
+    "ast_hash": "2b91d6a8c60ee059b6fb787c0e85a046",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Identification.md": {
@@ -910,7 +910,7 @@
     "semantic_hash": "2304f5f6b6bd249ec5aaa7366776b49d"
   },
   "docs/reference/guides/JUnit5_Integration.md": {
-    "mtime": 1781588115.71735,
+    "mtime": 1781874246.5907123,
     "ast_hash": "96e1d254a18921d6e471d28e931228d7",
     "semantic_hash": "96e1d254a18921d6e471d28e931228d7"
   },
@@ -985,7 +985,7 @@
     "semantic_hash": "e156aa22a0f85fc96cf13306cc0f5eea"
   },
   "docs/start/quick-start.md": {
-    "mtime": 1781788265.0524733,
+    "mtime": 1781874246.5907123,
     "ast_hash": "16561e5313f768b55ed048ae6d7d57ad",
     "semantic_hash": ""
   },


### PR DESCRIPTION
## Summary

Documents the coordinated SHAFT Capture codegen workbench, Playwright-shaped recording options, live browser recorder controls, and MCP agent handoff.

- Updates the capture guide with supported browser families, Playwright-shaped start flags, metadata-only mappings, and persistent profile behavior.
- Documents the generated `capture-workbench.html` review UI.
- Adds the visible browser Capture panel workflow: live plain-English actions, pause/resume, checkpoint, edit-note, and stop controls.
- Adds MCP tool guidance for `capture_start_codegen`, `capture_codegen_features`, and the post-stop `capture_code_blocks` snippet-versus-repository-insertion handoff.
- Clarifies that MCP/agent calls are treated as the AI approval boundary, while native terminal use still requires explicit AI provider and approval flags.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run test:playwright`
- `git diff --check`

## Graphify

- `graphify update .` refreshed tracked `graphify-out` metadata.
