### PR TITLE
Document touch end-scroll and image invisibility actions

### DIFF
--- a/docs/integrations/visual.md
+++ b/docs/integrations/visual.md
@@ -62,6 +62,7 @@ flowchart TD
 | `doesNotMatchReferenceImage()` and its overload                | Negative OpenCV/visual-engine comparison.                    |
 | `TouchActions.tap(String)`                                     | Finds and taps an image inside the current screen.           |
 | `TouchActions.waitUntilElementIsVisible(String)`               | Waits for an image match.                                    |
+| `TouchActions.waitUntilElementIsNotVisible(String)`            | Waits until an image match disappears from the screen.       |
 | `TouchActions.swipeElementIntoView(String, ...)`               | Swipes until the reference image is found.                   |
 | `ImageProcessingActions.findImageWithinCurrentPage(...)`       | Direct OpenCV-backed image lookup.                           |
 | `ImageProcessingActions.compareAgainstBaseline(...)`           | Direct baseline comparison.                                  |

--- a/docs/reference/actions/GUI/Touch_Actions.md
+++ b/docs/reference/actions/GUI/Touch_Actions.md
@@ -80,6 +80,21 @@ By targetElement = By.id("item_50");
 driver.touch().swipeElementIntoView(scrollableContainer, targetElement, TouchActions.SwipeDirection.DOWN);
 ```
 
+### swipeToEndOfView()
+
+Swipes until the current Appium view can no longer scroll in the requested direction.
+
+```java title="SwipeToEndExample.java"
+driver.touch().swipeToEndOfView(TouchActions.SwipeDirection.DOWN);
+```
+
+You can also limit the gesture to a scrollable container:
+
+```java title="SwipeContainerToEndExample.java"
+By scrollableContainer = By.id("list_view");
+driver.touch().swipeToEndOfView(scrollableContainer, TouchActions.SwipeDirection.UP);
+```
+
 ## Keyboard Actions
 
 ### nativeKeyboardKeyPress()
@@ -139,6 +154,14 @@ Waits until a specific element is visible on the screen using image-based detect
 
 ```java title="WaitForVisualElement.java"
 driver.touch().waitUntilElementIsVisible("path/to/reference-screenshot.png");
+```
+
+### waitUntilElementIsNotVisible()
+
+Waits until a reference image is no longer visible on the screen.
+
+```java title="WaitForVisualElementToDisappear.java"
+driver.touch().waitUntilElementIsNotVisible("path/to/reference-screenshot.png");
 ```
 
 ## Complete Example


### PR DESCRIPTION
## Summary
- document `swipeToEndOfView(...)` in the touch actions reference
- document `waitUntilElementIsNotVisible(String)` in touch and visual integration docs

## Validation
- `npm run test:docs`

## Notes
- Graphify refresh intentionally skipped per branch-conflict instruction.