### PR TITLE
Document query parameters with request bodies

### DIFF
--- a/docs/reference/actions/API/Request_Builder.md
+++ b/docs/reference/actions/API/Request_Builder.md
@@ -187,12 +187,24 @@ parameters.put("password", "1234");
 api.post("serviceName").setParameters(parameters, RestActions.ParametersType.FORM).perform();
 ```
 #### Parameters Type QUERY
+Query parameters are appended to the request URL. They can also be combined with a request body when the endpoint expects URL filters and payload data in the same request.
 ```java
 SHAFT.API api = new SHAFT.API("serviceURI");
 Map<String, Object> parameters = new LinkedHashMap<>();
 parameters.put("search", "john");
 parameters.put("orderBy", "desc");
 api.get("serviceName").setParameters(parameters, RestActions.ParametersType.QUERY).perform();
+```
+```java
+SHAFT.API api = new SHAFT.API("serviceURI");
+Map<String, Object> parameters = new LinkedHashMap<>();
+parameters.put("include", "profile");
+String body = "{\"status\":\"active\"}";
+
+api.post("serviceName")
+   .setRequestBody(body)
+   .setParameters(parameters, RestActions.ParametersType.QUERY)
+   .perform();
 ```
 #### Parameters Type MULTIPART
 Note that: Multipart parameters are used for file uploads and text fields.  


### PR DESCRIPTION
## Summary
- Document that `ParametersType.QUERY` parameters are appended to the URL.
- Add a request-builder example showing query parameters combined with a POST body.
- Related engine fix: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2985

## Validation
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:e2e`

## Notes
- `yarn test:playwright` was not run because `package.json` does not define that script; `yarn test:e2e` is the available Playwright/SHAFT smoke script.
- `graphify . --update --no-viz` is blocked locally because no `GEMINI_API_KEY` or `GOOGLE_API_KEY` is configured for semantic extraction.
