### PR TITLE
[codex] Document SHAFT Playwright MCP flows

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -71,6 +71,13 @@ The same lifecycle is exposed by the `capture_start`, `capture_start_codegen`,
 `capture_generate`; `capture_codegen_features` returns the feature map. Status
 contains safe metadata and counts, never typed values.
 
+WebDriver code generation remains the default through `capture_generate`,
+`capture_generate_replay`, and `capture_code_blocks`. Use
+`playwright_capture_generate_replay` or `playwright_capture_code_blocks` only
+when the target repository uses `SHAFT.GUI.Playwright` or the user asks for
+Playwright output. Those Playwright tools read the same Capture session format
+but emit `SHAFT.GUI.Playwright` setup, actions, waits, and assertions.
+
 When recording in a visible browser, SHAFT injects a compact Capture panel into
 the managed Chrome/Edge session. The panel lists captured actions in plain
 English while the user clicks, types, selects, uploads, or navigates. Its
@@ -82,13 +89,14 @@ and leaves the session in `COMPLETED` status for generation.
 For agent-driven MCP flows, the intended handoff is: call `capture_start` or
 `capture_start_codegen`, let the user interact with the visible browser, wait
 for either `capture_stop` or a browser-panel stop to complete, then call
-`capture_code_blocks`. The agent should show the generated result and ask
-whether the user wants the complete Java snippet or wants the agent to insert
-the code into the current repository. Snippet mode uses the returned Java
-full-class block, including imports, locator fields, setup, SHAFT actions, and
-teardown. Insertion mode should inspect the repository and move locators and
-actions into existing Page Object classes when that pattern already exists, or
-create the smallest matching page/test classes when it does not.
+`capture_code_blocks` for WebDriver or `playwright_capture_code_blocks` for
+Playwright. The agent should show the generated result and ask whether the user
+wants the complete Java snippet or wants the agent to insert the code into the
+current repository. Snippet mode uses the returned Java full-class block,
+including imports, locator fields, setup, SHAFT actions, and teardown.
+Insertion mode should inspect the repository and move locators and actions
+into existing Page Object classes when that pattern already exists, or create
+the smallest matching page/test classes when it does not.
 
 All process arguments and filesystem paths are built with Java APIs
 (`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
@@ -208,7 +216,9 @@ event IDs and remediation.
 Compilation is enabled by default. Add `--replay` to run the compiled TestNG
 class in an isolated process and require populated, passing Allure result
 files. Existing source, data, report, or preview files are never replaced
-unless `--overwrite` is supplied.
+unless `--overwrite` is supplied. MCP replay code follows the selected backend:
+WebDriver tools keep `SHAFT.GUI.WebDriver` and Playwright tools generate
+`SHAFT.GUI.Playwright`.
 
 AI enrichment is optional and uses two phases for native CLI users:
 

--- a/docs/agentic/doctor.mdx
+++ b/docs/agentic/doctor.mdx
@@ -158,6 +158,12 @@ the minimum expected Allure result count. The tool calls the same
 disabled; when the MCP server is explicitly started with an enabled provider,
 the same separate advisory and fallback rules apply.
 
+Use `doctor_analyze_failed_allure` and `doctor_suggest_fix` for default
+Selenium/WebDriver remediation snippets. Use
+`playwright_doctor_analyze_failed_allure` and `playwright_doctor_suggest_fix`
+when the failed test is written with `SHAFT.GUI.Playwright`; the evidence model
+is the same, but the returned code blocks use Playwright assertions and actions.
+
 ChatGPT, Codex, Claude, Gemini, and GitHub Copilot can invoke
 `doctor_analyze_failed_allure` as external MCP clients. Their model authentication stays in
 the client and is not ingested by SHAFT. Copilot is MCP interoperability, not a
@@ -170,10 +176,14 @@ generic Copilot API-key adapter. Download the credential-free
 an allowlisted Maven test command under guardrails, snapshots the populated
 Allure results that changed during each attempt, and sends the fresh failing
 evidence to `doctor_analyze_failed_allure` before returning repair suggestions.
+Use `playwright_healer_run_failed_test` for `SHAFT.GUI.Playwright` tests; it
+uses the same execution guardrails and sends evidence through the Playwright
+Doctor tool surface.
 
 The healer gives the MCP agent an explicit replay handoff: the agent may use
 its own LLM plus SHAFT MCP browser, DOM, screenshot, element, and natural-action
-tools to inspect the failed flow, even when no SHAFT provider API key is
+tools to inspect WebDriver failures, or the `playwright_*` inspection and
+replay tools for Playwright failures, even when no SHAFT provider API key is
 configured. Configured SHAFT provider advisories remain optional and require
 the same Pilot consent as Doctor.
 

--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -75,8 +75,10 @@ the runtime root when their SHAFT property paths are relative. Explicit absolute
 path overrides stay absolute.
 
 Use the normal `element_click` and `element_type` tools with explicit locator
-strategy and locator value arguments. Semantic click/type aliases are not
-exposed to MCP clients; use `natural_act` when a workflow needs approved
+strategy and locator value arguments for default WebDriver sessions. Use the
+`playwright_*` browser, element, recording, playback, Doctor, and healer tools
+when the project uses `SHAFT.GUI.Playwright`. Semantic click/type aliases are
+not exposed to MCP clients; use `natural_act` when a workflow needs approved
 natural-language execution.
 
 If an older setup fails with `AccessDeniedException` under

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -12,10 +12,12 @@ import {McpApplications} from '@site/src/components/DocSnippets';
 # Connect shaft-mcp
 
 `shaft-mcp` is the Model Context Protocol server for SHAFT browser,
-mobile, Capture, Doctor, and healer automation. It is published to Maven Central as
-the thin `io.github.shafthq:shaft-mcp` JAR, built in the SHAFT reactor, and
-depends on the canonical `shaft-engine` module. It does not add any dependency
-to ordinary `shaft-engine` consumers.
+mobile, Capture, Doctor, and healer automation. Web GUI tools default to
+SHAFT WebDriver; choose the `playwright_*` tools when the project already uses
+`SHAFT.GUI.Playwright` or the user explicitly asks for Playwright code. It is
+published to Maven Central as the thin `io.github.shafthq:shaft-mcp` JAR, built
+in the SHAFT reactor, and depends on the canonical `shaft-engine` module. It
+does not add any dependency to ordinary `shaft-engine` consumers.
 
 ## Applications
 
@@ -77,9 +79,12 @@ test data, Extent reports, execution summaries, and performance reports.
 Explicit absolute path overrides remain absolute.
 
 The element action tools stay explicit and locator-based. Use `element_click`
-and `element_type` with a locator strategy and locator value. The older
-semantic click/type aliases are not exposed to MCP clients; for approved
-natural-language execution, use `natural_act`.
+and `element_type` with a locator strategy and locator value for default
+WebDriver sessions; use `playwright_element_click`,
+`playwright_element_type`, and the other `playwright_*` browser or element
+tools for SHAFT Playwright sessions. The older semantic click/type aliases are
+not exposed to MCP clients; for approved natural-language execution, use
+`natural_act`.
 
 ## Guide search for agents
 
@@ -118,11 +123,13 @@ Common catalog entries include:
 | `api-openapi-contract-suite` | Read the Swagger/OpenAPI contract, group operations by tag/resource, write reusable request builders and response validators under `src/main/java`, then write TestNG scenarios under `src/test/java`. | Focused API tests compile, run, and validate against the configured OpenAPI contract. |
 | `web-pom-fluent-test` | Inspect the page with browser DOM/screenshot tools, create or extend Page Object classes, and write fluent SHAFT actions and assertions. | The headless GUI test passes and page object methods are reusable. |
 | `web-locator-refactor` | Replace brittle locators with SHAFT smart locators, ARIA locators, `SHAFT.GUI.Locator`, or stable Selenium `By` locators. | Affected tests pass without `@FindBy`, PageFactory, or absolute XPath. |
-| `web-capture-to-pom` | Record with Capture, generate replay snippets, then move stable locators and actions into existing page objects. | Replay-derived code is integrated instead of pasted as a generic generated class. |
+| `web-capture-to-pom` | Record with Capture, generate WebDriver replay snippets, then move stable locators and actions into existing page objects. | Replay-derived code is integrated instead of pasted as a generic generated class. |
+| `web-playwright-pom-fluent-test` | Use `playwright_*` browser and element tools to inspect the page, then write fluent `SHAFT.GUI.Playwright` page objects and tests. | The Playwright test compiles and follows the existing project backend. |
+| `web-playwright-record-replay` | Record Playwright MCP actions, generate replay snippets, and move stable actions into Playwright page methods. | The replay code is reviewed, guarded, and inserted into Playwright classes. |
 | `mobile-native-appium` | Inspect contexts and accessibility trees, prefer accessibility ids/Appium locators, and create mobile page objects plus TestNG tests. | The native mobile test compiles; any unavailable device/cloud run is reported. |
 | `mobile-record-replay` | Record mobile actions through MCP, generate code blocks, and move them into mobile page methods. | The replay code is reviewed, guarded, and inserted into the right classes. |
 | `failure-doctor-analysis` | Analyze Allure results with Doctor and separate product defects, test defects, and infrastructure issues. | The first actionable failure and next validation step are reported. |
-| `failure-healer-loop` | Rerun a guarded failing Selenium test, analyze fresh evidence, and propose review-only fixes. | The failure is fixed by validation or reported as blocked/product behavior. |
+| `failure-healer-loop` | Rerun a guarded failing Selenium or Playwright test, analyze fresh evidence, and propose review-only fixes. | The failure is fixed by validation or reported as blocked/product behavior. |
 | `report-generate-and-summarize` | Generate the report and summarize SHAFT/Allure evidence. | The report path and high-signal pass/fail summary are returned. |
 | `ci-local-validation` | Load validation gotchas, run affected checks first, then escalate only when needed. | The agent reports exact commands, results, and remaining risk. |
 
@@ -156,14 +163,23 @@ The packaged server supports:
 - Streamable HTTP with `--spring.profiles.active=http`, at `/mcp`;
 - managed recording through `capture_start`, `capture_status`, and
   `capture_stop`, with no AI provider required;
-- deterministic TestNG generation through `capture_generate`, with compile,
+- deterministic WebDriver TestNG generation through `capture_generate`,
+  `capture_generate_replay`, and `capture_code_blocks`, with compile,
   optional replay, and review-only AI enrichment phases;
-- deterministic diagnosis through `doctor_analyze_failed_allure`, restricted to explicit
-  input paths and allowed roots, with an optional separately identified
-  provider advisory when Pilot AI is explicitly enabled;
-- guarded Selenium test healing through `healer_run_failed_test`, which reruns
-  tokenized Maven validation commands, analyzes fresh Allure evidence through
-  Doctor, and returns review-only fixes plus an agent replay handoff;
+- deterministic Playwright TestNG generation through
+  `playwright_capture_generate_replay` and `playwright_capture_code_blocks`
+  when the target repository uses `SHAFT.GUI.Playwright`;
+- explicit Playwright browser, element, screenshot, DOM, action recording,
+  playback, and copy-paste replay tools through the `playwright_*` tool family;
+- deterministic diagnosis through `doctor_analyze_failed_allure` for
+  WebDriver remediation and `playwright_doctor_analyze_failed_allure` for
+  Playwright remediation, restricted to explicit input paths and allowed roots,
+  with an optional separately identified provider advisory when Pilot AI is
+  explicitly enabled;
+- guarded test healing through `healer_run_failed_test` for Selenium/WebDriver
+  and `playwright_healer_run_failed_test` for SHAFT Playwright, which rerun
+  tokenized Maven validation commands, analyze fresh Allure evidence through
+  Doctor, and return review-only fixes plus an agent replay handoff;
 - explicit browser element actions through `element_click` and `element_type`,
   using locator strategy and locator value arguments;
 - official guide search through `shaft_guide_search`, so agents can retrieve
@@ -217,12 +233,17 @@ See [SHAFT Doctor](/docs/agentic/doctor) for evidence categories, allowlisted pa
 handling, deterministic rules, redaction, offline bundle analysis, optional
 provider advisories, and safe fallback behavior.
 
-## Healing failed Selenium tests
+## Healing failed Selenium or Playwright tests
 
 `healer_run_failed_test` is the Selenium/SHAFT counterpart to test-agent
 healer loops: it reruns the failing test, inspects the fresh SHAFT Allure
 evidence, asks Doctor for the latest diagnosis, and stops when the guarded run
 passes or when guardrails block more attempts.
+
+Use `playwright_healer_run_failed_test` for tests built around
+`SHAFT.GUI.Playwright`. It uses the same guardrails and evidence handling, but
+returns Playwright-oriented remediation snippets and directs the agent to the
+`playwright_*` replay and inspection tools.
 
 The tool accepts a repository root, a tokenized Maven command, an output
 directory, optional source-path allowlists, and explicit approvals for
@@ -232,9 +253,10 @@ default. Shell syntax, release/deploy goals, external Maven settings, and
 worktree-escape paths are rejected.
 
 When the healer returns a failed diagnosis, the calling MCP agent may use its
-own LLM and the existing SHAFT MCP browser, DOM, screenshot, element, and
-natural-action tools to replay the failed Selenium flow and inspect the current
-UI. This agent-side reasoning does not require a SHAFT provider API key.
+own LLM and the matching SHAFT MCP browser, DOM, screenshot, element, and
+replay tools to inspect the current UI. Use the existing WebDriver tool names
+for Selenium tests and the `playwright_*` names for Playwright tests. This
+agent-side reasoning does not require a SHAFT provider API key.
 
 The healer never edits source or publishes a change by itself. Locator, wait,
 test-data, assertion, and product-bug recommendations remain review-only until

--- a/tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java
+++ b/tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java
@@ -110,7 +110,7 @@ public class SiteRenderTest {
         navigate("/");
 
         shaft.assertThat().browser().title().contains("SHAFT");
-        visible(By.xpath("//h1[normalize-space()='One Java engine for web, native mobile GUI, and API automation.']"));
+        visible(By.xpath("//h1[normalize-space()='One Java engine for web, mobile, API, database, and CLI automation.']"));
         SHAFT.Validations.assertThat().object(attribute(link("Generate a runnable project"), "href"))
                 .contains("/docs/start/installation");
         SHAFT.Validations.assertThat().object(attribute(link("Read the minimal web test"), "href"))
@@ -259,7 +259,7 @@ public class SiteRenderTest {
         if (!toggles.isEmpty() && toggles.getFirst().isDisplayed()) {
             click(By.cssSelector("button[title*='Switch between dark and light mode']"));
         }
-        visible(By.xpath("//h1[normalize-space()='One Java engine for web, native mobile GUI, and API automation.']"));
+        visible(By.xpath("//h1[normalize-space()='One Java engine for web, mobile, API, database, and CLI automation.']"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Document that SHAFT MCP Web GUI automation defaults to WebDriver and uses `playwright_*` tools when the project or user chooses `SHAFT.GUI.Playwright`.
- Add Capture, Doctor, Healer, and manual MCP setup guidance for Playwright codegen, recording, playback, and remediation flows.
- Update the SHAFT docs smoke test homepage assertion to match the current homepage H1 from `origin/master`, which was required for the e2e suite to pass.

## Related
- Engine PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/2990

## Validation
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:e2e`

## Notes
- `yarn test:playwright` is listed in AGENTS.md but is not defined in `package.json`; `yarn test:e2e` is the available SHAFT render test command and passed.
- Graphify refresh was attempted with `graphify . --update`, but graphify blocked because no supported LLM key is configured; docs refresh needs semantic extraction for 226 doc/image files.
