### PR TITLE
[codex] Suppress AspectJ Unsafe warning in docs smoke

### DIFF
--- a/tests/shaft/pom.xml
+++ b/tests/shaft/pom.xml
@@ -13,7 +13,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefire-testng.version>3.5.5</surefire-testng.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Seed the docs smoke-test POM with the same guarded Surefire JVM arg line used by SHAFT sample projects.
- Keeps docs smoke runs quiet on Java 25 while remaining accepted by Java 21.

## Root cause
The docs smoke POM launches `aspectjweaver` as a Surefire `-javaagent`. AspectJ 1.9.25.1 calls `sun.misc.Unsafe::objectFieldOffset` during startup, which Java 25 warns about unless `--sun-misc-unsafe-memory-access=allow` is present.

## Validation
- Direct Java 25 launch reproduced the warning without the flag.
- Direct Java 25 launch with the guarded arg line emitted no Unsafe warning.
- Direct Java 21 launch accepted the guarded arg line because `-XX:+IgnoreUnrecognizedVMOptions` is first.
- `mvn help:evaluate -f C:\Users\Mohab\IdeaProjects\shafthq.github.io\tests\shaft\pom.xml '-Dexpression=surefireArgLine' '-Dshaft.version=10.2.20260623' -q '-DforceStdout'`