### PR TITLE
[codex] Update MCP guardrail docs

### DIFF
--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -133,12 +133,16 @@ Common catalog entries include:
 | `report-generate-and-summarize` | Generate the report and summarize SHAFT/Allure evidence. | The report path and high-signal pass/fail summary are returned. |
 | `ci-local-validation` | Load validation gotchas, run affected checks first, then escalate only when needed. | The agent reports exact commands, results, and remaining risk. |
 
-Before finalizing generated Java, call `test_code_guardrails_check`. It fails
-code that contains `Thread.sleep(...)` or absolute XPath such as
-`By.xpath("/html/body/...")`. Prefer SHAFT waits/actions/assertions and the
-locator order from the catalog: smart/semantic locators, ARIA locators,
-`SHAFT.GUI.Locator`, stable `By`/`AppiumBy`, then non-absolute XPath only when
-nothing better exists.
+Before finalizing generated Java, call `test_code_guardrails_check`. It is a
+lexical check, so agents still need compile or runtime validation afterwards.
+The tool fails code that contains `Thread.sleep(...)`, absolute XPath such as
+`By.xpath("/html/body/...")`, or obvious hard-coded secrets in headers, tokens,
+passwords, and API keys. It warns on Selenium implicit waits, direct
+`driver.findElement`/`findElements` calls, hard-coded headed browser setup,
+direct `System.getProperty()`, and PageFactory usage. Prefer SHAFT
+waits/actions/assertions and the locator order from the catalog: smart/semantic
+locators, ARIA locators, `SHAFT.GUI.Locator`, stable `By`/`AppiumBy`, then
+non-absolute XPath only when nothing better exists.
 
 If you see an `AccessDeniedException` under `C:\Windows\system32`, the MCP host
 launched from a protected Windows directory. Upgrade to a release with the

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - codex-flakiness-docs  (2026-06-24)
+# Graph Report - issue-3032-mcp-guardrails-docs  (2026-06-24)
 
 ## Corpus Check
-- 221 files · ~215,018 words
+- 221 files · ~215,059 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -10,7 +10,7 @@
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `6aafe251`
+- Built from commit: `a12aec82`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6367,7 +6367,7 @@
       "label": "Build from source",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L147",
+      "source_location": "L151",
       "_origin": "ast",
       "id": "agentic_mcp_build_from_source",
       "community": 66,
@@ -6377,7 +6377,7 @@
       "label": "Healing failed Selenium or Playwright tests",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L236",
+      "source_location": "L240",
       "_origin": "ast",
       "id": "agentic_mcp_healing_failed_selenium_or_playwright_tests",
       "community": 66,
@@ -6387,7 +6387,7 @@
       "label": "Authentication boundary",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L280",
+      "source_location": "L284",
       "_origin": "ast",
       "id": "agentic_mcp_authentication_boundary",
       "community": 66,
@@ -6397,7 +6397,7 @@
       "label": "What the installer configures",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L296",
+      "source_location": "L300",
       "_origin": "ast",
       "id": "agentic_mcp_what_the_installer_configures",
       "community": 66,
@@ -6407,7 +6407,7 @@
       "label": "Remote clients",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L339",
+      "source_location": "L343",
       "_origin": "ast",
       "id": "agentic_mcp_remote_clients",
       "community": 66,
@@ -6417,7 +6417,7 @@
       "label": "Distribution identity",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L368",
+      "source_location": "L372",
       "_origin": "ast",
       "id": "agentic_mcp_distribution_identity",
       "community": 66,
@@ -6427,7 +6427,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/agentic/mcp.mdx",
-      "source_location": "L382",
+      "source_location": "L386",
       "_origin": "ast",
       "id": "agentic_mcp_related",
       "community": 66,
@@ -30656,9 +30656,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_changelog"
     },
     {
       "relation": "contains",
@@ -30666,9 +30666,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623"
     },
     {
       "relation": "contains",
@@ -30676,9 +30676,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_what_changed"
     },
     {
       "relation": "contains",
@@ -30686,9 +30686,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_community_spotlight",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_community_spotlight"
     },
     {
       "relation": "contains",
@@ -30696,9 +30696,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L114",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_get_started_in_seconds",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_get_started_in_seconds"
     },
     {
       "relation": "contains",
@@ -30706,9 +30706,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_join_the_conversation",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_join_the_conversation"
     },
     {
       "relation": "contains",
@@ -30716,9 +30716,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "target": "blog_2026_06_23_release_10_2_20260623_what_s_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_what_s_changed"
     },
     {
       "relation": "contains",
@@ -46146,9 +46146,9 @@
       "source_file": "docs/start/upgrade.mdx",
       "source_location": "L430",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "start_upgrade_upgrade_to_modular_shaft",
-      "target": "start_upgrade_selenium_source_migration",
-      "confidence_score": 1.0
+      "target": "start_upgrade_selenium_source_migration"
     },
     {
       "relation": "contains",
@@ -46206,9 +46206,9 @@
       "source_file": "docs/start/upgrade.mdx",
       "source_location": "L135",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "start_upgrade_automated_upgrade",
-      "target": "start_upgrade_choose_an_upgrade_type",
-      "confidence_score": 1.0
+      "target": "start_upgrade_choose_an_upgrade_type"
     },
     {
       "relation": "contains",
@@ -46306,9 +46306,9 @@
       "source_file": "docs/start/upgrade.mdx",
       "source_location": "L480",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "start_upgrade_selenium_source_migration",
-      "target": "start_upgrade_full_upgrade_rewrites",
-      "confidence_score": 1.0
+      "target": "start_upgrade_full_upgrade_rewrites"
     },
     {
       "relation": "contains",
@@ -46316,9 +46316,9 @@
       "source_file": "docs/start/upgrade.mdx",
       "source_location": "L436",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "start_upgrade_selenium_source_migration",
-      "target": "start_upgrade_session_upgrade_rewrites",
-      "confidence_score": 1.0
+      "target": "start_upgrade_session_upgrade_rewrites"
     },
     {
       "relation": "contains",
@@ -46376,9 +46376,9 @@
       "source_file": "docs/superpowers/plans/2026-06-24-flakiness-guide.md",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "plans_2026_06_24_flakiness_guide",
-      "target": "plans_2026_06_24_flakiness_guide_flakiness_guide_implementation_plan",
-      "confidence_score": 1.0
+      "target": "plans_2026_06_24_flakiness_guide_flakiness_guide_implementation_plan"
     },
     {
       "relation": "contains",
@@ -46386,9 +46386,9 @@
       "source_file": "docs/superpowers/plans/2026-06-24-flakiness-guide.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "plans_2026_06_24_flakiness_guide_flakiness_guide_implementation_plan",
-      "target": "plans_2026_06_24_flakiness_guide_task_1_add_the_guide",
-      "confidence_score": 1.0
+      "target": "plans_2026_06_24_flakiness_guide_task_1_add_the_guide"
     },
     {
       "relation": "contains",
@@ -46456,9 +46456,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness",
-      "target": "testing_flakiness_how_shaft_reduces_flakiness",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_how_shaft_reduces_flakiness"
     },
     {
       "relation": "contains",
@@ -46466,9 +46466,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_automatic_synchronization",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_automatic_synchronization"
     },
     {
       "relation": "contains",
@@ -46476,9 +46476,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L120",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_optional_self_healing",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_optional_self_healing"
     },
     {
       "relation": "contains",
@@ -46486,9 +46486,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L154",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_related",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_related"
     },
     {
       "relation": "contains",
@@ -46496,9 +46496,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L100",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_retry_with_evidence",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_retry_with_evidence"
     },
     {
       "relation": "contains",
@@ -46506,9 +46506,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_semantic_locators",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_semantic_locators"
     },
     {
       "relation": "contains",
@@ -46516,9 +46516,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L144",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "testing_flakiness_how_shaft_reduces_flakiness",
-      "target": "testing_flakiness_what_to_use_first",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_what_to_use_first"
     },
     {
       "relation": "contains",
@@ -46872,5 +46872,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "6aafe251084706082fd7c3b730f6721403515c98"
+  "built_at_commit": "a12aec820e01823a2f10d46ba06b6a744ef1bd21"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,1282 +1,1282 @@
 {
   "babel.config.js": {
-    "mtime": 1782275930.521312,
+    "mtime": 1782277797.0521798,
     "ast_hash": "319feac2fd3850e21aa4834fab5cdb46",
     "semantic_hash": ""
   },
   "demo-autobot-approach.mjs": {
-    "mtime": 1782275930.531629,
+    "mtime": 1782277797.0644624,
     "ast_hash": "8c336441fffbaf2f417474bc27644f5e",
     "semantic_hash": ""
   },
   "docusaurus.config.js": {
-    "mtime": 1782275930.5982656,
+    "mtime": 1782277797.131064,
     "ast_hash": "28d93b8dfc486cfcacce62c8322280ca",
     "semantic_hash": ""
   },
   "functions/api/gemini-proxy.js": {
-    "mtime": 1782275930.5982656,
+    "mtime": 1782277797.132064,
     "ast_hash": "50d09aefbe3e2499bb404a9ed952306b",
     "semantic_hash": ""
   },
   "netlify/functions/autobot-core.mjs": {
-    "mtime": 1782275930.6142662,
+    "mtime": 1782277797.148045,
     "ast_hash": "ac69e64e4bfa562b41bac3bed1a5c3e4",
     "semantic_hash": ""
   },
   "netlify/functions/constants.mjs": {
-    "mtime": 1782275930.6142662,
+    "mtime": 1782277797.148045,
     "ast_hash": "1d99ec839e81b17054d9938b2d9122f7",
     "semantic_hash": ""
   },
   "netlify/functions/docs-loader.mjs": {
-    "mtime": 1782275930.6152654,
+    "mtime": 1782277797.149044,
     "ast_hash": "344e7ea2d7fa3802506f8a8b5f109aac",
     "semantic_hash": ""
   },
   "netlify/functions/docs-retrieval.mjs": {
-    "mtime": 1782275930.6162658,
+    "mtime": 1782277797.149044,
     "ast_hash": "f4e4d4183f921c478bbdf1a9aec4fa33",
     "semantic_hash": ""
   },
   "netlify/functions/gemini-proxy.mjs": {
-    "mtime": 1782275930.6162658,
+    "mtime": 1782277797.149044,
     "ast_hash": "b5ae4c20bcd1dcbf078c819eb2f7ac85",
     "semantic_hash": ""
   },
   "netlify/functions/github-context.mjs": {
-    "mtime": 1782275930.6162658,
+    "mtime": 1782277797.1500635,
     "ast_hash": "315f9c46e52a2df11a933c590ce28d42",
     "semantic_hash": ""
   },
   "package.json": {
-    "mtime": 1782275930.6202457,
-    "ast_hash": "cea6105d217528099578c0d2adfff557",
+    "mtime": 1782277797.1540644,
+    "ast_hash": "c8e6a16efcdf990cd1201c3d11af2870",
     "semantic_hash": ""
   },
   "playwright.config.js": {
-    "mtime": 1782275930.62139,
+    "mtime": 1782277797.1540644,
     "ast_hash": "747b1e41b794168d3bfb7430072509e9",
     "semantic_hash": ""
   },
   "scripts/build-autobot-index.mjs": {
-    "mtime": 1782275930.6223905,
+    "mtime": 1782277797.1550639,
     "ast_hash": "2f58ec4e957a74dd66883bab1f60baa2",
     "semantic_hash": ""
   },
   "scripts/check-doc-duplicates.mjs": {
-    "mtime": 1782275930.6233904,
+    "mtime": 1782277797.1550639,
     "ast_hash": "e16b88e21e33e87c6c7df4b05ec1fff5",
     "semantic_hash": ""
   },
   "scripts/prune-search-index.mjs": {
-    "mtime": 1782275930.6233904,
+    "mtime": 1782277797.1560636,
     "ast_hash": "cdfc97593baaa1ca2ee4bb4f40137ce2",
     "semantic_hash": ""
   },
   "scripts/run-shaft-tests.mjs": {
-    "mtime": 1782275930.6243925,
+    "mtime": 1782277797.1560636,
     "ast_hash": "4a81904c720af93da79392c240c2e09b",
     "semantic_hash": ""
   },
   "scripts/verify-models.js": {
-    "mtime": 1782275930.6243925,
+    "mtime": 1782277797.1570628,
     "ast_hash": "cdcff0adb4994356e7ed5b08fbeaca74",
     "semantic_hash": ""
   },
   "sidebars.js": {
-    "mtime": 1782276239.455856,
-    "ast_hash": "262369684e18de68f2557a41d0d96db8",
+    "mtime": 1782277797.1570628,
+    "ast_hash": "73930514bb0cf10abf126d78202c139c",
     "semantic_hash": ""
   },
   "src/components/AutoBot/index.tsx": {
-    "mtime": 1782275930.62639,
+    "mtime": 1782277797.1580625,
     "ast_hash": "7975dce5717eead8da723d4472c8f490",
     "semantic_hash": ""
   },
   "src/components/DocSnippets/McpApplications.tsx": {
-    "mtime": 1782275930.6285834,
+    "mtime": 1782277797.160063,
     "ast_hash": "d6314d5fecb43d9141dc84455f3bdfec",
     "semantic_hash": ""
   },
   "src/components/DocSnippets/index.tsx": {
-    "mtime": 1782275930.6285834,
+    "mtime": 1782277797.1610644,
     "ast_hash": "1b39ccf0cb5f95ef192da988890d57fb",
     "semantic_hash": ""
   },
   "src/components/HomepageFeatures/FeatureBackgrounds.tsx": {
-    "mtime": 1782275930.6296966,
+    "mtime": 1782277797.1621306,
     "ast_hash": "4fa49a43a19f4f1f67e2079ae296bf93",
     "semantic_hash": ""
   },
   "src/components/HomepageFeatures/index.tsx": {
-    "mtime": 1782275930.6306984,
+    "mtime": 1782277797.1621306,
     "ast_hash": "5b99e529e9b2845c25a9c4a11ab0fda1",
     "semantic_hash": ""
   },
   "src/components/ParticleBackground/index.tsx": {
-    "mtime": 1782275930.6316967,
+    "mtime": 1782277797.163265,
     "ast_hash": "92fc3034da7c24b20fe4ab48cf99c914",
     "semantic_hash": ""
   },
   "src/components/ParticleBackground/particleWorker.ts": {
-    "mtime": 1782275930.6316967,
+    "mtime": 1782277797.1642652,
     "ast_hash": "d5855a82df07f34e289711f8897c1fc5",
     "semantic_hash": ""
   },
   "src/components/PropertiesGenerator/index.tsx": {
-    "mtime": 1782275930.6326995,
+    "mtime": 1782277797.1642652,
     "ast_hash": "911d71385f2fea0d0a2418d6b7b44b57",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/App.js": {
-    "mtime": 1782275930.6336966,
+    "mtime": 1782277797.166265,
     "ast_hash": "44124ccb59fba90f62126e831f1b34c6",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/index.tsx": {
-    "mtime": 1782275930.634697,
+    "mtime": 1782277797.166265,
     "ast_hash": "44de1ebbd9c06b5ca3dacdf2407522ff",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/input.js": {
-    "mtime": 1782275930.6356964,
+    "mtime": 1782277797.166265,
     "ast_hash": "6bf8c53d395442428888bb5a97b0508f",
     "semantic_hash": ""
   },
   "src/components/ShaftRobot/index.tsx": {
-    "mtime": 1782275930.636747,
+    "mtime": 1782277797.167269,
     "ast_hash": "eb4a12e2a8c0c65063524f57d0221886",
     "semantic_hash": ""
   },
   "src/data/properties-catalog.json": {
-    "mtime": 1782275930.6379118,
+    "mtime": 1782277797.169928,
     "ast_hash": "b7057119d89316ef3c8b8f0d3d8fedab",
     "semantic_hash": ""
   },
   "src/data/releases.json": {
-    "mtime": 1782275930.63891,
+    "mtime": 1782277797.169928,
     "ast_hash": "19856109549d8f7c2abb581cb9701256",
     "semantic_hash": ""
   },
   "src/data/snippets.json": {
-    "mtime": 1782275930.63891,
+    "mtime": 1782277797.170605,
     "ast_hash": "bf377a419dee9a4111090cc96cf9d6c3",
     "semantic_hash": ""
   },
   "src/pages/index.tsx": {
-    "mtime": 1782275930.6399117,
+    "mtime": 1782277797.1717076,
     "ast_hash": "719e5f4506f7952d9dc6f40e117ac463",
     "semantic_hash": ""
   },
   "src/pages/project-generator.tsx": {
-    "mtime": 1782275930.6409159,
+    "mtime": 1782277797.172707,
     "ast_hash": "0c410aae1b311698ceefefa2cc446b27",
     "semantic_hash": ""
   },
   "src/theme/DocItem/Metadata/index.tsx": {
-    "mtime": 1782275930.6429162,
+    "mtime": 1782277797.1737072,
     "ast_hash": "383e8539fbd126cf1f66341a400365b5",
     "semantic_hash": ""
   },
   "src/theme/MDXComponents.js": {
-    "mtime": 1782275930.6429162,
+    "mtime": 1782277797.1737072,
     "ast_hash": "d80ac4bbba95ec956cfcfd83865e6be0",
     "semantic_hash": ""
   },
   "src/theme/Root.tsx": {
-    "mtime": 1782275930.6429162,
+    "mtime": 1782277797.1747067,
     "ast_hash": "0d17733de18030f7568816e94d93771c",
     "semantic_hash": ""
   },
   "src/types/jsx-namespace.d.ts": {
-    "mtime": 1782275930.6439166,
+    "mtime": 1782277797.1747067,
     "ast_hash": "85fbc9e8f1a5e8998143b93be1085e49",
     "semantic_hash": ""
   },
   "static/examples/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1782275930.6453807,
+    "mtime": 1782277797.1767077,
     "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "static/examples/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1782275930.646458,
+    "mtime": 1782277797.1767077,
     "ast_hash": "0afabccf31612085d45b67e2b4d94490",
     "semantic_hash": ""
   },
   "tests/chat-history.test.js": {
-    "mtime": 1782275930.676372,
+    "mtime": 1782277797.2078784,
     "ast_hash": "cd4331cbc09f106efa9b5ce5a094257b",
     "semantic_hash": ""
   },
   "tests/chatbot-api.test.js": {
-    "mtime": 1782275930.6773715,
+    "mtime": 1782277797.2078784,
     "ast_hash": "b6f45713490fa5d29ac52d0358f0e95f",
     "semantic_hash": ""
   },
   "tests/cloudflare-autobot.test.js": {
-    "mtime": 1782275930.6779847,
+    "mtime": 1782277797.2088783,
     "ast_hash": "8abf051640dceeb15f3e35f4a2555b63",
     "semantic_hash": ""
   },
   "tests/docs-loader.test.js": {
-    "mtime": 1782275930.6785223,
+    "mtime": 1782277797.2088783,
     "ast_hash": "8cd316f2463c44d394be605b3ade25f0",
     "semantic_hash": ""
   },
   "tests/docs-quality.test.js": {
-    "mtime": 1782275930.6785223,
+    "mtime": 1782277797.2088783,
     "ast_hash": "df55dfe7f36c7f485cf85ffedab78063",
     "semantic_hash": ""
   },
   "tests/e2e/homepage.spec.js": {
-    "mtime": 1782275930.6795921,
+    "mtime": 1782277797.2098787,
     "ast_hash": "b1900d6c3f5a9afd6d59d284487ab0cd",
     "semantic_hash": ""
   },
   "tests/enhanced-instruction.test.js": {
-    "mtime": 1782275930.6795921,
+    "mtime": 1782277797.2098787,
     "ast_hash": "1a1b7ea74cf96b3d554a5f91209f5d37",
     "semantic_hash": ""
   },
   "tests/homepage-performance.test.js": {
-    "mtime": 1782275930.6795921,
+    "mtime": 1782277797.2108777,
     "ast_hash": "116f17ea94452c8039a95b4465300a85",
     "semantic_hash": ""
   },
   "tests/properties-catalog.test.js": {
-    "mtime": 1782275930.6805928,
+    "mtime": 1782277797.2108777,
     "ast_hash": "fb069219b6994aea7fef28ca20c4f076",
     "semantic_hash": ""
   },
   "tests/release-blog-template.test.js": {
-    "mtime": 1782275930.6805928,
+    "mtime": 1782277797.2115521,
     "ast_hash": "367c242f98f431ee822c157446afccf1",
     "semantic_hash": ""
   },
   "tests/run-all-tests.js": {
-    "mtime": 1782275930.681592,
+    "mtime": 1782277797.212053,
     "ast_hash": "f5003560f9018c49cc6e7a185b3c444e",
     "semantic_hash": ""
   },
   "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java": {
-    "mtime": 1782275930.6845927,
+    "mtime": 1782277797.214191,
     "ast_hash": "fa62e8caf66c5da6376dfa7b959ffa0a",
     "semantic_hash": ""
   },
   "tsconfig.json": {
-    "mtime": 1782275930.6845927,
+    "mtime": 1782277797.214191,
     "ast_hash": "60c815b8f748b78547a76ef6aa4b2c9d",
     "semantic_hash": ""
   },
   "versions.json": {
-    "mtime": 1782275930.6855938,
+    "mtime": 1782277797.215191,
     "ast_hash": "d751713988987e9331980363e24189ce",
     "semantic_hash": ""
   },
   "worker/index.js": {
-    "mtime": 1782275930.6855938,
+    "mtime": 1782277797.215191,
     "ast_hash": "40a5cb7392ddc9201c1faaec21ab8f82",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1782275930.5148313,
+    "mtime": 1782277797.04558,
     "ast_hash": "12222b1d973f8eabde048aee1aa3fe40",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1782275930.5158315,
+    "mtime": 1782277797.04558,
     "ast_hash": "09cac864013c81959c13ff2c7c8ab0ed",
     "semantic_hash": ""
   },
   ".github/workflows/automated-release-blog-post.yml": {
-    "mtime": 1782275930.5158315,
+    "mtime": 1782277797.0466692,
     "ast_hash": "e9b2fd65ffa8265e9d0940e382146d3b",
     "semantic_hash": ""
   },
   ".github/workflows/deploy.yml": {
-    "mtime": 1782275930.5168316,
+    "mtime": 1782277797.0466692,
     "ast_hash": "48f16a6a2588abc7b5e5e87aa0bb07fd",
     "semantic_hash": ""
   },
   ".github/workflows/update-sitemap.yml": {
-    "mtime": 1782275930.5168316,
+    "mtime": 1782277797.0476677,
     "ast_hash": "cc010aac3430c8f227b26a9154780b96",
     "semantic_hash": ""
   },
   ".vscode/ltex.dictionary.en-US.txt": {
-    "mtime": 1782275930.5195708,
+    "mtime": 1782277797.0491745,
     "ast_hash": "d012e95e452c1e3b48053a142929fa26",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1782275930.5195708,
+    "mtime": 1782277797.050184,
     "ast_hash": "2f8286328336b05322dd8338f2fef200",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1782275930.5202036,
+    "mtime": 1782277797.050184,
     "ast_hash": "a1503e8e0b5719635106523963b66fba",
     "semantic_hash": ""
   },
   "DESIGN_LANGUAGE.md": {
-    "mtime": 1782275930.5202036,
+    "mtime": 1782277797.051182,
     "ast_hash": "c8f794809d5b3fcc39553b8e617878dc",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1782275930.521312,
+    "mtime": 1782277797.051182,
     "ast_hash": "75446b068ecd0706f858204dce52ab93",
     "semantic_hash": ""
   },
   "blog/2023-01-21-welcome/index.md": {
-    "mtime": 1782275930.522312,
+    "mtime": 1782277797.0531802,
     "ast_hash": "4c12009dac1a2da01d134954c18f9327",
     "semantic_hash": ""
   },
   "blog/2023-01-24-selenium-ecosystem.md": {
-    "mtime": 1782275930.522312,
+    "mtime": 1782277797.053484,
     "ast_hash": "40c854cc054134eca54e703fea7a967c",
     "semantic_hash": ""
   },
   "blog/2023-02-12-self-managed-appium-execution.md": {
-    "mtime": 1782275930.523311,
+    "mtime": 1782277797.0542169,
     "ast_hash": "aa81634b4bcc6d898258f3c2e943a5bb",
     "semantic_hash": ""
   },
   "blog/2023-02-28-we-need-your-support.md": {
-    "mtime": 1782275930.523311,
+    "mtime": 1782277797.0542169,
     "ast_hash": "efb1d8b9c08b34d1aff7efc0f9522294",
     "semantic_hash": ""
   },
   "blog/2023-03-10-release_announcement.md": {
-    "mtime": 1782275930.524311,
+    "mtime": 1782277797.0554135,
     "ast_hash": "d007f4c24f31daacd1ff54eb22739b04",
     "semantic_hash": ""
   },
   "blog/2023-04-27-bingAI.md": {
-    "mtime": 1782275930.524311,
+    "mtime": 1782277797.0554135,
     "ast_hash": "552affe93e34e4c10c8ca4eb135deb42",
     "semantic_hash": ""
   },
   "blog/2024-01-27-virtual-threads-release.md": {
-    "mtime": 1782275930.524311,
+    "mtime": 1782277797.056413,
     "ast_hash": "e9a3af37b48ca6fb5d192b1a11eb083e",
     "semantic_hash": ""
   },
   "blog/2025-03-27-swagger-validation.md": {
-    "mtime": 1782275930.525311,
+    "mtime": 1782277797.056413,
     "ast_hash": "6f27e2b1e36363272e8362de96b85efe",
     "semantic_hash": ""
   },
   "blog/2026-03-24-release-10.1.20260324.md": {
-    "mtime": 1782275930.525311,
+    "mtime": 1782277797.0574136,
     "ast_hash": "654f8736540808936270ee7db97b5e5d",
     "semantic_hash": ""
   },
   "blog/2026-03-31-release-10.1.20260331.md": {
-    "mtime": 1782275930.526311,
+    "mtime": 1782277797.0574136,
     "ast_hash": "051b1b7c7f73531117b774515b38333f",
     "semantic_hash": ""
   },
   "blog/2026-05-02-release-10.2.20260501.md": {
-    "mtime": 1782275930.526311,
+    "mtime": 1782277797.0584137,
     "ast_hash": "c8020deebd5950f7c29c06de7adf4fd7",
     "semantic_hash": ""
   },
   "blog/2026-05-05-release-10.2.20260505.md": {
-    "mtime": 1782275930.526311,
+    "mtime": 1782277797.0584137,
     "ast_hash": "570a5c34e124c43fbf40c95db80e70a1",
     "semantic_hash": ""
   },
   "blog/2026-05-06-release-10.2.20260506.md": {
-    "mtime": 1782275930.5273106,
+    "mtime": 1782277797.0584137,
     "ast_hash": "ca7b9d38d13c1c1936f94fc15e5c1f40",
     "semantic_hash": ""
   },
   "blog/2026-06-05-release-10.2.20260605.md": {
-    "mtime": 1782275930.5273106,
+    "mtime": 1782277797.059414,
     "ast_hash": "0f90017918e7e254fa751da939f52013",
     "semantic_hash": ""
   },
   "blog/2026-06-10-release-10.2.20260610.md": {
-    "mtime": 1782275930.5279398,
+    "mtime": 1782277797.059414,
     "ast_hash": "6765363149528f006b51b8a7f340fe87",
     "semantic_hash": ""
   },
   "blog/2026-06-12-release-10.2.20260612.md": {
-    "mtime": 1782275930.528545,
+    "mtime": 1782277797.0604138,
     "ast_hash": "ee2cb8a322ac718ffd87699edd763397",
     "semantic_hash": ""
   },
   "blog/2026-06-14-release-10.2.20260614.md": {
-    "mtime": 1782275930.528545,
+    "mtime": 1782277797.0604138,
     "ast_hash": "741def4c2b94eb0562568e9944fb3974",
     "semantic_hash": ""
   },
   "blog/2026-06-15-release-10.2.20260615.md": {
-    "mtime": 1782275930.528545,
+    "mtime": 1782277797.0614126,
     "ast_hash": "20fe58f70f1ef343c56122f23488b08b",
     "semantic_hash": ""
   },
   "blog/2026-06-17-release-10.2.20260617.md": {
-    "mtime": 1782275930.5296283,
+    "mtime": 1782277797.061718,
     "ast_hash": "d6f70b6f410ce41d956b03826f81e10f",
     "semantic_hash": ""
   },
   "blog/2026-06-18-release-10.2.20260618.md": {
-    "mtime": 1782275930.5296283,
+    "mtime": 1782277797.061718,
     "ast_hash": "555586e796f33504423243dacd09ba3b",
     "semantic_hash": ""
   },
   "blog/2026-06-19-release-10.2.20260620.md": {
-    "mtime": 1782275930.530629,
+    "mtime": 1782277797.06233,
     "ast_hash": "a7a9d29618a74b4480ca36f492a0c9a6",
     "semantic_hash": ""
   },
   "blog/2026-06-21-release-10.2.20260621.md": {
-    "mtime": 1782275930.530629,
+    "mtime": 1782277797.06233,
     "ast_hash": "d231d492a7b16e2601d70790de98ae01",
     "semantic_hash": ""
   },
   "blog/2026-06-22-release-10.2.20260622.md": {
-    "mtime": 1782275930.530629,
+    "mtime": 1782277797.0634637,
     "ast_hash": "c331469e36d4c2307cbc4137a3f1e512",
     "semantic_hash": ""
   },
   "blog/authors.yml": {
-    "mtime": 1782275930.531629,
+    "mtime": 1782277797.0634637,
     "ast_hash": "4463638287b65c50badbf15a8c238ed3",
     "semantic_hash": ""
   },
   "demo-output.txt": {
-    "mtime": 1782275930.532629,
+    "mtime": 1782277797.0644624,
     "ast_hash": "487656e0a23181cb1ba53136a6045cfd",
     "semantic_hash": ""
   },
   "docs/agentic/capture.md": {
-    "mtime": 1782275930.532629,
+    "mtime": 1782277797.065463,
     "ast_hash": "8cfa8f35adb92e7a3cb17bd4aaddb14d",
     "semantic_hash": ""
   },
   "docs/agentic/doctor.mdx": {
-    "mtime": 1782275930.5336287,
+    "mtime": 1782277797.065463,
     "ast_hash": "eddfa76e46cf58bf4e41e87f8ce61f94",
     "semantic_hash": ""
   },
   "docs/agentic/examples.md": {
-    "mtime": 1782275930.5336287,
+    "mtime": 1782277797.0664625,
     "ast_hash": "06583aac83314a17365082cbcf95ec86",
     "semantic_hash": ""
   },
   "docs/agentic/heal.mdx": {
-    "mtime": 1782275930.5336287,
+    "mtime": 1782277797.0664625,
     "ast_hash": "fc4e8ac5f7fe1b9ccf76b9de298be753",
     "semantic_hash": ""
   },
   "docs/agentic/mcp-manual.mdx": {
-    "mtime": 1782275930.5346284,
+    "mtime": 1782277797.0674622,
     "ast_hash": "7683650813af23e9cb086577b3d541d6",
     "semantic_hash": ""
   },
   "docs/agentic/mcp.mdx": {
-    "mtime": 1782275930.5346284,
-    "ast_hash": "2a50235271861fee1bba22088bc0ed93",
+    "mtime": 1782277812.655579,
+    "ast_hash": "2c5565d3d466259be3e14eb10422c611",
     "semantic_hash": ""
   },
   "docs/agentic/overview.mdx": {
-    "mtime": 1782275930.5356288,
+    "mtime": 1782277797.068463,
     "ast_hash": "43e37a98663599720e9400f8c2c67fd2",
     "semantic_hash": ""
   },
   "docs/agentic/pilot.md": {
-    "mtime": 1782275930.5356288,
+    "mtime": 1782277797.068463,
     "ast_hash": "c190210a2773409a08fa6b042b33ca64",
     "semantic_hash": ""
   },
   "docs/agentic/providers.md": {
-    "mtime": 1782275930.5362427,
+    "mtime": 1782277797.0694633,
     "ast_hash": "3eb19467a226f81fc59513f794e903bd",
     "semantic_hash": ""
   },
   "docs/archive/engine/2026-05-08-actions-run-25572054507.md": {
-    "mtime": 1782275930.536776,
+    "mtime": 1782277797.0694633,
     "ast_hash": "f8e7bf85b2d015bbe355c10b0ef5d5a1",
     "semantic_hash": ""
   },
   "docs/archive/engine/2026-05-08-agent-knowledge-migration.md": {
-    "mtime": 1782275930.536776,
+    "mtime": 1782277797.0704637,
     "ast_hash": "e4204073a7f6705f37392b85ec17ce37",
     "semantic_hash": ""
   },
   "docs/archive/engine/ci-coverage-readiness.md": {
-    "mtime": 1782275930.537876,
+    "mtime": 1782277797.0704637,
     "ast_hash": "b4a224846a43e2ea9f4aebbdea8ee037",
     "semantic_hash": ""
   },
   "docs/archive/engine/contributors-history.md": {
-    "mtime": 1782275930.537876,
+    "mtime": 1782277797.0714655,
     "ast_hash": "85aad4e221541f075f2d78fa3cffc4ec",
     "semantic_hash": ""
   },
   "docs/archive/engine/history-rewrite-validation.md": {
-    "mtime": 1782275930.5388737,
+    "mtime": 1782277797.0714655,
     "ast_hash": "e66ed83424e99e2cd610cf002eb7e7a8",
     "semantic_hash": ""
   },
   "docs/archive/engine/mcp-history-import.md": {
-    "mtime": 1782275930.5388737,
+    "mtime": 1782277797.0724616,
     "ast_hash": "d564daadffa41fa98de394798002db75",
     "semantic_hash": ""
   },
   "docs/archive/engine/modular-dependency-report.md": {
-    "mtime": 1782275930.5398736,
+    "mtime": 1782277797.0724616,
     "ast_hash": "59c8c5df43de702530df31c976c1db89",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/SKILL.md": {
-    "mtime": 1782275930.5398736,
+    "mtime": 1782277797.0724616,
     "ast_hash": "70ef4ed39f3e960abbc92d102c2da8b1",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/code-analysis-and-optimization.md": {
-    "mtime": 1782275930.540878,
+    "mtime": 1782277797.0734627,
     "ast_hash": "010cbbd4466601c21dc21e4509d69740",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/overview.md": {
-    "mtime": 1782275930.540878,
+    "mtime": 1782277797.0734627,
     "ast_hash": "d8d7d444539e796e19dd4683a6195b30",
     "semantic_hash": ""
   },
   "docs/archive/engine/tink-design-journal.md": {
-    "mtime": 1782275930.5418782,
+    "mtime": 1782277797.074463,
     "ast_hash": "6e2545fb06ae6db4ed8be694e2ac271d",
     "semantic_hash": ""
   },
   "docs/archive/overview.md": {
-    "mtime": 1782275930.5418782,
+    "mtime": 1782277797.074463,
     "ast_hash": "96f79fbdabc02d655d8edff9cd0a6b39",
     "semantic_hash": ""
   },
   "docs/archive/site/autobot-optimization-summary.md": {
-    "mtime": 1782275930.5428774,
+    "mtime": 1782277797.0754628,
     "ast_hash": "92be1145ef00cec1799361fd5838be07",
     "semantic_hash": ""
   },
   "docs/archive/site/chatbot-testing.md": {
-    "mtime": 1782275930.5428774,
+    "mtime": 1782277797.0754628,
     "ast_hash": "97a854b9d78e5802c362ebd1c7e2f6e1",
     "semantic_hash": ""
   },
   "docs/archive/site/configuration-verification.md": {
-    "mtime": 1782275930.5438783,
+    "mtime": 1782277797.076463,
     "ast_hash": "4062aade28b856313e6f85dbb1371fd8",
     "semantic_hash": ""
   },
   "docs/archive/site/deployment-checklist.md": {
-    "mtime": 1782275930.5438783,
+    "mtime": 1782277797.076463,
     "ast_hash": "7e64842a64765b741f1c606ebad3bf2d",
     "semantic_hash": ""
   },
   "docs/archive/site/e2e-test-results.md": {
-    "mtime": 1782275930.544598,
+    "mtime": 1782277797.076463,
     "ast_hash": "a074c0d6bed5f80c973a5e51d11c3330",
     "semantic_hash": ""
   },
   "docs/archive/site/final-summary.md": {
-    "mtime": 1782275930.544598,
+    "mtime": 1782277797.077463,
     "ast_hash": "42e299ac6fe753b6d63a772c02971784",
     "semantic_hash": ""
   },
   "docs/archive/site/github-actions-test-setup.md": {
-    "mtime": 1782275930.5453274,
+    "mtime": 1782277797.077463,
     "ast_hash": "4178400a49d83a71ca43e2b6fed915a9",
     "semantic_hash": ""
   },
   "docs/archive/site/netlify-migration-guide.md": {
-    "mtime": 1782275930.5453274,
+    "mtime": 1782277797.0783067,
     "ast_hash": "e2beb4b4e7b9aa1615fe1df241d4dcd9",
     "semantic_hash": ""
   },
   "docs/archive/site/security-fix-summary.md": {
-    "mtime": 1782275930.5464153,
+    "mtime": 1782277797.0788186,
     "ast_hash": "3f0119a5cc347eb8109fc413711c2918",
     "semantic_hash": ""
   },
   "docs/features/architecture.md": {
-    "mtime": 1782275930.5464153,
+    "mtime": 1782277797.0788186,
     "ast_hash": "d8865d7a44bb5b3630b5f41b28b60652",
     "semantic_hash": ""
   },
   "docs/features/modules.md": {
-    "mtime": 1782275930.5474143,
+    "mtime": 1782277797.0799265,
     "ast_hash": "c38c55692407d84fec06490d32b1fb51",
     "semantic_hash": ""
   },
   "docs/features/partners.md": {
-    "mtime": 1782275930.5474143,
+    "mtime": 1782277797.0799265,
     "ast_hash": "d7ccfd92176ca55d15fa2a0923e7a10a",
     "semantic_hash": ""
   },
   "docs/features/reporting.md": {
-    "mtime": 1782275930.5484152,
+    "mtime": 1782277797.0799265,
     "ast_hash": "d6447e264329c9e7a7c703f7eee61134",
     "semantic_hash": ""
   },
   "docs/features/technology.md": {
-    "mtime": 1782275930.5484152,
+    "mtime": 1782277797.0809271,
     "ast_hash": "bd517694557a7744f1ebe89de1381196",
     "semantic_hash": ""
   },
   "docs/integrations/browserstack.md": {
-    "mtime": 1782275930.5494156,
+    "mtime": 1782277797.08193,
     "ast_hash": "7730a0995261efa42a538b96d22bd5a7",
     "semantic_hash": ""
   },
   "docs/integrations/video.md": {
-    "mtime": 1782275930.5494156,
+    "mtime": 1782277797.08193,
     "ast_hash": "c5a168298e3a0034164b719d059cd344",
     "semantic_hash": ""
   },
   "docs/integrations/visual.md": {
-    "mtime": 1782275930.5504158,
+    "mtime": 1782277797.08193,
     "ast_hash": "3823ee66987d147f3b0c2a98616ee598",
     "semantic_hash": ""
   },
   "docs/maintainers/agent-guidance.md": {
-    "mtime": 1782275930.5504158,
+    "mtime": 1782277797.0829265,
     "ast_hash": "444c4b07e9d347947eb7ed402a8a9866",
     "semantic_hash": ""
   },
   "docs/maintainers/ci-failure-investigation.md": {
-    "mtime": 1782275930.5514143,
+    "mtime": 1782277797.083927,
     "ast_hash": "92c53bc7be0f4bc12bc7651662a182d2",
     "semantic_hash": ""
   },
   "docs/maintainers/history-rewrite.md": {
-    "mtime": 1782275930.5524144,
+    "mtime": 1782277797.083927,
     "ast_hash": "d45826fb4a4b1761f1c18456960ff08e",
     "semantic_hash": ""
   },
   "docs/maintainers/mcp-deployment.md": {
-    "mtime": 1782275930.5524144,
+    "mtime": 1782277797.0849268,
     "ast_hash": "def4d269b70adb35f4579cb15ada7a25",
     "semantic_hash": ""
   },
   "docs/maintainers/overview.md": {
-    "mtime": 1782275930.5529118,
+    "mtime": 1782277797.0849268,
     "ast_hash": "6d8541c0686c2dedcca528e3e1052a97",
     "semantic_hash": ""
   },
   "docs/maintainers/pilot-release.md": {
-    "mtime": 1782275930.5535944,
+    "mtime": 1782277797.0849268,
     "ast_hash": "792cba3bd1f4d747908fa210acd5b92b",
     "semantic_hash": ""
   },
   "docs/maintainers/publication.md": {
-    "mtime": 1782275930.5535944,
+    "mtime": 1782277797.085927,
     "ast_hash": "c50db868122c5e68aa3aa2bb7efcbcad",
     "semantic_hash": ""
   },
   "docs/maintainers/reactor.md": {
-    "mtime": 1782275930.5535944,
+    "mtime": 1782277797.0866096,
     "ast_hash": "c6a0cad254f0be1b580393e51bb8b5d5",
     "semantic_hash": ""
   },
   "docs/maintainers/site-operations.md": {
-    "mtime": 1782275930.5535944,
+    "mtime": 1782277797.0866096,
     "ast_hash": "0626e0cbe38034a30d9f3eb0adcb0adf",
     "semantic_hash": ""
   },
   "docs/maintainers/visual-provider.md": {
-    "mtime": 1782275930.555221,
+    "mtime": 1782277797.0872145,
     "ast_hash": "44ff03d3eaaf85573c233da6f3c1a875",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/API_Authentication.md": {
-    "mtime": 1782275930.5562267,
+    "mtime": 1782277797.0882988,
     "ast_hash": "a99080386a02b9904c7731e9cb017004",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/GraphQL_Testing.md": {
-    "mtime": 1782275930.5562267,
+    "mtime": 1782277797.0882988,
     "ast_hash": "5acc0ba8ae31807163a2dc1f4f031367",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Request_Builder.md": {
-    "mtime": 1782275930.557227,
+    "mtime": 1782277797.0892985,
     "ast_hash": "ff49153b5a2f3bfc7224df25814817db",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Response_Getters.md": {
-    "mtime": 1782275930.557227,
+    "mtime": 1782277797.0892985,
     "ast_hash": "5bbd54e16a84f9d5a20b4f09651ae806",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Response_Validations.md": {
-    "mtime": 1782275930.558226,
+    "mtime": 1782277797.090298,
     "ast_hash": "e024d75f119b51db063176bf304e8089",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/Docker_Terminal.md": {
-    "mtime": 1782275930.559226,
+    "mtime": 1782277797.090298,
     "ast_hash": "83ba508b0dfe6cf54986a0d0a7648833",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/File_Actions.md": {
-    "mtime": 1782275930.559226,
+    "mtime": 1782277797.0912986,
     "ast_hash": "86eca4e871423a8b8f3379f665e0f4d2",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/SSH_Terminal.md": {
-    "mtime": 1782275930.559226,
+    "mtime": 1782277797.0912986,
     "ast_hash": "ad2acb12ad60a7f0dd8bfb8f7995cbeb",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/Terminal_Actions.md": {
-    "mtime": 1782275930.5602274,
+    "mtime": 1782277797.092301,
     "ast_hash": "d47e8b6063f8bbdbdb5372da8735da82",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/Connection_Strings.md": {
-    "mtime": 1782275930.5602274,
+    "mtime": 1782277797.092301,
     "ast_hash": "6518d156d692623f088a8aa0623b16af",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/DB_Actions.md": {
-    "mtime": 1782275930.561226,
+    "mtime": 1782277797.093299,
     "ast_hash": "2d0e13fddb17dcf33d5c26ca604439e0",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/Oracle_JDBC_Setup.md": {
-    "mtime": 1782275930.561876,
+    "mtime": 1782277797.093299,
     "ast_hash": "e935c22642039c0dc65d3c4378aeb8b0",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Alert_Actions.md": {
-    "mtime": 1782275930.5629537,
+    "mtime": 1782277797.0942986,
     "ast_hash": "91bc6269bcff898aea5ea1d27a2fda54",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Async_Element_Actions.md": {
-    "mtime": 1782275930.5629537,
+    "mtime": 1782277797.0942986,
     "ast_hash": "03fa9f78d1242f6db3acc610282e0cad",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Browser_Actions.md": {
-    "mtime": 1782275930.5629537,
+    "mtime": 1782277797.094944,
     "ast_hash": "04162e9929a275865f9c8368475a186f",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Did_You_Know.md": {
-    "mtime": 1782275930.5639534,
+    "mtime": 1782277797.095493,
     "ast_hash": "26e991c7d1b405d9608dfe052d310e6b",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Actions.md": {
-    "mtime": 1782275930.5639534,
+    "mtime": 1782277797.095493,
     "ast_hash": "86315db9dbc720658c336fba5c3ce928",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Identification.md": {
-    "mtime": 1782275930.5649538,
+    "mtime": 1782277797.0965993,
     "ast_hash": "d4ac77dff19d4d1635455c2ee75f03ca",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Validations.md": {
-    "mtime": 1782275930.5649538,
+    "mtime": 1782277797.0965993,
     "ast_hash": "c2403fba40fa1347bf12da132f39909c",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Natural_Language_Actions.md": {
-    "mtime": 1782275930.5659535,
+    "mtime": 1782277797.0975997,
     "ast_hash": "c3d45a73794b074f0533803d4469ef88",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Playwright_Backend.md": {
-    "mtime": 1782275930.5659535,
+    "mtime": 1782277797.0975997,
     "ast_hash": "4afc5abf0ec4e5b9ac0e6498271622ca",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Touch_Actions.md": {
-    "mtime": 1782275930.5669541,
+    "mtime": 1782277797.0975997,
     "ast_hash": "b3db8adc5eecccf9fe184885103ff1a8",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md": {
-    "mtime": 1782275930.5669541,
+    "mtime": 1782277797.0986023,
     "ast_hash": "f679c221d416da847b47e8d43c819da5",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md": {
-    "mtime": 1782275930.5679536,
+    "mtime": 1782277797.0996003,
     "ast_hash": "add6d9310d0b9dc8c398af7914958447",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md": {
-    "mtime": 1782275930.5679536,
+    "mtime": 1782277797.0996003,
     "ast_hash": "e879f24d5a6e8d264855e3d930f9e40a",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md": {
-    "mtime": 1782275930.5689535,
+    "mtime": 1782277797.0996003,
     "ast_hash": "1683b153d24b8029daff9f000179cc93",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md": {
-    "mtime": 1782275930.5689535,
+    "mtime": 1782277797.1006,
     "ast_hash": "577c4ecc43c196464508ceab69264200",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md": {
-    "mtime": 1782275930.5696194,
+    "mtime": 1782277797.1006,
     "ast_hash": "86fb7d2efe6e51f09cfb068bc89bba5c",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Integrate_JIRA_With_SHAFT_Engine.md": {
-    "mtime": 1782275930.570298,
+    "mtime": 1782277797.1016,
     "ast_hash": "7856ec48c3191ef7ee79d75d6547cd76",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md": {
-    "mtime": 1782275930.570298,
+    "mtime": 1782277797.1016,
     "ast_hash": "121a549a8d2650182324c2cad14fbf62",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md": {
-    "mtime": 1782275930.571405,
+    "mtime": 1782277797.1025999,
     "ast_hash": "6daa21511c999290aca9425f29cad9a6",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md": {
-    "mtime": 1782275930.571405,
+    "mtime": 1782277797.1025999,
     "ast_hash": "3dbd4bc2af4a0c0e4457f8dd70fb3d63",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Native_selenium_Webdriver.md": {
-    "mtime": 1782275930.571405,
+    "mtime": 1782277797.1033182,
     "ast_hash": "6cfffeb9614a4009a196c6a1c5094f38",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md": {
-    "mtime": 1782275930.572404,
+    "mtime": 1782277797.1033182,
     "ast_hash": "0303f861b448e56f08d47d315f6e1ec5",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md": {
-    "mtime": 1782275930.572404,
+    "mtime": 1782277797.1039987,
     "ast_hash": "73a78c3362dd9e389ae1c8a4de6e2120",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md": {
-    "mtime": 1782275930.5734036,
+    "mtime": 1782277797.1039987,
     "ast_hash": "51096ad86850c47247dab8475de4934a",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md": {
-    "mtime": 1782275930.5734036,
+    "mtime": 1782277797.1051245,
     "ast_hash": "bfc0af12555aeb2733b7fa5d57c880ba",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md": {
-    "mtime": 1782275930.5734036,
+    "mtime": 1782277797.1051245,
     "ast_hash": "1eb9f4f0eaaeedccef0ebcb6f400b251",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md": {
-    "mtime": 1782275930.5744033,
+    "mtime": 1782277797.1051245,
     "ast_hash": "5e4bc14f2b9eb213c157df740082295f",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md": {
-    "mtime": 1782275930.5754035,
+    "mtime": 1782277797.106123,
     "ast_hash": "59a7ecebed41952d1bd53bff4ccafa57",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md": {
-    "mtime": 1782275930.5754035,
+    "mtime": 1782277797.106123,
     "ast_hash": "e5e4709cbec473793ca2ac56bd89741e",
     "semantic_hash": ""
   },
   "docs/reference/actions/TestData_Management.md": {
-    "mtime": 1782275930.5764034,
+    "mtime": 1782277797.1071236,
     "ast_hash": "0203e3c310886cb80901bc132fcf81a3",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Browser.md": {
-    "mtime": 1782275930.5764034,
+    "mtime": 1782277797.1081228,
     "ast_hash": "75bccc797afeac565a60a871ad56bc94",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Elements.md": {
-    "mtime": 1782275930.5774033,
+    "mtime": 1782277797.1081228,
     "ast_hash": "cf09d1e04846e8304b03730d368a2d72",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Files.md": {
-    "mtime": 1782275930.5779934,
+    "mtime": 1782277797.1081228,
     "ast_hash": "c3c0d57ed3d5a923f9d0404a65eebb01",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/ForceFail.md": {
-    "mtime": 1782275930.5783129,
+    "mtime": 1782277797.109123,
     "ast_hash": "45a25fd37095702977ede2259528b496",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/JSON_Schema_Validation.md": {
-    "mtime": 1782275930.5788717,
+    "mtime": 1782277797.109123,
     "ast_hash": "76e02d9db46cfa48b92b399eb949de3b",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Nums.md": {
-    "mtime": 1782275930.5788717,
+    "mtime": 1782277797.1101234,
     "ast_hash": "787b1223b5980d1c4aa6930423c6994e",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Objects.md": {
-    "mtime": 1782275930.5799897,
+    "mtime": 1782277797.1101234,
     "ast_hash": "4068bb1313a3cbd5da264765f7d7b00d",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Overview.md": {
-    "mtime": 1782275930.5799897,
+    "mtime": 1782277797.1111228,
     "ast_hash": "5694838b5e8ad855a2e6e79d0e2c003b",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Response.md": {
-    "mtime": 1782275930.5799897,
+    "mtime": 1782277797.1116264,
     "ast_hash": "2c9df47adcbab052cdb8402e37ebf21e",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md": {
-    "mtime": 1782275930.5809882,
+    "mtime": 1782277797.1116264,
     "ast_hash": "de25ff960dd3aeb8302cdcbfb54cd001",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig.md": {
-    "mtime": 1782275930.5809882,
+    "mtime": 1782277797.1124513,
     "ast_hash": "8234d9b8cec01c5a37d002d736baa750",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig2.md": {
-    "mtime": 1782275930.581989,
+    "mtime": 1782277797.1135898,
     "ast_hash": "a0aa8c409b01842e842b412918b4857b",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig3.md": {
-    "mtime": 1782275930.581989,
+    "mtime": 1782277797.1135898,
     "ast_hash": "ff142f3b709cedf2b475503e51e0d9a3",
     "semantic_hash": ""
   },
   "docs/reference/configuration/parallelExecution.md": {
-    "mtime": 1782275930.5829883,
+    "mtime": 1782277797.1145904,
     "ast_hash": "54f5e27ab50d7ed23b3dd6c17f3a2b28",
     "semantic_hash": ""
   },
   "docs/reference/guides/Architecture.md": {
-    "mtime": 1782275930.5829883,
+    "mtime": 1782277797.1145904,
     "ast_hash": "23839503a280197e0fb80984e09fcae4",
     "semantic_hash": ""
   },
   "docs/reference/guides/BDD_Style_Reports.md": {
-    "mtime": 1782275930.583988,
+    "mtime": 1782277797.1155906,
     "ast_hash": "1ac07b7d8fe95f36ed7c6ca3ed58ddc1",
     "semantic_hash": ""
   },
   "docs/reference/guides/CI_CD_Integration.md": {
-    "mtime": 1782275930.583988,
+    "mtime": 1782277797.1155906,
     "ast_hash": "8a3e83cb2c6938f2d53167f65a4b7734",
     "semantic_hash": ""
   },
   "docs/reference/guides/Cross_Platform_Strategy.md": {
-    "mtime": 1782275930.5849874,
+    "mtime": 1782277797.11659,
     "ast_hash": "7419fbeccf4a23f050c55ae29c046c2d",
     "semantic_hash": ""
   },
   "docs/reference/guides/Cucumber_BDD_Steps.md": {
-    "mtime": 1782275930.5849874,
+    "mtime": 1782277797.11659,
     "ast_hash": "6e5075ad337e26345760be40bdf9e4a8",
     "semantic_hash": ""
   },
   "docs/reference/guides/Element_Identification.md": {
-    "mtime": 1782275930.5849874,
+    "mtime": 1782277797.11659,
     "ast_hash": "d08e71b238fb4ddaed3ec39c732903c6",
     "semantic_hash": ""
   },
   "docs/reference/guides/Fluent_Design.md": {
-    "mtime": 1782275930.5862951,
+    "mtime": 1782277797.1175897,
     "ast_hash": "de73ea88d2d812c5dcc28494bcc8225b",
     "semantic_hash": ""
   },
   "docs/reference/guides/JUnit5_Integration.md": {
-    "mtime": 1782275930.5862951,
+    "mtime": 1782277797.1175897,
     "ast_hash": "0d3949ba94325346ee7e2ea0ca5a8141",
     "semantic_hash": ""
   },
   "docs/reference/guides/Solution_Design.md": {
-    "mtime": 1782275930.5871067,
+    "mtime": 1782277797.1185899,
     "ast_hash": "f60d8e095a5c7befaea9491c8acf9f5d",
     "semantic_hash": ""
   },
   "docs/reference/guides/Test_Artifacts.md": {
-    "mtime": 1782275930.5871067,
+    "mtime": 1782277797.1185899,
     "ast_hash": "9e979e9ab7599955f92feae2d5f68dde",
     "semantic_hash": ""
   },
   "docs/reference/guides/Test_Structure.md": {
-    "mtime": 1782275930.588271,
+    "mtime": 1782277797.1185899,
     "ast_hash": "a867d468628b5e29e3b868b5299066f5",
     "semantic_hash": ""
   },
   "docs/reference/guides/Testing_Pyramid.md": {
-    "mtime": 1782275930.588271,
+    "mtime": 1782277797.119589,
     "ast_hash": "7b6745e7b75c04da46b6802734c3b9ef",
     "semantic_hash": ""
   },
   "docs/reference/guides/Tool_Selection.md": {
-    "mtime": 1782275930.588271,
+    "mtime": 1782277797.1199598,
     "ast_hash": "704b6983fe0527aa422f690fcf78e41f",
     "semantic_hash": ""
   },
   "docs/reference/overview.md": {
-    "mtime": 1782275930.5892653,
+    "mtime": 1782277797.1206844,
     "ast_hash": "4b14a4fe96338e3e82797bc8fcade35a",
     "semantic_hash": ""
   },
   "docs/reference/properties/CommonExamples.mdx": {
-    "mtime": 1782275930.5902658,
+    "mtime": 1782277797.1206844,
     "ast_hash": "006eff316d1e2bc9238f7175189cf684",
     "semantic_hash": ""
   },
   "docs/reference/properties/Programmatic_Config.md": {
-    "mtime": 1782275930.5902658,
+    "mtime": 1782277797.121802,
     "ast_hash": "8e371d8150a81e6f8d45c3d55d2ab6e1",
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertiesList.mdx": {
-    "mtime": 1782275930.591269,
+    "mtime": 1782277797.1228025,
     "ast_hash": "6f0df1f04ab6469f72b56a72283787bb",
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertyTypes.md": {
-    "mtime": 1782275930.591269,
+    "mtime": 1782277797.1228025,
     "ast_hash": "46c016df870b6dcb449e6cfa53776f1c",
     "semantic_hash": ""
   },
   "docs/reference/properties/custom-properties-generator.mdx": {
-    "mtime": 1782275930.5922656,
+    "mtime": 1782277797.1228025,
     "ast_hash": "298e62b3e809eed6646ab188a5e1d260",
     "semantic_hash": ""
   },
   "docs/reference/reporting/Custom_Report_Messages.md": {
-    "mtime": 1782275930.5922656,
+    "mtime": 1782277797.1238027,
     "ast_hash": "ed23940cdf10b241b73c0b813dda84d6",
     "semantic_hash": ""
   },
   "docs/reference/reporting/reporting.mdx": {
-    "mtime": 1782275930.5932658,
+    "mtime": 1782277797.124802,
     "ast_hash": "75e37248b15e23ccc616c12565090a5a",
     "semantic_hash": ""
   },
   "docs/start/installation.mdx": {
-    "mtime": 1782275930.5932658,
+    "mtime": 1782277797.124802,
     "ast_hash": "7929e3944f5d9212c8efc4d2443995ac",
     "semantic_hash": ""
   },
   "docs/start/overview.mdx": {
-    "mtime": 1782275930.594266,
+    "mtime": 1782277797.125802,
     "ast_hash": "442b54b8ad5b1c6f646d626c979c03d6",
     "semantic_hash": ""
   },
   "docs/start/quick-start.md": {
-    "mtime": 1782275930.594266,
+    "mtime": 1782277797.125802,
     "ast_hash": "9ea9fbef3c21a2baad34045d1a0da202",
     "semantic_hash": ""
   },
   "docs/start/upgrade.mdx": {
-    "mtime": 1782275930.5952654,
+    "mtime": 1782277797.1268015,
     "ast_hash": "5cc6260c517d8d598686ee7d2753a422",
     "semantic_hash": ""
   },
   "docs/testing/api.mdx": {
-    "mtime": 1782275930.5952654,
+    "mtime": 1782277797.1282315,
     "ast_hash": "6db7dc13203a0770259df43aefa97bba",
     "semantic_hash": ""
   },
   "docs/testing/cli.md": {
-    "mtime": 1782275930.5962684,
+    "mtime": 1782277797.1288953,
     "ast_hash": "1ac6a085e470bc4b91e4ac58479cc2d2",
     "semantic_hash": ""
   },
   "docs/testing/database.md": {
-    "mtime": 1782275930.5962684,
+    "mtime": 1782277797.1288953,
     "ast_hash": "8f7f5df5f70d3df15464c23a64ce4c5d",
     "semantic_hash": ""
   },
   "docs/testing/mobile.md": {
-    "mtime": 1782275930.5972655,
+    "mtime": 1782277797.130065,
     "ast_hash": "d9bbe5102558e1e2fdc1c167f4873d1f",
     "semantic_hash": ""
   },
   "docs/testing/web.mdx": {
-    "mtime": 1782275930.5972655,
+    "mtime": 1782277797.130065,
     "ast_hash": "f539b1e0fa813c5bc1f97e6ece057d7c",
     "semantic_hash": ""
   },
   "static/google7a9ed995e574e7e9.html": {
-    "mtime": 1782275930.6494582,
+    "mtime": 1782277797.1801848,
     "ast_hash": "4d0d5c52c1d5a466c2516742d98b05ee",
     "semantic_hash": ""
   },
   "static/robots.txt": {
-    "mtime": 1782275930.6723716,
+    "mtime": 1782277797.2032247,
     "ast_hash": "a17931d0ec73cff4d3be5ed847888e16",
     "semantic_hash": ""
   },
   "static/img/JIRA/Account_settings.png": {
-    "mtime": 1782275930.650458,
+    "mtime": 1782277797.181185,
     "ast_hash": "758be0c1dc99b4d464b788d3ee0f21db",
     "semantic_hash": ""
   },
   "static/img/JIRA/Label.png": {
-    "mtime": 1782275930.6524587,
+    "mtime": 1782277797.1831856,
     "ast_hash": "b3531e26b8bafb25064e46a0358125c0",
     "semantic_hash": ""
   },
   "static/img/JIRA/Security_Tap.png": {
-    "mtime": 1782275930.6529286,
+    "mtime": 1782277797.1831856,
     "ast_hash": "8c949453e0b50763fa301efea3325a98",
     "semantic_hash": ""
   },
   "static/img/autobot-avatar.svg": {
-    "mtime": 1782275930.6533866,
+    "mtime": 1782277797.184186,
     "ast_hash": "ee9b4ef90bf10f6db0e44aa164442b4f",
     "semantic_hash": ""
   },
   "static/img/code.svg": {
-    "mtime": 1782275930.6533866,
+    "mtime": 1782277797.184186,
     "ast_hash": "c2450ac71613aa602e1a05a674a41183",
     "semantic_hash": ""
   },
   "static/img/easy.svg": {
-    "mtime": 1782275930.654473,
+    "mtime": 1782277797.185185,
     "ast_hash": "60e67f962686803fa3b43c2fa42900ba",
     "semantic_hash": ""
   },
   "static/img/logo.svg": {
-    "mtime": 1782275930.6554718,
+    "mtime": 1782277797.1861856,
     "ast_hash": "aef5dff11792d8a1fcc61d8aca9e5025",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/claude.svg": {
-    "mtime": 1782275930.6554718,
+    "mtime": 1782277797.1865647,
     "ast_hash": "46486fd772561b765651afd11d9baffc",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/github-copilot.svg": {
-    "mtime": 1782275930.6554718,
+    "mtime": 1782277797.1872003,
     "ast_hash": "e7370db8dcbb829fd83d8df43c697fef",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/intellij-idea.svg": {
-    "mtime": 1782275930.6567554,
+    "mtime": 1782277797.1872003,
     "ast_hash": "de44a4b672f84126d8d99502fafce366",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/openai.svg": {
-    "mtime": 1782275930.6567554,
+    "mtime": 1782277797.1872003,
     "ast_hash": "0f750d4f4f5f84bb042ced00f295bb66",
     "semantic_hash": ""
   },
   "static/img/png/code.png": {
-    "mtime": 1782275930.6577551,
+    "mtime": 1782277797.1883745,
     "ast_hash": "34340deb5105399edca4c36c4abeddf7",
     "semantic_hash": ""
   },
   "static/img/png/easy.png": {
-    "mtime": 1782275930.6577551,
+    "mtime": 1782277797.1883745,
     "ast_hash": "ae2716ac04b4d420c8b23777c0adf9a9",
     "semantic_hash": ""
   },
   "static/img/png/logo.png": {
-    "mtime": 1782275930.6587546,
+    "mtime": 1782277797.1893747,
     "ast_hash": "130e29551be112933a2710dd3c61fa4d",
     "semantic_hash": ""
   },
   "static/img/png/mindmap.png": {
-    "mtime": 1782275930.6617744,
+    "mtime": 1782277797.1923738,
     "ast_hash": "cc63ad8937c730036e5a7e503de73d6b",
     "semantic_hash": ""
   },
   "static/img/png/selenium.png": {
-    "mtime": 1782275930.6617744,
+    "mtime": 1782277797.1933749,
     "ast_hash": "a9af07deef806c3739c976e707cbcb11",
     "semantic_hash": ""
   },
   "static/img/png/shaft.png": {
-    "mtime": 1782275930.6628504,
+    "mtime": 1782277797.1933749,
     "ast_hash": "130e29551be112933a2710dd3c61fa4d",
     "semantic_hash": ""
   },
   "static/img/png/shaft_bg.png": {
-    "mtime": 1782275930.6628504,
+    "mtime": 1782277797.1943753,
     "ast_hash": "5a81c90f9ccba7b82ee864cfadf318a5",
     "semantic_hash": ""
   },
   "static/img/pr/release-contributor-avatars-32px.png": {
-    "mtime": 1782275930.6648495,
+    "mtime": 1782277797.1954556,
     "ast_hash": "aba4c4b64bf43f240d2b1a7af26a216a",
     "semantic_hash": ""
   },
   "static/img/pr/release-resources-links-updated.png": {
-    "mtime": 1782275930.6658528,
+    "mtime": 1782277797.197585,
     "ast_hash": "602ef3b80f494b2841896cf2be509988",
     "semantic_hash": ""
   },
   "static/img/selenium.svg": {
-    "mtime": 1782275930.6668506,
+    "mtime": 1782277797.197585,
     "ast_hash": "b648a25671137e687b2c574a8b4e3b5b",
     "semantic_hash": ""
   },
   "static/img/shaft-automation-hero.png": {
-    "mtime": 1782275930.6696024,
+    "mtime": 1782277797.2005856,
     "ast_hash": "67b14d3e88001929554cd9cb9f343ef4",
     "semantic_hash": ""
   },
   "static/img/shaft-automation-hero.webp": {
-    "mtime": 1782275930.6701705,
+    "mtime": 1782277797.2005856,
     "ast_hash": "4c185fe996dd86fc76874aec08e1c865",
     "semantic_hash": ""
   },
   "static/img/shaft.svg": {
-    "mtime": 1782275930.6713724,
+    "mtime": 1782277797.2015855,
     "ast_hash": "64e523a48c02aed838b2fc5b5aed8b09",
     "semantic_hash": ""
   },
   "static/img/shaft_bg.svg": {
-    "mtime": 1782275930.6713724,
+    "mtime": 1782277797.2025857,
     "ast_hash": "02fbab86799674757030d187d263d3ec",
     "semantic_hash": ""
   },
   "static/img/shaft_white.svg": {
-    "mtime": 1782275930.6723716,
+    "mtime": 1782277797.2032247,
     "ast_hash": "bb879f9ab9e674ae6aff9f2be911b17a",
     "semantic_hash": ""
   },
   "blog/2026-06-23-release-10.2.20260623.md": {
-    "mtime": 1782275930.531629,
+    "mtime": 1782277797.0634637,
     "ast_hash": "298d3bbad2e41bfda115547cdbb3ed5b",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-06-24-flakiness-guide.md": {
-    "mtime": 1782276161.0465624,
-    "ast_hash": "6ac18a7761deb6ba694607524fd1f100",
+    "mtime": 1782277797.1278017,
+    "ast_hash": "e444393d7f2437a2d60d17b225425a1a",
     "semantic_hash": ""
   },
   "docs/testing/flakiness.mdx": {
-    "mtime": 1782276508.8110461,
-    "ast_hash": "d83546de464c2390bd65c63a053c3fd6",
+    "mtime": 1782277797.130065,
+    "ast_hash": "da4423b327891319a90e310319aaf410",
     "semantic_hash": ""
   }
 }


### PR DESCRIPTION
## Summary
- Document the expanded `test_code_guardrails_check` coverage for generated Java.
- Clarify that the guardrail check is lexical and compile/runtime validation is still required.
- Refresh Graphify outputs for the docs update.

## Validation
- `yarn install --frozen-lockfile`
- `yarn test:docs`

Refs ShaftHQ/SHAFT_ENGINE#3032