### PR TITLE
[codex] Document semantic MCP element tools

### DIFF
--- a/docs/agentic/mcp-manual.mdx
+++ b/docs/agentic/mcp-manual.mdx
@@ -74,12 +74,17 @@ Extent reports, execution summaries, and performance reports are resolved under
 the runtime root when their SHAFT property paths are relative. Explicit absolute
 path overrides stay absolute.
 
-Use the normal `element_click` and `element_type` tools with explicit locator
-strategy and locator value arguments for default WebDriver sessions. Use the
-`playwright_*` browser, element, recording, playback, Doctor, and healer tools
-when the project uses `SHAFT.GUI.Playwright`. Semantic click/type aliases are
-not exposed to MCP clients; use `natural_act` when a workflow needs approved
-natural-language execution.
+Use `element_click` and `element_type` with explicit locator strategy and
+locator value arguments for default WebDriver sessions, or
+`element_click_semantic` and `element_type_semantic` when the client has a
+human-readable element name such as a visible label, placeholder, or accessible
+name. Use the `playwright_*` browser, element, recording, playback, Doctor, and
+healer tools when the project uses `SHAFT.GUI.Playwright`; Playwright also
+exposes `playwright_element_click_semantic` and
+`playwright_element_type_semantic`. Type tools keep generated recording
+snippets redacted unless the recording flow explicitly includes sensitive
+values. Use `natural_act` when a workflow needs approved natural-language
+execution.
 
 If an older setup fails with `AccessDeniedException` under
 `C:\Windows\system32`, the MCP host launched from a protected Windows directory.

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -78,13 +78,16 @@ properties, downloads, videos, services files, dynamic object repository files,
 test data, Extent reports, execution summaries, and performance reports.
 Explicit absolute path overrides remain absolute.
 
-The element action tools stay explicit and locator-based. Use `element_click`
-and `element_type` with a locator strategy and locator value for default
-WebDriver sessions; use `playwright_element_click`,
-`playwright_element_type`, and the other `playwright_*` browser or element
-tools for SHAFT Playwright sessions. The older semantic click/type aliases are
-not exposed to MCP clients; for approved natural-language execution, use
-`natural_act`.
+Element action tools support both explicit locators and semantic names. Use
+`element_click` and `element_type` with a locator strategy and locator value for
+default WebDriver sessions, or `element_click_semantic` and
+`element_type_semantic` when the client has a human-readable element name such
+as a visible label, placeholder, or accessible name. For SHAFT Playwright
+sessions, use `playwright_element_click`, `playwright_element_type`, and the
+semantic `playwright_element_click_semantic` and
+`playwright_element_type_semantic` tools. Type tools keep generated recording
+snippets redacted unless the recording flow explicitly includes sensitive
+values. For approved natural-language execution, use `natural_act`.
 
 ## Guide search for agents
 
@@ -185,7 +188,8 @@ The packaged server supports:
   tokenized Maven validation commands, analyze fresh Allure evidence through
   Doctor, and return review-only fixes plus an agent replay handoff;
 - explicit browser element actions through `element_click` and `element_type`,
-  using locator strategy and locator value arguments;
+  using locator strategy and locator value arguments, plus semantic
+  WebDriver/Playwright click and type tools for human-readable element names;
 - official guide search through `shaft_guide_search`, so agents can retrieve
   cited SHAFT best practices, API/GUI/CLI examples, locators, Page Object Model
   guidance, and troubleshooting steps before writing code;


### PR DESCRIPTION
## Summary
- Documents WebDriver and Playwright semantic MCP click/type tools.
- Replaces outdated guidance that semantic click/type tools are absent.
- Notes recording redaction behavior for semantic type tools.

Refs ShaftHQ/SHAFT_ENGINE#3031

## Test Plan
- `node tests/docs-loader.test.js`
- `node tests/docs-quality.test.js`
- `node scripts/check-doc-duplicates.mjs`
