### PR TITLE
[codex] Document SHAFT failure trace viewer

### DIFF
--- a/docs/reference/guides/Test_Artifacts.md
+++ b/docs/reference/guides/Test_Artifacts.md
@@ -22,6 +22,7 @@ After a test run, SHAFT generates several artifacts that you can use for debuggi
 | **Screenshots** | Attached inside `allure-results/` | Automatically captured on validation and failure |
 | **Videos** | Generated under `video.folder`, attached inside `allure-results/` | When `videoParams_recordVideo=true` |
 | **Animated GIFs** | Generated under `video.folder`, attached inside `allure-results/` | When `createAnimatedGif=true` |
+| **Failure trace viewer** | Attached inside `allure-results/` | `SHAFT Trace Report.html`, `shaft-trace.json`, and `shaft-trace.zip` on failed tests by default |
 
 :::info
 All paths are relative to your project root directory.
@@ -36,6 +37,7 @@ The Allure report is the **primary artifact** from every SHAFT test run. It cont
 - Step-by-step action logs
 - Screenshots attached at each validation point
 - Video recordings and animated GIFs (when enabled)
+- Failure trace viewer attachments for failed tests
 - Test history and trend graphs across multiple runs
 - Environment metadata
 
@@ -121,6 +123,7 @@ Always use `if: always()` (GitHub Actions) or `post { always { } }` (Jenkins) so
 | `videoParams_recordVideo` | `false` | Record video of each test session |
 | `createAnimatedGif` | `false` | Create an animated GIF; retry attempts can enable it automatically |
 | `allure.generateArchive` | `false` | Generate a portable ZIP archive of the report |
+| `shaft.trace.mode` | `failure` | Attach failure trace viewer artifacts on `failure`, `retry`, or `always` |
 
 For the full list of reporting properties, see the
 [Properties List](/docs/reference/properties/PropertiesList).

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -499,13 +499,16 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   /** get **/
   var captureElementName = SHAFT.Properties.reporting.captureElementName();
   var locatorHealthReportEnabled = SHAFT.Properties.reporting.locatorHealthReportEnabled();
+  var traceMode = SHAFT.Properties.reporting.traceMode();
 
   /** set **/
   SHAFT.Properties.reporting.set()
       .captureElementName(false)
       .locatorHealthReportEnabled(true)
       .slowLocatorThresholdMillis(750)
-      .failOnLocatorHealthWarnings(false);
+      .failOnLocatorHealthWarnings(false)
+      .traceEnabled(true)
+      .traceMode("failure");
   ```
 
   </TabItem>
@@ -527,6 +530,14 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | locatorHealthReportEnabled                    | `false`       | `true`, `false` | • Generate end-of-run HTML/JSON locator health reports and attach them to Allure. |
 | slowLocatorThresholdMillis                    | `750`         | Integer milliseconds | • Mark locator lookups at or above this duration as slow warnings. |
 | failOnLocatorHealthWarnings                   | `false`       | `true`, `false` | • Fail the run when locator health warnings are present. |
+| shaft.trace.enabled                           | `true`        | `true`, `false` | • Attach SHAFT failure trace viewer artifacts to Allure. |
+| shaft.trace.mode                              | `failure`     | `failure`, `retry`, `always` | • Control whether traces are generated on failures, retry attempts, or every test. |
+| shaft.trace.includeCodeContext                | `true`        | `true`, `false` | • Include the best matching project source-code frame and snippet. |
+| shaft.trace.includeFullPageSnapshots          | `true`        | `true`, `false` | • Include web page snapshots when available. |
+| shaft.trace.includeNativePageSource           | `true`        | `true`, `false` | • Include native mobile page source when available. |
+| shaft.trace.includeNetwork                    | `true`        | `true`, `false` | • Reserve network evidence in the trace metadata. |
+| shaft.trace.includeConsole                    | `true`        | `true`, `false` | • Reserve console evidence in the trace metadata. |
+| shaft.trace.maxArtifactMb                     | `50`          | Integer megabytes | • Maximum size for a single trace bundle entry. |
 
   </TabItem>
 </Tabs>

--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -35,6 +35,34 @@ The **Allure Report** is the primary report in SHAFT. It opens automatically in 
 - Test history and trend graphs across multiple runs
 - Environment information and categories
 
+### Failure Trace Viewer
+
+When a test fails, SHAFT attaches a failure trace viewer to Allure by default.
+The viewer collects the failure timeline, exception and stacktrace, source-code
+frame fallback, available page or native source snapshot, and related artifacts
+without generating heavy trace artifacts for passing tests.
+
+Allure receives these attachments on failed tests:
+
+- `SHAFT Trace Report.html`
+- `shaft-trace.json`
+- `shaft-trace.zip`
+- Native Playwright trace ZIP, when Playwright tracing is enabled and available
+
+Use `shaft.trace.mode=failure` for normal runs. Switch to `retry` or `always`
+only while actively debugging.
+
+```properties title="src/main/resources/properties/custom.properties"
+shaft.trace.enabled=true
+shaft.trace.mode=failure
+shaft.trace.includeCodeContext=true
+shaft.trace.includeFullPageSnapshots=true
+shaft.trace.includeNativePageSource=true
+shaft.trace.includeNetwork=true
+shaft.trace.includeConsole=true
+shaft.trace.maxArtifactMb=50
+```
+
 ### Open Allure Report Manually
 
 SHAFT writes convenience scripts to your project root during the first run. Use them to regenerate and serve the Allure report at any time:
@@ -532,6 +560,14 @@ Key properties quick reference:
 | `locatorHealthReportEnabled` | `false` | Generate end-of-run HTML/JSON locator health reports and Allure attachments |
 | `slowLocatorThresholdMillis` | `750` | Lookup duration that marks a locator as slow |
 | `failOnLocatorHealthWarnings` | `false` | Fail the run when locator health warnings are present |
+| `shaft.trace.enabled` | `true` | Attach the SHAFT failure trace viewer artifacts |
+| `shaft.trace.mode` | `failure` | Trace mode: `failure`, `retry`, or `always` |
+| `shaft.trace.includeCodeContext` | `true` | Include the best matching source-code frame and snippet |
+| `shaft.trace.includeFullPageSnapshots` | `true` | Include web snapshots when available |
+| `shaft.trace.includeNativePageSource` | `true` | Include Appium/native page source when available |
+| `shaft.trace.includeNetwork` | `true` | Reserve network evidence in the trace metadata |
+| `shaft.trace.includeConsole` | `true` | Reserve console evidence in the trace metadata |
+| `shaft.trace.maxArtifactMb` | `50` | Maximum size for a single trace bundle entry |
 | `videoParams_recordVideo` | `false` | Enable video recording of test sessions |
 | `videoParams_scope` | `DriverSession` | Scope of video recording |
 | `createAnimatedGif` | `false` | Create an animated GIF; retries can enable it automatically |

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -704,6 +704,70 @@
     "description": "Open Lighthouse performance report during execution."
   },
   {
+    "section": "Reporting",
+    "key": "shaft.trace.enabled",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Attach SHAFT failure trace viewer artifacts to Allure."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.mode",
+    "targetFile": "custom.properties",
+    "defaultValue": "failure",
+    "possibleValues": "failure, retry, always",
+    "description": "Control whether traces are generated on failures, retry attempts, or every test."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.includeCodeContext",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Include the best matching project source-code frame and snippet."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.includeFullPageSnapshots",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Include web page snapshots when available."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.includeNativePageSource",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Include native mobile page source when available."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.includeNetwork",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Reserve network evidence in the trace metadata."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.includeConsole",
+    "targetFile": "custom.properties",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Reserve console evidence in the trace metadata."
+  },
+  {
+    "section": "Reporting",
+    "key": "shaft.trace.maxArtifactMb",
+    "targetFile": "custom.properties",
+    "defaultValue": "50",
+    "possibleValues": "integer megabytes",
+    "description": "Maximum size for a single trace bundle entry."
+  },
+  {
     "section": "Allure",
     "key": "allure.accumulateHistory",
     "targetFile": "custom.properties",


### PR DESCRIPTION
## Summary
- Document the failure trace viewer behavior and Allure attachments.
- Add `shaft.trace.*` rows to the reporting properties list and properties catalog.
- Update test artifact guidance for trace viewer outputs.

## Validation
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('src/data/properties-catalog.json','utf8')); console.log('properties-catalog ok')"`
- `npm run test:docs`

Related to ShaftHQ/SHAFT_ENGINE#3062