### PR TITLE
Use GUI driver facade in Playwright docs

### DIFF
--- a/docs/reference/actions/GUI/Playwright_Backend.md
+++ b/docs/reference/actions/GUI/Playwright_Backend.md
@@ -14,7 +14,7 @@ high-level SHAFT browser, element, alert, and assertion entry points.
 import com.shaft.driver.SHAFT;
 
 public class PlaywrightTest {
-    private com.shaft.gui.driver.Driver driver;
+    private SHAFT.GUI.Driver driver;
 
     @BeforeMethod
     public void openBrowser() {
@@ -36,7 +36,7 @@ public class PlaywrightTest {
 
 Use `SHAFT.GUI.WebDriver` for the Selenium/Appium backend and
 `SHAFT.GUI.Playwright` for the Playwright backend. Both implement
-`com.shaft.gui.driver.Driver`, so test classes can choose the backend at setup time.
+`SHAFT.GUI.Driver`, so test classes can choose the backend at setup time.
 
 ## Configuration
 
@@ -78,7 +78,7 @@ SHAFT.GUI.Playwright driver = new SHAFT.GUI.Playwright();
 
 com.microsoft.playwright.Page page = driver.getDriver();
 com.microsoft.playwright.BrowserContext context = driver.getNativeContext();
-com.microsoft.playwright.Playwright Playwright = driver.getPlaywright();
+com.microsoft.playwright.Playwright playwright = driver.getPlaywright();
 ```
 
 Element actions accept SHAFT locators and concrete Playwright actions also

--- a/docs/testing/web.mdx
+++ b/docs/testing/web.mdx
@@ -56,10 +56,10 @@ network mocking.
 
 Use `SHAFT.GUI.Playwright` when a test should run through Microsoft Playwright
 instead of Selenium/Appium WebDriver. Both backends implement
-`com.shaft.gui.driver.Driver`, so setup code can choose the backend per test class.
+`SHAFT.GUI.Driver`, so setup code can choose the backend per test class.
 
 ```java
-private com.shaft.gui.driver.Driver driver;
+private SHAFT.GUI.Driver driver;
 
 @BeforeMethod
 public void openBrowser() {

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -995,8 +995,8 @@
     "semantic_hash": ""
   },
   "docs/testing/web.mdx": {
-    "mtime": 1782032053.1955428,
-    "ast_hash": "3ee10283cd760830ed13e35e5748570b",
+    "mtime": 1782033275.2266262,
+    "ast_hash": "f539b1e0fa813c5bc1f97e6ece057d7c",
     "semantic_hash": ""
   },
   "redirect-page/index.html": {
@@ -2180,8 +2180,8 @@
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Playwright_Backend.md": {
-    "mtime": 1782032053.1925416,
-    "ast_hash": "ef4af0f9de70cbdfc1b0ba2c7424d3ab",
+    "mtime": 1782033275.2266262,
+    "ast_hash": "731b5e90110cd38427ebb05939362dbf",
     "semantic_hash": ""
   }
 }


### PR DESCRIPTION
## Summary
- update Playwright docs to show `SHAFT.GUI.Driver driver = new SHAFT.GUI.Playwright();`
- keep the docs examples aligned with the public SHAFT unified entry point
- refresh graphify manifest for the changed docs

## Validation
- `npm run test:docs`
- `git diff --check`

Depends on the engine API follow-up PR for `SHAFT.GUI.Driver`.