### PR TITLE
[codex] Document CLI action reporting updates

### DIFF
--- a/docs/reference/actions/CLI/Docker_Terminal.md
+++ b/docs/reference/actions/CLI/Docker_Terminal.md
@@ -2,12 +2,12 @@
 id: Docker_Terminal
 title: Docker Container Terminal
 sidebar_label: Docker Terminal
-description: "Execute commands inside running Docker containers using SHAFT Engine's TerminalActions with the Docker constructor."
+description: "Legacy Docker-wrapped terminal execution using SHAFT Engine's deprecated TerminalActions Docker constructor."
 keywords: [SHAFT, docker terminal, container commands, CLI, TerminalActions, docker exec, automation]
 tags: [cli, terminal, docker, containers]
 ---
 
-SHAFT's `TerminalActions` class supports **Docker container execution** out of the box. Using the Docker-specific constructor, you can run shell commands inside any running container and capture the output — no external tooling required.
+Docker-wrapped `TerminalActions` execution is deprecated for removal. Existing tests can still use the Docker-specific constructor while migrating, but new code should execute `docker` commands through `SHAFT.CLI.terminal()` or use the target environment directly.
 
 ---
 
@@ -28,6 +28,8 @@ import com.shaft.cli.TerminalActions;
 // Connect to a running container named "my-app-container" as root
 TerminalActions docker = new TerminalActions("my-container-name", "root");
 ```
+
+This constructor is deprecated; keep it only for existing compatibility tests.
 
 You can verify that the terminal is operating inside a Docker container:
 
@@ -188,4 +190,4 @@ void createUserViaDbAndVerifyThroughApi() {
 
 - [Terminal Actions](./Terminal_Actions.md) — Local terminal execution overview and common patterns.
 - [SSH Remote Terminal](./SSH_Terminal.md) — Execute commands on remote servers via SSH.
-- [File Actions](./File_Actions.md) — Copy files between local and remote/container filesystems.
+- [File Actions](./File_Actions.md) — Manage local files and directories.

--- a/docs/reference/actions/CLI/File_Actions.md
+++ b/docs/reference/actions/CLI/File_Actions.md
@@ -22,14 +22,14 @@ You can also use the legacy `FileActions.getInstance()` in existing projects.
 
 ## Read File
 
-### readFromFile()
+### readFile()
 
 Reads and returns the complete contents of a file as a string.
 
 ```java title="ReadFile.java"
 FileActions file = SHAFT.CLI.file();
 
-String content = file.readFromFile("src/test/resources/testData/users.json");
+String content = file.readFile("src/test/resources/testData/users.json");
 ```
 
 **Practical example — load test data before a test:**
@@ -46,7 +46,7 @@ public class UserImportTest {
     @BeforeClass
     public void loadTestData() {
         usersPayload = SHAFT.CLI.file()
-                           .readFromFile("src/test/resources/testDataFiles/users.json");
+                           .readFile("src/test/resources/testDataFiles/users.json");
     }
 
     @Test
@@ -76,6 +76,8 @@ FileActions file = SHAFT.CLI.file();
 
 file.writeToFile("target/reports/execution-summary.txt", "All 42 tests passed.");
 ```
+
+SHAFT reports the target path and byte count for write operations; it does not attach raw byte payloads as action output.
 
 **Practical example — save API response for later comparison:**
 
@@ -132,7 +134,7 @@ public class ReportDownloadTest {
               .and().element().click(By.id("download-report-btn"));
 
         // Give the download a moment to complete, then read and validate
-        String content = file.readFromFile(DOWNLOAD_PATH);
+        String content = file.readFile(DOWNLOAD_PATH);
         SHAFT.Validations.assertThat()
              .object(content)
              .isNotNull()

--- a/docs/reference/actions/CLI/SSH_Terminal.md
+++ b/docs/reference/actions/CLI/SSH_Terminal.md
@@ -7,7 +7,7 @@ keywords: [SHAFT, SSH terminal, remote server, CLI, TerminalActions, SSH executi
 tags: [cli, terminal, ssh, remote]
 ---
 
-SHAFT's `TerminalActions` class supports **SSH remote execution** natively. Using the SSH-specific constructor, you can connect to any remote machine, run shell commands, and transfer files — all from within your test code.
+SHAFT's `TerminalActions` class supports **SSH remote execution** natively. Use the `SHAFT.CLI.remoteTerminal(...)` facade for reusable SSH sessions, command execution, port forwarding, and SFTP transfers.
 
 ---
 
@@ -23,13 +23,14 @@ SHAFT's `TerminalActions` class supports **SSH remote execution** natively. Usin
 
 ```java title="SshTerminalSetup.java"
 import com.shaft.cli.TerminalActions;
+import com.shaft.driver.SHAFT;
 
-TerminalActions remote = new TerminalActions(
+TerminalActions remote = SHAFT.CLI.remoteTerminal(
     "192.168.1.100",    // SSH host (IP or hostname)
     22,                 // SSH port (default: 22)
     "deploy-user",      // SSH username
     "~/.ssh/",          // Directory containing the private key
-    false               // isKeyRecursive — set to true for recursive key search
+    "id_rsa"            // SSH private key file name
 );
 ```
 
@@ -77,23 +78,22 @@ System.out.println(result);
 
 ## File Transfer
 
-SHAFT's `FileActions` class integrates with SSH terminals to transfer files between the remote server and the local machine.
+`TerminalActions` includes SFTP helpers for transferring files between the remote server and the local machine.
 
 ### Download a File from the Remote Server
 
 ```java title="SshDownloadFile.java"
 import com.shaft.cli.TerminalActions;
-import com.shaft.tools.io.FileActions;
+import com.shaft.driver.SHAFT;
 
-TerminalActions remote = new TerminalActions(
-    "192.168.1.100", 22, "deploy-user", "~/.ssh/", false
+TerminalActions remote = SHAFT.CLI.remoteTerminal(
+    "192.168.1.100", 22, "deploy-user", "~/.ssh/", "id_rsa"
 );
 
 // Copy a remote log file to the local target directory
-FileActions.getInstance().copyFileToLocalMachine(
-    remote,
-    "/var/log/app/application.log",   // remote file path
-    "target/logs/"                     // local destination directory
+String localPath = remote.downloadFile(
+    "/var/log/app/application.log",
+    "target/logs/application.log"
 );
 ```
 
@@ -102,10 +102,10 @@ FileActions.getInstance().copyFileToLocalMachine(
 Use checksums to verify file integrity after deployments or transfers:
 
 ```java title="SshFileChecksum.java"
-String checksum = FileActions.getInstance().getFileChecksum(
+String checksum = SHAFT.CLI.file().getFileChecksum(
     remote,
-    "/opt/app/build.jar",   // remote file path
-    "SHA-256"               // algorithm
+    "/opt/app/",
+    "build.jar"
 );
 
 SHAFT.Validations.assertThat()
@@ -127,8 +127,8 @@ import com.shaft.driver.SHAFT;
 
 @Test
 void verifyApplicationDeployedSuccessfully() {
-    TerminalActions remote = new TerminalActions(
-        "prod-server.example.com", 22, "ci-user", "~/.ssh/", false
+    TerminalActions remote = SHAFT.CLI.remoteTerminal(
+        "prod-server.example.com", 22, "ci-user", "~/.ssh/", "id_rsa"
     );
 
     // Check the process is running
@@ -154,18 +154,14 @@ void verifyApplicationDeployedSuccessfully() {
 ### Collect Remote Logs as Test Evidence
 
 ```java title="CollectRemoteLogs.java"
-TerminalActions remote = new TerminalActions(
-    "test-server.example.com", 22, "testuser", "~/.ssh/", false
+TerminalActions remote = SHAFT.CLI.remoteTerminal(
+    "test-server.example.com", 22, "testuser", "~/.ssh/", "id_rsa"
 );
 
 @AfterMethod
 void collectLogs() {
     // Download the log file from the remote server
-    FileActions.getInstance().copyFileToLocalMachine(
-        remote,
-        "/var/log/app/test-run.log",
-        "target/logs/"
-    );
+    remote.downloadFile("/var/log/app/test-run.log", "target/logs/test-run.log");
 
     // Also attach recent log tail directly to the Allure report
     String recentLogs = remote.performTerminalCommand("tail -n 100 /var/log/app/test-run.log");
@@ -176,8 +172,8 @@ void collectLogs() {
 ### Trigger Remote Scripts
 
 ```java title="TriggerRemoteScript.java"
-TerminalActions remote = new TerminalActions(
-    "build-server.example.com", 22, "build-user", "~/.ssh/", false
+TerminalActions remote = SHAFT.CLI.remoteTerminal(
+    "build-server.example.com", 22, "build-user", "~/.ssh/", "id_rsa"
 );
 
 @BeforeClass
@@ -196,8 +192,8 @@ void resetTestEnvironment() {
 ### Check Remote Disk Space Before Tests
 
 ```java title="CheckDiskSpaceRemote.java"
-TerminalActions remote = new TerminalActions(
-    "192.168.1.50", 22, "ops-user", "~/.ssh/", false
+TerminalActions remote = SHAFT.CLI.remoteTerminal(
+    "192.168.1.50", 22, "ops-user", "~/.ssh/", "id_rsa"
 );
 
 @BeforeClass

--- a/docs/reference/actions/CLI/Terminal_Actions.md
+++ b/docs/reference/actions/CLI/Terminal_Actions.md
@@ -22,28 +22,28 @@ You can also instantiate directly for legacy projects: `new TerminalActions()`.
 
 ## Execute a Single Command
 
-### executeCommand()
+### performTerminalCommand()
 
 Executes a terminal command and returns the standard output as a string.
 
 ```java title="SingleCommand.java"
 TerminalActions terminal = SHAFT.CLI.terminal();
 
-String output = terminal.executeCommand("echo Hello SHAFT");
+String output = terminal.performTerminalCommand("echo Hello SHAFT");
 SHAFT.Validations.assertThat().object(output).contains("Hello SHAFT").perform();
 ```
 
 **Linux / macOS:**
 ```java title="LinuxCommands.java"
-String files   = terminal.executeCommand("ls -la /tmp");
-String diskUse = terminal.executeCommand("df -h /");
-String uptime  = terminal.executeCommand("uptime");
+String files   = terminal.performTerminalCommand("ls -la /tmp");
+String diskUse = terminal.performTerminalCommand("df -h /");
+String uptime  = terminal.performTerminalCommand("uptime");
 ```
 
 **Windows:**
 ```java title="WindowsCommands.java"
-String dir       = terminal.executeCommand("dir C:\\");
-String processes = terminal.executeCommand("tasklist");
+String dir       = terminal.performTerminalCommand("dir C:\\");
+String processes = terminal.performTerminalCommand("tasklist");
 ```
 
 ## Execute Multiple Commands
@@ -83,19 +83,19 @@ public class DatabaseSeedTest {
     public void setUp() {
         terminal = SHAFT.CLI.terminal();
         // Seed the database before the test class
-        terminal.executeCommand("psql -U testuser -d testdb -f src/test/resources/seed.sql");
+        terminal.performTerminalCommand("psql -U testuser -d testdb -f src/test/resources/seed.sql");
     }
 
     @Test
     public void verifyRecordsWereSeeded() {
-        String result = terminal.executeCommand("psql -U testuser -d testdb -c \"SELECT COUNT(*) FROM users;\"");
+        String result = terminal.performTerminalCommand("psql -U testuser -d testdb -c \"SELECT COUNT(*) FROM users;\"");
         SHAFT.Validations.assertThat().object(result).contains("10").perform();
     }
 
     @AfterClass
     public void tearDown() {
         // Clean up test data
-        terminal.executeCommand("psql -U testuser -d testdb -c \"DELETE FROM users WHERE email LIKE '%test%';\"");
+        terminal.performTerminalCommand("psql -U testuser -d testdb -c \"DELETE FROM users WHERE email LIKE '%test%';\"");
     }
 }
 ```
@@ -114,7 +114,7 @@ public class DeploymentTest {
         TerminalActions terminal = SHAFT.CLI.terminal();
 
         // Trigger deployment
-        String deployOutput = terminal.executeCommand("./scripts/deploy.sh staging");
+        String deployOutput = terminal.performTerminalCommand("./scripts/deploy.sh staging");
         SHAFT.Validations.assertThat()
              .object(deployOutput)
              .contains("Deployment successful")
@@ -122,7 +122,7 @@ public class DeploymentTest {
              .perform();
 
         // Verify the service is running
-        String healthCheck = terminal.executeCommand("curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health");
+        String healthCheck = terminal.performTerminalCommand("curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health");
         SHAFT.Validations.assertThat()
              .object(healthCheck)
              .isEqualTo("200")
@@ -147,10 +147,10 @@ public class FileSystemTest {
 
         // Trigger the export via your application's API or UI …
         // Then validate the generated file
-        String exists = terminal.executeCommand("test -f /tmp/export.csv && echo 'found' || echo 'missing'");
+        String exists = terminal.performTerminalCommand("test -f /tmp/export.csv && echo 'found' || echo 'missing'");
         SHAFT.Validations.assertThat().object(exists).contains("found").perform();
 
-        String lineCount = terminal.executeCommand("wc -l < /tmp/export.csv");
+        String lineCount = terminal.performTerminalCommand("wc -l < /tmp/export.csv");
         SHAFT.Validations.assertThat()
              .object(lineCount.trim()).isNotNull().perform();
     }
@@ -162,14 +162,30 @@ public class FileSystemTest {
 | OS | Shell | Example command |
 |----|-------|----------------|
 | **Linux / macOS** | bash | `ls -la`, `chmod 755 script.sh`, `./deploy.sh` |
-| **Windows** | cmd | `dir`, `tasklist`, `powershell -Command "..."` |
+| **Windows** | PowerShell | `dir`, `tasklist`, `Get-Process` |
 
 When writing cross-platform tests, guard with a platform check:
 
 ```java title="CrossPlatformCommand.java"
 String os = System.getProperty("os.name").toLowerCase();
 String listCmd = os.contains("win") ? "dir" : "ls -la";
-String output = terminal.executeCommand(listCmd);
+String output = terminal.performTerminalCommand(listCmd);
+```
+
+## Timeouts and Reporting
+
+Local commands use `shellSessionTimeout`; timed-out processes are destroyed and reported as failures.
+Returned output stays unchanged for assertions, while command/report logs redact common secrets such as tokens, passwords, bearer headers, and URI credentials.
+
+Use the environment-variable overload when a command needs secret input:
+
+```java title="CommandEnvironment.java"
+import java.util.Map;
+
+String output = SHAFT.CLI.terminal().performTerminalCommand(
+    "echo $env:DEPLOY_TOKEN",
+    Map.of("DEPLOY_TOKEN", System.getenv("DEPLOY_TOKEN"))
+);
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Summary

- Update CLI docs to use the current `performTerminalCommand` and `readFile` APIs.
- Document terminal timeout/reporting behavior and byte-count reporting for file writes.
- Refresh SSH and deprecated Docker terminal examples to match current CLI guidance.

Companion engine PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2978

## Validation

- `npm run build` passed.
- Graphify refresh attempted with `graphify . --update --no-viz`, but it was blocked because no LLM API key was available for semantic extraction of changed docs/images.