### PR TITLE
Refresh deprecated API documentation

### DIFF
--- a/docs/reference/actions/CLI/Docker_Terminal.md
+++ b/docs/reference/actions/CLI/Docker_Terminal.md
@@ -162,7 +162,7 @@ void createUserViaDbAndVerifyThroughApi() {
     SHAFT.API api = new SHAFT.API("https://api.example.com");
     api.get("/users?email=test@example.com")
        .setTargetStatusCode(200)
-       .performRequest();
+       .perform();
 
     api.assertThatResponse()
         .extractedJsonValue("$[0].name")

--- a/docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md
+++ b/docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md
@@ -204,9 +204,6 @@ targetBrowserName=chrome
 
 # Optional: Enable headless mode for faster execution
 headlessExecution=true
-
-# Optional: Set session timeout
-dockerCommandTimeout=300
 ```
 
   </TabItem>
@@ -380,13 +377,14 @@ Logs are displayed in the terminal where you started the Hub/Node.
 **Problem**: Tests timeout when creating a session.
 
 **Solutions**:
-- Increase session timeout values:
-  ```properties
-  dockerCommandTimeout=600
-  ```
-- Reduce `SE_NODE_MAX_SESSIONS` if nodes are overloaded
-- Add more nodes to increase capacity
-- Check node health status in Grid console
+- Increase Selenium Grid session timeout values in your Grid or node configuration.
+- Reduce `SE_NODE_MAX_SESSIONS` if nodes are overloaded.
+- Add more nodes to increase capacity.
+- Check node health status in Grid console.
+
+:::note
+`dockerCommandTimeout` is deprecated and only affects the legacy docker-wrapped terminal execution path. It does not tune Selenium Grid session creation.
+:::
 
 ### Browser Not Found
 
@@ -429,9 +427,8 @@ Logs are displayed in the terminal where you started the Hub/Node.
 
 2. **Monitor Resource Usage**: Keep an eye on CPU and memory usage, especially when running many parallel sessions.
 
-3. **Set Appropriate Timeouts**: Configure session and command timeouts based on your test duration:
+3. **Set Appropriate Timeouts**: Configure Grid session capacity in Selenium Grid and element waits in SHAFT based on your test duration:
    ```properties
-   dockerCommandTimeout=300
    webDriverElementTimeout=30
    ```
 

--- a/docs/reference/actions/Validations/JSON_Schema_Validation.md
+++ b/docs/reference/actions/Validations/JSON_Schema_Validation.md
@@ -52,7 +52,7 @@ SHAFT.API api = new SHAFT.API("https://api.example.com");
 
 api.get("/users/1")
    .setTargetStatusCode(200)
-   .performRequest();
+   .perform();
 
 api.assertThatResponse()
    .matchesSchema("src/test/resources/schemas/user-schema.json");
@@ -85,7 +85,7 @@ public class JSONSchemaValidationTest {
 
         api.get("/users/1")
            .setTargetStatusCode(200)
-           .performRequest();
+           .perform();
 
         api.assertThatResponse()
            .matchesSchema("src/test/resources/schemas/user-schema.json");
@@ -97,7 +97,7 @@ public class JSONSchemaValidationTest {
 
         api.get("/users")
            .setTargetStatusCode(200)
-           .performRequest();
+           .perform();
 
         api.assertThatResponse()
            .matchesSchema("src/test/resources/schemas/user-list-schema.json");
@@ -109,7 +109,7 @@ public class JSONSchemaValidationTest {
 
         api.get("/users/1")
            .setTargetStatusCode(200)
-           .performRequest();
+           .perform();
 
         // Confirm the response does not expose admin-only fields
         api.assertThatResponse()

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -515,7 +515,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | apiConnectionTimeout                | `30`          | (seconds)       | Timeout in seconds for API connections.                                            |
 | apiConnectionManagerTimeout         | `30`          | (seconds)       | Timeout in seconds for API connection manager.                                     |
 | shellSessionTimeout                 | `30`          | (seconds)       | Timeout in seconds for shell session.                                              |
-| dockerCommandTimeout                | `30`          | (seconds)       | Timeout in seconds for Docker commands.                                            |
+| dockerCommandTimeout                | `30`          | (seconds)       | Deprecated. Legacy docker-wrapped terminal command timeout.                        |
 | databaseLoginTimeout                | `30`          | (seconds)       | Timeout in seconds for database login.                                             |
 | databaseNetworkTimeout              | `30`          | (seconds)       | Timeout in seconds for database network operations.                                |
 | databaseQueryTimeout                | `30`          | (seconds)       | Timeout in seconds for database queries.                                           |


### PR DESCRIPTION
## Summary
- replace public docs examples that used deprecated `performRequest()` with `perform()`
- remove `dockerCommandTimeout` from Selenium Grid timeout tuning guidance
- mark `dockerCommandTimeout` as deprecated in the properties catalog

## Validation
- `npm run test:docs`

## Notes
- Graphify refresh intentionally skipped per branch-conflict instruction.