### PR TITLE
Document quiet TestNG verbosity default

### DIFF
--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -1192,7 +1192,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   ```properties showLineNumbers title="src/main/resources/properties/TestNG.properties"
   setParallel=NONE
   setThreadCount=1
-  setVerbose=1
+  setVerbose=0
   setPreserveOrder=true
   setGroupByInstances=true
   setDataProviderThreadCount=1
@@ -1208,7 +1208,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | setParallel                | `NONE`        | `METHODS, CLASSES, TESTS, INSTANCES` |             |
 | setParallelMode            | `STATIC`      | `STATIC, DYNAMIC`                    |             |
 | setThreadCount             | `1.0d`        |                                      | ThreadCount is used as-is in case of STATIC mode. Total ThreadCount is automatically calculated for DYNAMIC mode; (Total ThreadCount =  Number of available processor cores * setThreadCount)            |
-| setVerbose                 | `1`           |                                      |             |
+| setVerbose                 | `0`           |                                      |             |
 | setPreserveOrder           | `false`       | `true`, `false`                      |             |
 | setGroupByInstances        | `false`       | `true`, `false`                      |             |
 | setDataProviderThreadCount | `1`           |                                      |             |

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -2291,7 +2291,7 @@
     "section": "TestNG",
     "key": "setVerbose",
     "targetFile": "TestNG.properties",
-    "defaultValue": "1",
+    "defaultValue": "0",
     "possibleValues": "",
     "description": "Set Verbose setting."
   },


### PR DESCRIPTION
## Summary
- update public `setVerbose` documentation from `1` to `0`
- align the property catalog with the new quiet TestNG verbosity default

## Validation
- `node tests\properties-catalog.test.js`
- `graphify update .` (reported no topology changes; timestamp-only manifest churn was not committed)