### PR TITLE
docs: use GitHub Pages guide links

### DIFF
--- a/blog/2026-06-23-release-10.2.20260623.md
+++ b/blog/2026-06-23-release-10.2.20260623.md
@@ -27,7 +27,7 @@ A fresh release just dropped and it's packed with improvements you don't want to
 
 Auto-generated release notes are included below. Users upgrading from
 `SHAFT_ENGINE` should read the
-[modular SHAFT upgrade guide](https://shaftengine.netlify.app/docs/start/upgrade).
+[modular SHAFT upgrade guide](https://shafthq.github.io/docs/start/upgrade).
 
 SHAFT Pilot adds deterministic Capture, TestNG generation, Doctor diagnosis,
 reviewed repair proposals, and MCP interoperability. AI is optional, disabled
@@ -35,7 +35,7 @@ by default, and direct OpenAI, Anthropic, Gemini, or Ollama access requires
 explicit enablement and consent. Microsoft/GitHub Copilot integrates through
 MCP rather than a generic provider API-key adapter.
 
-See the [SHAFT Pilot guide](https://shaftengine.netlify.app/docs/agentic/pilot)
+See the [SHAFT Pilot guide](https://shafthq.github.io/docs/agentic/pilot)
 for installation, configuration, privacy, troubleshooting, and usage examples.
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->


### PR DESCRIPTION
## Summary
- Update the latest AutoBot-authored release post to use the GitHub Pages guide host instead of the old Netlify host.

## Validation
- yarn install --frozen-lockfile
- yarn test:release-template
- yarn test:docs
- static AutoBot URL check for https://shafthq.github.io/
- rg stale Netlify host invariant
- graphify update . completed code graph refresh; semantic doc/image refresh reported missing GEMINI_API_KEY/GOOGLE_API_KEY.

## Notes
- yarn test:api is blocked locally without GEMINI_API_KEY.
