### PR TITLE
Document locator health dashboard scoring

### DIFF
--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -80,17 +80,28 @@ Enable locator health reporting when you want a run-level view of slow or flaky
 web locators without changing test code.
 
 ```properties title="src/main/resources/properties/custom.properties"
-locatorHealthReportEnabled=true
+shaft.locatorHealth.enabled=true
+shaft.locatorHealth.warnBelowScore=70
+shaft.locatorHealth.attachDashboard=true
+shaft.locatorHealth.failBelowScore=-1
 slowLocatorThresholdMillis=750
-failOnLocatorHealthWarnings=false
 ```
 
-When enabled, SHAFT records lookup counts, average and p95 lookup time, polling
-attempts, timeouts, stale-element retries, multiple matches, slow lookups, and
-SHAFT Heal recovery attempts. At the end of the run it writes HTML and JSON
-reports under `execution-summary/locator-health/` and attaches them to Allure.
-Set `failOnLocatorHealthWarnings=true` only when locator health warnings should
-fail the build.
+When enabled, SHAFT records lookup counts, unique/no-match/multi-match/stale
+rates, average and p95 lookup time, polling attempts, timeouts, slow lookups,
+SHAFT Heal attempts, accepted recoveries, confidence, and selected replacement
+locators when available. It scores each locator, flags selector smells such as
+absolute XPath, index-heavy XPath, generated IDs, text-only selectors, and deep
+CSS chains, then adds plain-language recommendations.
+
+At the end of the run it writes HTML and JSON reports under
+`execution-summary/locator-health/` and attaches the JSON export to Allure. The
+HTML dashboard is attached when `shaft.locatorHealth.attachDashboard=true`. Keep
+`shaft.locatorHealth.failBelowScore=-1` while introducing the report; set it to
+a score threshold only after the suite has a stable baseline. The older
+`locatorHealthReportEnabled=true` key remains supported. When the failure trace
+viewer is enabled, failed-test trace JSON also includes the current locator
+health snapshot.
 
 ## Related
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -498,14 +498,18 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 
   /** get **/
   var captureElementName = SHAFT.Properties.reporting.captureElementName();
-  var locatorHealthReportEnabled = SHAFT.Properties.reporting.locatorHealthReportEnabled();
+  var locatorHealthEnabled = SHAFT.Properties.reporting.locatorHealthEnabled();
+  var locatorHealthWarnBelowScore = SHAFT.Properties.reporting.locatorHealthWarnBelowScore();
   var diagnosticsBundleEnabled = SHAFT.Properties.reporting.diagnosticsBundleEnabled();
   var traceMode = SHAFT.Properties.reporting.traceMode();
 
   /** set **/
   SHAFT.Properties.reporting.set()
       .captureElementName(false)
-      .locatorHealthReportEnabled(true)
+      .locatorHealthEnabled(true)
+      .locatorHealthWarnBelowScore(70)
+      .locatorHealthAttachDashboard(true)
+      .locatorHealthFailBelowScore(-1)
       .slowLocatorThresholdMillis(750)
       .failOnLocatorHealthWarnings(false)
       .diagnosticsBundleEnabled(true)
@@ -531,6 +535,10 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | disableLogging                                | `false`       | `true`, `false` | • Disable all logging output.                            |
 | attachFullLog                                 | `false`       | `true`, `false` | • Attach a streamed, deduplicated snapshot of the full engine log to the Allure report after test execution without deleting the live log file. |
 | locatorHealthReportEnabled                    | `false`       | `true`, `false` | • Generate end-of-run HTML/JSON locator health reports and attach them to Allure. |
+| shaft.locatorHealth.enabled                   | `false`       | `true`, `false` | • Generate end-of-run locator health reports. |
+| shaft.locatorHealth.warnBelowScore            | `70`          | `0` to `100` | • Mark locators below this health score as risky in the dashboard. |
+| shaft.locatorHealth.attachDashboard           | `true`        | `true`, `false` | • Attach the HTML locator health dashboard to Allure. |
+| shaft.locatorHealth.failBelowScore            | `-1`          | `-1` or `0` to `100` | • Fail the run when any locator score is below this threshold; `-1` disables score-based failure. |
 | slowLocatorThresholdMillis                    | `750`         | Integer milliseconds | • Mark locator lookups at or above this duration as slow warnings. |
 | failOnLocatorHealthWarnings                   | `false`       | `true`, `false` | • Fail the run when locator health warnings are present. |
 | shaft.diagnostics.enabled                     | `true`        | `true`, `false` | • Attach `shaft-diagnostics.zip` with sanitized `diagnostics.json` for failed and broken tests. |

--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -339,28 +339,36 @@ SHAFT.Properties.reporting.set().openExecutionSummaryReportAfterExecution(true);
 
 The **Locator Health Report** is disabled by default. Enable it when you want to
 find slow, flaky, ambiguous, stale, or healed web locators across a full run.
-SHAFT records lightweight metrics during element identification and writes both
-HTML and JSON reports under `execution-summary/locator-health/`. The same report
-is attached to Allure when locator health reporting is enabled.
+SHAFT records lightweight metrics during element identification and writes HTML
+and JSON reports under `execution-summary/locator-health/`. The JSON export is
+attached to Allure, and the HTML dashboard is attached when
+`shaft.locatorHealth.attachDashboard=true`.
 
-Recorded metrics include lookup count, average and p95 lookup time, polling
-attempts, timeout count, stale-element retries, multiple-element matches, slow
-lookups, SHAFT Heal attempts, accepted recoveries, and rejected recoveries.
+Recorded metrics include lookup count, unique-match, no-match, multi-match, and
+stale rates, average and p95 lookup time, polling attempts, timeout count, slow
+lookups, SHAFT Heal attempts, accepted recoveries, selected replacement locator,
+and confidence when the provider exposes it. Each locator also gets a health
+score, selector-smell labels, and plain-language recommendations for risky
+patterns such as absolute XPath, index-heavy XPath, generated IDs, text-only
+selectors, and deep CSS chains. When the failure trace viewer is enabled,
+failed-test trace JSON also includes the current locator health snapshot.
 
 <Tabs groupId="configMethod">
   <TabItem value="file" label="File-based">
 
 ```properties title="src/main/resources/properties/custom.properties"
-locatorHealthReportEnabled=true
+shaft.locatorHealth.enabled=true
+shaft.locatorHealth.warnBelowScore=70
+shaft.locatorHealth.attachDashboard=true
+shaft.locatorHealth.failBelowScore=-1
 slowLocatorThresholdMillis=750
-failOnLocatorHealthWarnings=false
 ```
 
   </TabItem>
   <TabItem value="cli" label="CLI-based">
 
 ```bash
-mvn test -DlocatorHealthReportEnabled=true -DslowLocatorThresholdMillis=750 -DfailOnLocatorHealthWarnings=false
+mvn test -Dshaft.locatorHealth.enabled=true -Dshaft.locatorHealth.warnBelowScore=70 -Dshaft.locatorHealth.failBelowScore=-1 -DslowLocatorThresholdMillis=750
 ```
 
   </TabItem>
@@ -370,7 +378,10 @@ mvn test -DlocatorHealthReportEnabled=true -DslowLocatorThresholdMillis=750 -Dfa
 import com.shaft.driver.SHAFT;
 
 SHAFT.Properties.reporting.set()
-    .locatorHealthReportEnabled(true)
+    .locatorHealthEnabled(true)
+    .locatorHealthWarnBelowScore(70)
+    .locatorHealthAttachDashboard(true)
+    .locatorHealthFailBelowScore(-1)
     .slowLocatorThresholdMillis(750)
     .failOnLocatorHealthWarnings(false);
 ```
@@ -378,8 +389,10 @@ SHAFT.Properties.reporting.set()
   </TabItem>
 </Tabs>
 
-Keep `failOnLocatorHealthWarnings=false` while introducing the report. Set it to
-`true` only after the suite has a stable locator-health baseline.
+Keep `shaft.locatorHealth.failBelowScore=-1` while introducing the report. Set
+it to a score threshold only after the suite has a stable locator-health
+baseline. The legacy `locatorHealthReportEnabled=true` and
+`failOnLocatorHealthWarnings=false` keys remain supported.
 
 ---
 
@@ -558,6 +571,10 @@ Key properties quick reference:
 | `allure.groupBy` | `package,testClass` | Comma-separated label hierarchy for the Allure 3 report tree |
 | `openExecutionSummaryReportAfterExecution` | `false` | Open the Execution Summary report after the run |
 | `locatorHealthReportEnabled` | `false` | Generate end-of-run HTML/JSON locator health reports and Allure attachments |
+| `shaft.locatorHealth.enabled` | `false` | Generate end-of-run locator health reports |
+| `shaft.locatorHealth.warnBelowScore` | `70` | Mark locators below this health score as risky |
+| `shaft.locatorHealth.attachDashboard` | `true` | Attach the HTML locator health dashboard to Allure |
+| `shaft.locatorHealth.failBelowScore` | `-1` | Fail the run when any locator score is below this threshold; `-1` disables score-based failure |
 | `slowLocatorThresholdMillis` | `750` | Lookup duration that marks a locator as slow |
 | `failOnLocatorHealthWarnings` | `false` | Fail the run when locator health warnings are present |
 | `shaft.trace.enabled` | `true` | Attach the SHAFT failure trace viewer artifacts |

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - shafthq.github.io  (2026-06-25)
 
 ## Corpus Check
-- 223 files · ~245,977 words
+- 223 files · ~246,272 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -10,7 +10,7 @@
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `76b30cf2`
+- Built from commit: `3b9fb8b5`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -10137,7 +10137,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/features/reporting.md",
-      "source_location": "L95",
+      "source_location": "L106",
       "_origin": "ast",
       "id": "features_reporting_related",
       "community": 180,
@@ -21597,7 +21597,7 @@
       "label": "Allure",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L550",
+      "source_location": "L558",
       "_origin": "ast",
       "id": "properties_propertieslist_allure",
       "community": 17,
@@ -21607,7 +21607,7 @@
       "label": "Timeouts",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L631",
+      "source_location": "L639",
       "_origin": "ast",
       "id": "properties_propertieslist_timeouts",
       "community": 17,
@@ -21617,7 +21617,7 @@
       "label": "Visuals",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L680",
+      "source_location": "L688",
       "_origin": "ast",
       "id": "properties_propertieslist_visuals",
       "community": 17,
@@ -21627,7 +21627,7 @@
       "label": "Jira",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L722",
+      "source_location": "L730",
       "_origin": "ast",
       "id": "properties_propertieslist_jira",
       "community": 17,
@@ -21637,7 +21637,7 @@
       "label": "Cucumber",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L763",
+      "source_location": "L771",
       "_origin": "ast",
       "id": "properties_propertieslist_cucumber",
       "community": 17,
@@ -21647,7 +21647,7 @@
       "label": "Healenium",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L820",
+      "source_location": "L828",
       "_origin": "ast",
       "id": "properties_propertieslist_healenium",
       "community": 17,
@@ -21657,7 +21657,7 @@
       "label": "Healing",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L840",
+      "source_location": "L848",
       "_origin": "ast",
       "id": "properties_propertieslist_healing",
       "community": 17,
@@ -21667,7 +21667,7 @@
       "label": "Natural Actions",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L910",
+      "source_location": "L918",
       "_origin": "ast",
       "id": "properties_propertieslist_natural_actions",
       "community": 17,
@@ -21677,7 +21677,7 @@
       "label": "Paths",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L959",
+      "source_location": "L967",
       "_origin": "ast",
       "id": "properties_propertieslist_paths",
       "community": 17,
@@ -21687,7 +21687,7 @@
       "label": "Pattern",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L986",
+      "source_location": "L994",
       "_origin": "ast",
       "id": "properties_propertieslist_pattern",
       "community": 17,
@@ -21697,7 +21697,7 @@
       "label": "Tinkey",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1002",
+      "source_location": "L1010",
       "_origin": "ast",
       "id": "properties_propertieslist_tinkey",
       "community": 17,
@@ -21707,7 +21707,7 @@
       "label": "Internal",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1020",
+      "source_location": "L1028",
       "_origin": "ast",
       "id": "properties_propertieslist_internal",
       "community": 17,
@@ -21717,7 +21717,7 @@
       "label": "BrowserStack",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1091",
+      "source_location": "L1099",
       "_origin": "ast",
       "id": "properties_propertieslist_browserstack",
       "community": 17,
@@ -21727,7 +21727,7 @@
       "label": "LambdaTest",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1134",
+      "source_location": "L1142",
       "_origin": "ast",
       "id": "properties_propertieslist_lambdatest",
       "community": 17,
@@ -21737,7 +21737,7 @@
       "label": "Performance",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1181",
+      "source_location": "L1189",
       "_origin": "ast",
       "id": "properties_propertieslist_performance",
       "community": 17,
@@ -21747,7 +21747,7 @@
       "label": "TestNG",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1198",
+      "source_location": "L1206",
       "_origin": "ast",
       "id": "properties_propertieslist_testng",
       "community": 17,
@@ -21757,7 +21757,7 @@
       "label": "Log4j",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1236",
+      "source_location": "L1244",
       "_origin": "ast",
       "id": "properties_propertieslist_log4j",
       "community": 17,
@@ -21767,7 +21767,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/reference/properties/PropertiesList.mdx",
-      "source_location": "L1287",
+      "source_location": "L1295",
       "_origin": "ast",
       "id": "properties_propertieslist_related",
       "community": 17,
@@ -22137,7 +22137,7 @@
       "label": "Video Recording",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L386",
+      "source_location": "L399",
       "_origin": "ast",
       "id": "reporting_reporting_video_recording",
       "community": 20,
@@ -22147,7 +22147,7 @@
       "label": "Where to Put Your Properties File",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L416",
+      "source_location": "L429",
       "_origin": "ast",
       "id": "reporting_reporting_where_to_put_your_properties_file",
       "community": 20,
@@ -22157,7 +22157,7 @@
       "label": "Control Video Recording Scope",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L430",
+      "source_location": "L443",
       "_origin": "ast",
       "id": "reporting_reporting_control_video_recording_scope",
       "community": 20,
@@ -22167,7 +22167,7 @@
       "label": "Animated GIFs",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L471",
+      "source_location": "L484",
       "_origin": "ast",
       "id": "reporting_reporting_animated_gifs",
       "community": 20,
@@ -22177,7 +22177,7 @@
       "label": "Recommended Configurations by Use Case",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L507",
+      "source_location": "L520",
       "_origin": "ast",
       "id": "reporting_reporting_recommended_configurations_by_use_case",
       "community": 20,
@@ -22187,7 +22187,7 @@
       "label": "CI/CD Pipeline (archive report as artifact)",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L509",
+      "source_location": "L522",
       "_origin": "ast",
       "id": "reporting_reporting_ci_cd_pipeline_archive_report_as_artifact",
       "community": 20,
@@ -22197,7 +22197,7 @@
       "label": "Active Debugging (rich visuals)",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L518",
+      "source_location": "L531",
       "_origin": "ast",
       "id": "reporting_reporting_active_debugging_rich_visuals",
       "community": 20,
@@ -22207,7 +22207,7 @@
       "label": "Quick Pass/Fail Summary",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L528",
+      "source_location": "L541",
       "_origin": "ast",
       "id": "reporting_reporting_quick_pass_fail_summary",
       "community": 20,
@@ -22217,7 +22217,7 @@
       "label": "All Reporting Properties",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L537",
+      "source_location": "L550",
       "_origin": "ast",
       "id": "reporting_reporting_all_reporting_properties",
       "community": 20,
@@ -22227,7 +22227,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/reference/reporting/reporting.mdx",
-      "source_location": "L577",
+      "source_location": "L594",
       "_origin": "ast",
       "id": "reporting_reporting_related",
       "community": 20,
@@ -24499,9 +24499,9 @@
       "source_file": "package.json",
       "source_location": "L66",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_browserslist",
-      "confidence_score": 1.0
+      "target": "package_browserslist"
     },
     {
       "relation": "contains",
@@ -24509,9 +24509,9 @@
       "source_file": "package.json",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_dependencies",
-      "confidence_score": 1.0
+      "target": "package_dependencies"
     },
     {
       "relation": "contains",
@@ -24519,9 +24519,9 @@
       "source_file": "package.json",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_devdependencies",
-      "confidence_score": 1.0
+      "target": "package_devdependencies"
     },
     {
       "relation": "contains",
@@ -24529,9 +24529,9 @@
       "source_file": "package.json",
       "source_location": "L78",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_engines",
-      "confidence_score": 1.0
+      "target": "package_engines"
     },
     {
       "relation": "contains",
@@ -24539,9 +24539,9 @@
       "source_file": "package.json",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_license",
-      "confidence_score": 1.0
+      "target": "package_license"
     },
     {
       "relation": "contains",
@@ -24549,9 +24549,9 @@
       "source_file": "package.json",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_name",
-      "confidence_score": 1.0
+      "target": "package_name"
     },
     {
       "relation": "contains",
@@ -24559,9 +24559,9 @@
       "source_file": "package.json",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_overrides",
-      "confidence_score": 1.0
+      "target": "package_overrides"
     },
     {
       "relation": "contains",
@@ -24569,9 +24569,9 @@
       "source_file": "package.json",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_packagemanager",
-      "confidence_score": 1.0
+      "target": "package_packagemanager"
     },
     {
       "relation": "contains",
@@ -24579,9 +24579,9 @@
       "source_file": "package.json",
       "source_location": "L4",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_private",
-      "confidence_score": 1.0
+      "target": "package_private"
     },
     {
       "relation": "contains",
@@ -24589,9 +24589,9 @@
       "source_file": "package.json",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_resolutions",
-      "confidence_score": 1.0
+      "target": "package_resolutions"
     },
     {
       "relation": "contains",
@@ -24599,9 +24599,9 @@
       "source_file": "package.json",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_scripts",
-      "confidence_score": 1.0
+      "target": "package_scripts"
     },
     {
       "relation": "contains",
@@ -24609,9 +24609,9 @@
       "source_file": "package.json",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_package_json",
-      "target": "package_version",
-      "confidence_score": 1.0
+      "target": "package_version"
     },
     {
       "relation": "contains",
@@ -26180,9 +26180,9 @@
       "source_file": "src/pages/index.tsx",
       "source_location": "L128",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "pages_index",
-      "target": "pages_index_herosignals",
-      "confidence_score": 1.0
+      "target": "pages_index_herosignals"
     },
     {
       "relation": "contains",
@@ -26270,9 +26270,9 @@
       "source_file": "src/pages/index.tsx",
       "source_location": "L143",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "pages_index",
-      "target": "pages_index_telemetryrows",
-      "confidence_score": 1.0
+      "target": "pages_index_telemetryrows"
     },
     {
       "relation": "contains",
@@ -27311,9 +27311,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "aftermethod",
-      "confidence_score": 1.0
+      "target": "aftermethod"
     },
     {
       "relation": "imports",
@@ -27322,9 +27322,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "beforemethod",
-      "confidence_score": 1.0
+      "target": "beforemethod"
     },
     {
       "relation": "imports",
@@ -27333,9 +27333,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L4",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "by",
-      "confidence_score": 1.0
+      "target": "by"
     },
     {
       "relation": "imports",
@@ -27344,9 +27344,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "dataprovider",
-      "confidence_score": 1.0
+      "target": "dataprovider"
     },
     {
       "relation": "contains",
@@ -27354,9 +27354,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "docs_siterendertest_siterendertest",
-      "confidence_score": 1.0
+      "target": "docs_siterendertest_siterendertest"
     },
     {
       "relation": "imports",
@@ -27365,9 +27365,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "test",
-      "confidence_score": 1.0
+      "target": "test"
     },
     {
       "relation": "imports",
@@ -27376,9 +27376,9 @@
       "source_file": "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tests_shaft_src_test_java_net_shaftengine_docs_siterendertest_java",
-      "target": "webelement",
-      "confidence_score": 1.0
+      "target": "webelement"
     },
     {
       "relation": "method",
@@ -29012,9 +29012,9 @@
       "source_file": "tsconfig.json",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tsconfig_json",
-      "target": "tsconfig_compileroptions",
-      "confidence_score": 1.0
+      "target": "tsconfig_compileroptions"
     },
     {
       "relation": "contains",
@@ -29022,9 +29022,9 @@
       "source_file": "tsconfig.json",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tsconfig_json",
-      "target": "tsconfig_exclude",
-      "confidence_score": 1.0
+      "target": "tsconfig_exclude"
     },
     {
       "relation": "contains",
@@ -29032,9 +29032,9 @@
       "source_file": "tsconfig.json",
       "source_location": "L2",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tsconfig_json",
-      "target": "tsconfig_extends",
-      "confidence_score": 1.0
+      "target": "tsconfig_extends"
     },
     {
       "relation": "contains",
@@ -29042,9 +29042,9 @@
       "source_file": "tsconfig.json",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_tsconfig_json",
-      "target": "tsconfig_include",
-      "confidence_score": 1.0
+      "target": "tsconfig_include"
     },
     {
       "relation": "contains",
@@ -29186,9 +29186,9 @@
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_github_copilot_instructions_md",
-      "target": "github_copilot_instructions_shaft_documentation_copilot_instructions",
-      "confidence_score": 1.0
+      "target": "github_copilot_instructions_shaft_documentation_copilot_instructions"
     },
     {
       "relation": "contains",
@@ -29196,9 +29196,9 @@
       "source_file": "AGENTS.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_agents_md",
-      "target": "agents_agents_md",
-      "confidence_score": 1.0
+      "target": "agents_agents_md"
     },
     {
       "relation": "contains",
@@ -29246,9 +29246,9 @@
       "source_file": "CONTRIBUTING.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_contributing_md",
-      "target": "contributing_contributing_to_the_shaft_user_guide",
-      "confidence_score": 1.0
+      "target": "contributing_contributing_to_the_shaft_user_guide"
     },
     {
       "relation": "contains",
@@ -29316,9 +29316,9 @@
       "source_file": "DESIGN_LANGUAGE.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_design_language_md",
-      "target": "design_language_shaft_ui_design_language",
-      "confidence_score": 1.0
+      "target": "design_language_shaft_ui_design_language"
     },
     {
       "relation": "contains",
@@ -29416,9 +29416,9 @@
       "source_file": "README.md",
       "source_location": "L1",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_readme_md",
-      "target": "readme_shaft_user_guide",
-      "confidence_score": 1.0
+      "target": "readme_shaft_user_guide"
     },
     {
       "relation": "contains",
@@ -29456,9 +29456,9 @@
       "source_file": "blog/2023-01-21-welcome/index.md",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2023_01_21_welcome_index_md",
-      "target": "2023_01_21_welcome_index_welcome_to_shaft_engine_s_first_blog_post",
-      "confidence_score": 1.0
+      "target": "2023_01_21_welcome_index_welcome_to_shaft_engine_s_first_blog_post"
     },
     {
       "relation": "contains",
@@ -29476,9 +29476,9 @@
       "source_file": "blog/2023-01-24-selenium-ecosystem.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2023_01_24_selenium_ecosystem_md",
-      "target": "blog_2023_01_24_selenium_ecosystem_b_shaft_engine_b_is_now_a_part_of_the_a_href_https_www_selenium_dev_ecosystem_selenium_ecosystem_a",
-      "confidence_score": 1.0
+      "target": "blog_2023_01_24_selenium_ecosystem_b_shaft_engine_b_is_now_a_part_of_the_a_href_https_www_selenium_dev_ecosystem_selenium_ecosystem_a"
     },
     {
       "relation": "contains",
@@ -29536,9 +29536,9 @@
       "source_file": "blog/2023-02-12-self-managed-appium-execution.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2023_02_12_self_managed_appium_execution_md",
-      "target": "blog_2023_02_12_self_managed_appium_execution_b_shaft_engine_b_will_now_manage_its_own_appium_execution_environment",
-      "confidence_score": 1.0
+      "target": "blog_2023_02_12_self_managed_appium_execution_b_shaft_engine_b_will_now_manage_its_own_appium_execution_environment"
     },
     {
       "relation": "contains",
@@ -29566,9 +29566,9 @@
       "source_file": "blog/2023-02-28-we-need-your-support.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2023_02_28_we_need_your_support_md",
-      "target": "blog_2023_02_28_we_need_your_support_join_us_now_https_forms_gle_swwg629opy9opapz8",
-      "confidence_score": 1.0
+      "target": "blog_2023_02_28_we_need_your_support_join_us_now_https_forms_gle_swwg629opy9opapz8"
     },
     {
       "relation": "contains",
@@ -29576,9 +29576,9 @@
       "source_file": "blog/2023-03-10-release_announcement.md",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2023_03_10_release_announcement_md",
-      "target": "blog_2023_03_10_release_announcement_7_1_20230309_https_github_com_shafthq_shaft_engine_releases_tag_7_1_20230309_our_first_release_after_implementing_fully_automated_continuous_releases_is_out",
-      "confidence_score": 1.0
+      "target": "blog_2023_03_10_release_announcement_7_1_20230309_https_github_com_shafthq_shaft_engine_releases_tag_7_1_20230309_our_first_release_after_implementing_fully_automated_continuous_releases_is_out"
     },
     {
       "relation": "contains",
@@ -29606,9 +29606,9 @@
       "source_file": "blog/2024-01-27-virtual-threads-release.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2024_01_27_virtual_threads_release_md",
-      "target": "blog_2024_01_27_virtual_threads_release_b_shaft_engine_b_is_introducing_virtual_threads_for_everyday_tasks",
-      "confidence_score": 1.0
+      "target": "blog_2024_01_27_virtual_threads_release_b_shaft_engine_b_is_introducing_virtual_threads_for_everyday_tasks"
     },
     {
       "relation": "contains",
@@ -29666,9 +29666,9 @@
       "source_file": "blog/2025-03-27-swagger-validation.md",
       "source_location": "L8",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2025_03_27_swagger_validation_md",
-      "target": "blog_2025_03_27_swagger_validation_shaft_engine_now_supports_swagger_openapi_contract_validation",
-      "confidence_score": 1.0
+      "target": "blog_2025_03_27_swagger_validation_shaft_engine_now_supports_swagger_openapi_contract_validation"
     },
     {
       "relation": "contains",
@@ -29756,9 +29756,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_changelog"
     },
     {
       "relation": "contains",
@@ -29766,9 +29766,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L37",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_community_spotlight",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_community_spotlight"
     },
     {
       "relation": "contains",
@@ -29776,9 +29776,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L89",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_get_started_in_seconds",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_get_started_in_seconds"
     },
     {
       "relation": "contains",
@@ -29786,9 +29786,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L101",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_join_the_conversation",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_join_the_conversation"
     },
     {
       "relation": "contains",
@@ -29796,9 +29796,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_what_changed"
     },
     {
       "relation": "contains",
@@ -29806,9 +29806,9 @@
       "source_file": "blog/2026-03-24-release-10.1.20260324.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_24_release_10_1_20260324_md",
-      "target": "blog_2026_03_24_release_10_1_20260324_what_s_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_24_release_10_1_20260324_what_s_changed"
     },
     {
       "relation": "contains",
@@ -29816,9 +29816,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_changelog"
     },
     {
       "relation": "contains",
@@ -29826,9 +29826,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_community_spotlight",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_community_spotlight"
     },
     {
       "relation": "contains",
@@ -29836,9 +29836,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L94",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_get_started_in_seconds",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_get_started_in_seconds"
     },
     {
       "relation": "contains",
@@ -29846,9 +29846,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L106",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_join_the_conversation",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_join_the_conversation"
     },
     {
       "relation": "contains",
@@ -29856,9 +29856,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_new_contributors",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_new_contributors"
     },
     {
       "relation": "contains",
@@ -29866,9 +29866,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_what_changed"
     },
     {
       "relation": "contains",
@@ -29876,9 +29876,9 @@
       "source_file": "blog/2026-03-31-release-10.1.20260331.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_03_31_release_10_1_20260331_md",
-      "target": "blog_2026_03_31_release_10_1_20260331_what_s_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_03_31_release_10_1_20260331_what_s_changed"
     },
     {
       "relation": "contains",
@@ -29886,9 +29886,9 @@
       "source_file": "blog/2026-05-02-release-10.2.20260501.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_02_release_10_2_20260501_md",
-      "target": "blog_2026_05_02_release_10_2_20260501_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_02_release_10_2_20260501_changelog"
     },
     {
       "relation": "contains",
@@ -29896,9 +29896,9 @@
       "source_file": "blog/2026-05-02-release-10.2.20260501.md",
       "source_location": "L37",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_02_release_10_2_20260501_md",
-      "target": "blog_2026_05_02_release_10_2_20260501_shaft_engine_10_2_20260501",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_02_release_10_2_20260501_shaft_engine_10_2_20260501"
     },
     {
       "relation": "contains",
@@ -29906,9 +29906,9 @@
       "source_file": "blog/2026-05-02-release-10.2.20260501.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_02_release_10_2_20260501_md",
-      "target": "blog_2026_05_02_release_10_2_20260501_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_02_release_10_2_20260501_what_changed"
     },
     {
       "relation": "contains",
@@ -29996,9 +29996,9 @@
       "source_file": "blog/2026-05-05-release-10.2.20260505.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_05_release_10_2_20260505_md",
-      "target": "blog_2026_05_05_release_10_2_20260505_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_05_release_10_2_20260505_changelog"
     },
     {
       "relation": "contains",
@@ -30006,9 +30006,9 @@
       "source_file": "blog/2026-05-05-release-10.2.20260505.md",
       "source_location": "L37",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_05_release_10_2_20260505_md",
-      "target": "blog_2026_05_05_release_10_2_20260505_shaft_engine_10_2_20260505",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_05_release_10_2_20260505_shaft_engine_10_2_20260505"
     },
     {
       "relation": "contains",
@@ -30016,9 +30016,9 @@
       "source_file": "blog/2026-05-05-release-10.2.20260505.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_05_release_10_2_20260505_md",
-      "target": "blog_2026_05_05_release_10_2_20260505_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_05_release_10_2_20260505_what_changed"
     },
     {
       "relation": "contains",
@@ -30106,9 +30106,9 @@
       "source_file": "blog/2026-05-06-release-10.2.20260506.md",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_06_release_10_2_20260506_md",
-      "target": "blog_2026_05_06_release_10_2_20260506_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_06_release_10_2_20260506_changelog"
     },
     {
       "relation": "contains",
@@ -30116,9 +30116,9 @@
       "source_file": "blog/2026-05-06-release-10.2.20260506.md",
       "source_location": "L39",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_06_release_10_2_20260506_md",
-      "target": "blog_2026_05_06_release_10_2_20260506_shaft_engine_10_2_20260506",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_06_release_10_2_20260506_shaft_engine_10_2_20260506"
     },
     {
       "relation": "contains",
@@ -30126,9 +30126,9 @@
       "source_file": "blog/2026-05-06-release-10.2.20260506.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_05_06_release_10_2_20260506_md",
-      "target": "blog_2026_05_06_release_10_2_20260506_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_05_06_release_10_2_20260506_what_changed"
     },
     {
       "relation": "contains",
@@ -30216,9 +30216,9 @@
       "source_file": "blog/2026-06-05-release-10.2.20260605.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_05_release_10_2_20260605_md",
-      "target": "blog_2026_06_05_release_10_2_20260605_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_05_release_10_2_20260605_changelog"
     },
     {
       "relation": "contains",
@@ -30226,9 +30226,9 @@
       "source_file": "blog/2026-06-05-release-10.2.20260605.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_05_release_10_2_20260605_md",
-      "target": "blog_2026_06_05_release_10_2_20260605_shaft_engine_10_2_20260605",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_05_release_10_2_20260605_shaft_engine_10_2_20260605"
     },
     {
       "relation": "contains",
@@ -30236,9 +30236,9 @@
       "source_file": "blog/2026-06-05-release-10.2.20260605.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_05_release_10_2_20260605_md",
-      "target": "blog_2026_06_05_release_10_2_20260605_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_05_release_10_2_20260605_what_changed"
     },
     {
       "relation": "contains",
@@ -30286,9 +30286,9 @@
       "source_file": "blog/2026-06-10-release-10.2.20260610.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_10_release_10_2_20260610_md",
-      "target": "blog_2026_06_10_release_10_2_20260610_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_10_release_10_2_20260610_changelog"
     },
     {
       "relation": "contains",
@@ -30296,9 +30296,9 @@
       "source_file": "blog/2026-06-10-release-10.2.20260610.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_10_release_10_2_20260610_md",
-      "target": "blog_2026_06_10_release_10_2_20260610_shaft_10_2_20260610",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_10_release_10_2_20260610_shaft_10_2_20260610"
     },
     {
       "relation": "contains",
@@ -30306,9 +30306,9 @@
       "source_file": "blog/2026-06-10-release-10.2.20260610.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_10_release_10_2_20260610_md",
-      "target": "blog_2026_06_10_release_10_2_20260610_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_10_release_10_2_20260610_what_changed"
     },
     {
       "relation": "contains",
@@ -30356,9 +30356,9 @@
       "source_file": "blog/2026-06-12-release-10.2.20260612.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_12_release_10_2_20260612_md",
-      "target": "blog_2026_06_12_release_10_2_20260612_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_12_release_10_2_20260612_changelog"
     },
     {
       "relation": "contains",
@@ -30366,9 +30366,9 @@
       "source_file": "blog/2026-06-12-release-10.2.20260612.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_12_release_10_2_20260612_md",
-      "target": "blog_2026_06_12_release_10_2_20260612_shaft_10_2_20260612",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_12_release_10_2_20260612_shaft_10_2_20260612"
     },
     {
       "relation": "contains",
@@ -30376,9 +30376,9 @@
       "source_file": "blog/2026-06-12-release-10.2.20260612.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_12_release_10_2_20260612_md",
-      "target": "blog_2026_06_12_release_10_2_20260612_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_12_release_10_2_20260612_what_changed"
     },
     {
       "relation": "contains",
@@ -30426,9 +30426,9 @@
       "source_file": "blog/2026-06-14-release-10.2.20260614.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_14_release_10_2_20260614_md",
-      "target": "blog_2026_06_14_release_10_2_20260614_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_14_release_10_2_20260614_changelog"
     },
     {
       "relation": "contains",
@@ -30436,9 +30436,9 @@
       "source_file": "blog/2026-06-14-release-10.2.20260614.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_14_release_10_2_20260614_md",
-      "target": "blog_2026_06_14_release_10_2_20260614_shaft_10_2_20260614",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_14_release_10_2_20260614_shaft_10_2_20260614"
     },
     {
       "relation": "contains",
@@ -30446,9 +30446,9 @@
       "source_file": "blog/2026-06-14-release-10.2.20260614.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_14_release_10_2_20260614_md",
-      "target": "blog_2026_06_14_release_10_2_20260614_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_14_release_10_2_20260614_what_changed"
     },
     {
       "relation": "contains",
@@ -30496,9 +30496,9 @@
       "source_file": "blog/2026-06-15-release-10.2.20260615.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_15_release_10_2_20260615_md",
-      "target": "blog_2026_06_15_release_10_2_20260615_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_15_release_10_2_20260615_changelog"
     },
     {
       "relation": "contains",
@@ -30506,9 +30506,9 @@
       "source_file": "blog/2026-06-15-release-10.2.20260615.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_15_release_10_2_20260615_md",
-      "target": "blog_2026_06_15_release_10_2_20260615_shaft_10_2_20260615",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_15_release_10_2_20260615_shaft_10_2_20260615"
     },
     {
       "relation": "contains",
@@ -30516,9 +30516,9 @@
       "source_file": "blog/2026-06-15-release-10.2.20260615.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_15_release_10_2_20260615_md",
-      "target": "blog_2026_06_15_release_10_2_20260615_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_15_release_10_2_20260615_what_changed"
     },
     {
       "relation": "contains",
@@ -30566,9 +30566,9 @@
       "source_file": "blog/2026-06-17-release-10.2.20260617.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_17_release_10_2_20260617_md",
-      "target": "blog_2026_06_17_release_10_2_20260617_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_17_release_10_2_20260617_changelog"
     },
     {
       "relation": "contains",
@@ -30576,9 +30576,9 @@
       "source_file": "blog/2026-06-17-release-10.2.20260617.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_17_release_10_2_20260617_md",
-      "target": "blog_2026_06_17_release_10_2_20260617_shaft_10_2_20260617",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_17_release_10_2_20260617_shaft_10_2_20260617"
     },
     {
       "relation": "contains",
@@ -30586,9 +30586,9 @@
       "source_file": "blog/2026-06-17-release-10.2.20260617.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_17_release_10_2_20260617_md",
-      "target": "blog_2026_06_17_release_10_2_20260617_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_17_release_10_2_20260617_what_changed"
     },
     {
       "relation": "contains",
@@ -30636,9 +30636,9 @@
       "source_file": "blog/2026-06-18-release-10.2.20260618.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_18_release_10_2_20260618_md",
-      "target": "blog_2026_06_18_release_10_2_20260618_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_18_release_10_2_20260618_changelog"
     },
     {
       "relation": "contains",
@@ -30646,9 +30646,9 @@
       "source_file": "blog/2026-06-18-release-10.2.20260618.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_18_release_10_2_20260618_md",
-      "target": "blog_2026_06_18_release_10_2_20260618_shaft_10_2_20260618",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_18_release_10_2_20260618_shaft_10_2_20260618"
     },
     {
       "relation": "contains",
@@ -30656,9 +30656,9 @@
       "source_file": "blog/2026-06-18-release-10.2.20260618.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_18_release_10_2_20260618_md",
-      "target": "blog_2026_06_18_release_10_2_20260618_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_18_release_10_2_20260618_what_changed"
     },
     {
       "relation": "contains",
@@ -30706,9 +30706,9 @@
       "source_file": "blog/2026-06-19-release-10.2.20260620.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_19_release_10_2_20260620_md",
-      "target": "blog_2026_06_19_release_10_2_20260620_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_19_release_10_2_20260620_changelog"
     },
     {
       "relation": "contains",
@@ -30716,9 +30716,9 @@
       "source_file": "blog/2026-06-19-release-10.2.20260620.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_19_release_10_2_20260620_md",
-      "target": "blog_2026_06_19_release_10_2_20260620_shaft_10_2_20260620",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_19_release_10_2_20260620_shaft_10_2_20260620"
     },
     {
       "relation": "contains",
@@ -30726,9 +30726,9 @@
       "source_file": "blog/2026-06-19-release-10.2.20260620.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_19_release_10_2_20260620_md",
-      "target": "blog_2026_06_19_release_10_2_20260620_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_19_release_10_2_20260620_what_changed"
     },
     {
       "relation": "contains",
@@ -30776,9 +30776,9 @@
       "source_file": "blog/2026-06-21-release-10.2.20260621.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_21_release_10_2_20260621_md",
-      "target": "blog_2026_06_21_release_10_2_20260621_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_21_release_10_2_20260621_changelog"
     },
     {
       "relation": "contains",
@@ -30786,9 +30786,9 @@
       "source_file": "blog/2026-06-21-release-10.2.20260621.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_21_release_10_2_20260621_md",
-      "target": "blog_2026_06_21_release_10_2_20260621_shaft_10_2_20260621",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_21_release_10_2_20260621_shaft_10_2_20260621"
     },
     {
       "relation": "contains",
@@ -30796,9 +30796,9 @@
       "source_file": "blog/2026-06-21-release-10.2.20260621.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_21_release_10_2_20260621_md",
-      "target": "blog_2026_06_21_release_10_2_20260621_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_21_release_10_2_20260621_what_changed"
     },
     {
       "relation": "contains",
@@ -30846,9 +30846,9 @@
       "source_file": "blog/2026-06-22-release-10.2.20260622.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_22_release_10_2_20260622_md",
-      "target": "blog_2026_06_22_release_10_2_20260622_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_22_release_10_2_20260622_changelog"
     },
     {
       "relation": "contains",
@@ -30856,9 +30856,9 @@
       "source_file": "blog/2026-06-22-release-10.2.20260622.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_22_release_10_2_20260622_md",
-      "target": "blog_2026_06_22_release_10_2_20260622_shaft_10_2_20260622",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_22_release_10_2_20260622_shaft_10_2_20260622"
     },
     {
       "relation": "contains",
@@ -30866,9 +30866,9 @@
       "source_file": "blog/2026-06-22-release-10.2.20260622.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_22_release_10_2_20260622_md",
-      "target": "blog_2026_06_22_release_10_2_20260622_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_22_release_10_2_20260622_what_changed"
     },
     {
       "relation": "contains",
@@ -30916,9 +30916,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_23_release_10_2_20260623_md",
-      "target": "blog_2026_06_23_release_10_2_20260623_changelog",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_changelog"
     },
     {
       "relation": "contains",
@@ -30926,9 +30926,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_23_release_10_2_20260623_md",
-      "target": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_shaft_10_2_20260623"
     },
     {
       "relation": "contains",
@@ -30936,9 +30936,9 @@
       "source_file": "blog/2026-06-23-release-10.2.20260623.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_blog_2026_06_23_release_10_2_20260623_md",
-      "target": "blog_2026_06_23_release_10_2_20260623_what_changed",
-      "confidence_score": 1.0
+      "target": "blog_2026_06_23_release_10_2_20260623_what_changed"
     },
     {
       "relation": "contains",
@@ -30986,9 +30986,9 @@
       "source_file": "docs/agentic/capture.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_capture_md",
-      "target": "agentic_capture_record_tests_with_capture",
-      "confidence_score": 1.0
+      "target": "agentic_capture_record_tests_with_capture"
     },
     {
       "relation": "contains",
@@ -31186,9 +31186,9 @@
       "source_file": "docs/agentic/examples.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_examples_md",
-      "target": "agentic_examples_pilot_examples",
-      "confidence_score": 1.0
+      "target": "agentic_examples_pilot_examples"
     },
     {
       "relation": "contains",
@@ -31246,9 +31246,9 @@
       "source_file": "docs/agentic/heal.mdx",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_heal_mdx",
-      "target": "agentic_heal_recover_locators_with_heal",
-      "confidence_score": 1.0
+      "target": "agentic_heal_recover_locators_with_heal"
     },
     {
       "relation": "contains",
@@ -31336,9 +31336,9 @@
       "source_file": "docs/agentic/mcp-manual.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_mcp_manual_mdx",
-      "target": "agentic_mcp_manual_configure_shaft_mcp_manually",
-      "confidence_score": 1.0
+      "target": "agentic_mcp_manual_configure_shaft_mcp_manually"
     },
     {
       "relation": "contains",
@@ -31436,9 +31436,9 @@
       "source_file": "docs/agentic/mcp.mdx",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_mcp_mdx",
-      "target": "agentic_mcp_connect_shaft_mcp",
-      "confidence_score": 1.0
+      "target": "agentic_mcp_connect_shaft_mcp"
     },
     {
       "relation": "contains",
@@ -31556,9 +31556,9 @@
       "source_file": "docs/agentic/overview.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_overview_mdx",
-      "target": "agentic_overview_agentic_testing_without_hidden_automation",
-      "confidence_score": 1.0
+      "target": "agentic_overview_agentic_testing_without_hidden_automation"
     },
     {
       "relation": "contains",
@@ -31576,9 +31576,9 @@
       "source_file": "docs/agentic/pilot.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_pilot_md",
-      "target": "agentic_pilot_shaft_pilot",
-      "confidence_score": 1.0
+      "target": "agentic_pilot_shaft_pilot"
     },
     {
       "relation": "contains",
@@ -31686,9 +31686,9 @@
       "source_file": "docs/agentic/providers.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_agentic_providers_md",
-      "target": "agentic_providers_optional_ai_providers",
-      "confidence_score": 1.0
+      "target": "agentic_providers_optional_ai_providers"
     },
     {
       "relation": "contains",
@@ -31746,9 +31746,9 @@
       "source_file": "docs/archive/engine/2026-05-08-actions-run-25572054507.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_2026_05_08_actions_run_25572054507_md",
-      "target": "engine_2026_05_08_actions_run_25572054507_investigate_e2e_test_failures_from_github_actions_run_25572054507",
-      "confidence_score": 1.0
+      "target": "engine_2026_05_08_actions_run_25572054507_investigate_e2e_test_failures_from_github_actions_run_25572054507"
     },
     {
       "relation": "contains",
@@ -31806,9 +31806,9 @@
       "source_file": "docs/archive/engine/2026-05-08-agent-knowledge-migration.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_2026_05_08_agent_knowledge_migration_md",
-      "target": "engine_2026_05_08_agent_knowledge_migration_ticket_agent_knowledge_migration_and_instruction_consolidation",
-      "confidence_score": 1.0
+      "target": "engine_2026_05_08_agent_knowledge_migration_ticket_agent_knowledge_migration_and_instruction_consolidation"
     },
     {
       "relation": "contains",
@@ -31866,9 +31866,9 @@
       "source_file": "docs/archive/engine/ci-coverage-readiness.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_ci_coverage_readiness_md",
-      "target": "engine_ci_coverage_readiness_ci_coverage_readiness_workflow",
-      "confidence_score": 1.0
+      "target": "engine_ci_coverage_readiness_ci_coverage_readiness_workflow"
     },
     {
       "relation": "contains",
@@ -31906,9 +31906,9 @@
       "source_file": "docs/archive/engine/contributors-history.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_contributors_history_md",
-      "target": "engine_contributors_history_maintainer_history_manifest_pre_flatten_baseline",
-      "confidence_score": 1.0
+      "target": "engine_contributors_history_maintainer_history_manifest_pre_flatten_baseline"
     },
     {
       "relation": "contains",
@@ -31916,9 +31916,9 @@
       "source_file": "docs/archive/engine/history-rewrite-validation.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_history_rewrite_validation_md",
-      "target": "engine_history_rewrite_validation_repository_history_rewrite_validation_temporary_clone",
-      "confidence_score": 1.0
+      "target": "engine_history_rewrite_validation_repository_history_rewrite_validation_temporary_clone"
     },
     {
       "relation": "contains",
@@ -31956,9 +31956,9 @@
       "source_file": "docs/archive/engine/mcp-history-import.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_mcp_history_import_md",
-      "target": "engine_mcp_history_import_shaft_mcp_history_import",
-      "confidence_score": 1.0
+      "target": "engine_mcp_history_import_shaft_mcp_history_import"
     },
     {
       "relation": "contains",
@@ -32036,9 +32036,9 @@
       "source_file": "docs/archive/engine/modular-dependency-report.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_modular_dependency_report_md",
-      "target": "engine_modular_dependency_report_modular_cold_cache_dependency_baseline",
-      "confidence_score": 1.0
+      "target": "engine_modular_dependency_report_modular_cold_cache_dependency_baseline"
     },
     {
       "relation": "contains",
@@ -32046,9 +32046,9 @@
       "source_file": "docs/archive/engine/retired-agent-skill/SKILL.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_retired_agent_skill_skill_md",
-      "target": "retired_agent_skill_skill_shaft_engine_test_automation_expert",
-      "confidence_score": 1.0
+      "target": "retired_agent_skill_skill_shaft_engine_test_automation_expert"
     },
     {
       "relation": "contains",
@@ -32226,9 +32226,9 @@
       "source_file": "docs/archive/engine/retired-agent-skill/code-analysis-and-optimization.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_retired_agent_skill_code_analysis_and_optimization_md",
-      "target": "retired_agent_skill_code_analysis_and_optimization_archived_skill_code_analysis_and_optimization",
-      "confidence_score": 1.0
+      "target": "retired_agent_skill_code_analysis_and_optimization_archived_skill_code_analysis_and_optimization"
     },
     {
       "relation": "contains",
@@ -32346,9 +32346,9 @@
       "source_file": "docs/archive/engine/retired-agent-skill/overview.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_retired_agent_skill_overview_md",
-      "target": "retired_agent_skill_overview_archived_google_gemma_skill",
-      "confidence_score": 1.0
+      "target": "retired_agent_skill_overview_archived_google_gemma_skill"
     },
     {
       "relation": "contains",
@@ -32416,9 +32416,9 @@
       "source_file": "docs/archive/engine/tink-design-journal.md",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_tink_design_journal_md",
-      "target": "engine_tink_design_journal_milestone_1_reached_initial_implementation_success",
-      "confidence_score": 1.0
+      "target": "engine_tink_design_journal_milestone_1_reached_initial_implementation_success"
     },
     {
       "relation": "contains",
@@ -32426,9 +32426,9 @@
       "source_file": "docs/archive/engine/tink-design-journal.md",
       "source_location": "L91",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_tink_design_journal_md",
-      "target": "engine_tink_design_journal_milestone_2_reached_extended_implementation_success",
-      "confidence_score": 1.0
+      "target": "engine_tink_design_journal_milestone_2_reached_extended_implementation_success"
     },
     {
       "relation": "contains",
@@ -32436,9 +32436,9 @@
       "source_file": "docs/archive/engine/tink-design-journal.md",
       "source_location": "L96",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_engine_tink_design_journal_md",
-      "target": "engine_tink_design_journal_milestone_3_reached_all_requirements_implemented_successfully_with_several_enhancements",
-      "confidence_score": 1.0
+      "target": "engine_tink_design_journal_milestone_3_reached_all_requirements_implemented_successfully_with_several_enhancements"
     },
     {
       "relation": "contains",
@@ -32446,9 +32446,9 @@
       "source_file": "docs/archive/overview.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_overview_md",
-      "target": "archive_overview_documentation_archive",
-      "confidence_score": 1.0
+      "target": "archive_overview_documentation_archive"
     },
     {
       "relation": "contains",
@@ -32456,9 +32456,9 @@
       "source_file": "docs/archive/site/autobot-optimization-summary.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_autobot_optimization_summary_md",
-      "target": "site_autobot_optimization_summary_autobot_optimization_summary",
-      "confidence_score": 1.0
+      "target": "site_autobot_optimization_summary_autobot_optimization_summary"
     },
     {
       "relation": "contains",
@@ -32726,9 +32726,9 @@
       "source_file": "docs/archive/site/chatbot-testing.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_chatbot_testing_md",
-      "target": "site_chatbot_testing_chatbot_testing_guide",
-      "confidence_score": 1.0
+      "target": "site_chatbot_testing_chatbot_testing_guide"
     },
     {
       "relation": "contains",
@@ -32946,9 +32946,9 @@
       "source_file": "docs/archive/site/configuration-verification.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_configuration_verification_md",
-      "target": "site_configuration_verification_configuration_verification_report",
-      "confidence_score": 1.0
+      "target": "site_configuration_verification_configuration_verification_report"
     },
     {
       "relation": "contains",
@@ -33096,9 +33096,9 @@
       "source_file": "docs/archive/site/deployment-checklist.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_deployment_checklist_md",
-      "target": "site_deployment_checklist_deployment_checklist",
-      "confidence_score": 1.0
+      "target": "site_deployment_checklist_deployment_checklist"
     },
     {
       "relation": "contains",
@@ -33336,9 +33336,9 @@
       "source_file": "docs/archive/site/e2e-test-results.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_e2e_test_results_md",
-      "target": "site_e2e_test_results_e2e_test_execution_results",
-      "confidence_score": 1.0
+      "target": "site_e2e_test_results_e2e_test_execution_results"
     },
     {
       "relation": "contains",
@@ -33596,9 +33596,9 @@
       "source_file": "docs/archive/site/final-summary.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_final_summary_md",
-      "target": "site_final_summary_final_summary_chatbot_fix_implementation",
-      "confidence_score": 1.0
+      "target": "site_final_summary_final_summary_chatbot_fix_implementation"
     },
     {
       "relation": "contains",
@@ -33886,9 +33886,9 @@
       "source_file": "docs/archive/site/github-actions-test-setup.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_github_actions_test_setup_md",
-      "target": "site_github_actions_test_setup_github_actions_test_setup_api_key_configuration",
-      "confidence_score": 1.0
+      "target": "site_github_actions_test_setup_github_actions_test_setup_api_key_configuration"
     },
     {
       "relation": "contains",
@@ -34146,9 +34146,9 @@
       "source_file": "docs/archive/site/netlify-migration-guide.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_netlify_migration_guide_md",
-      "target": "site_netlify_migration_guide_migration_guide_github_pages_to_netlify",
-      "confidence_score": 1.0
+      "target": "site_netlify_migration_guide_migration_guide_github_pages_to_netlify"
     },
     {
       "relation": "contains",
@@ -34426,9 +34426,9 @@
       "source_file": "docs/archive/site/security-fix-summary.md",
       "source_location": "L7",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_archive_site_security_fix_summary_md",
-      "target": "site_security_fix_summary_security_fix_summary",
-      "confidence_score": 1.0
+      "target": "site_security_fix_summary_security_fix_summary"
     },
     {
       "relation": "contains",
@@ -34696,9 +34696,9 @@
       "source_file": "docs/features/architecture.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_features_architecture_md",
-      "target": "features_architecture_architecture",
-      "confidence_score": 1.0
+      "target": "features_architecture_architecture"
     },
     {
       "relation": "contains",
@@ -34756,9 +34756,9 @@
       "source_file": "docs/features/modules.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_features_modules_md",
-      "target": "features_modules_features_and_modules",
-      "confidence_score": 1.0
+      "target": "features_modules_features_and_modules"
     },
     {
       "relation": "contains",
@@ -34846,9 +34846,9 @@
       "source_file": "docs/features/partners.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_features_partners_md",
-      "target": "features_partners_partners_and_adopters",
-      "confidence_score": 1.0
+      "target": "features_partners_partners_and_adopters"
     },
     {
       "relation": "contains",
@@ -34906,9 +34906,9 @@
       "source_file": "docs/features/reporting.md",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "features_reporting_reporting_and_evidence",
-      "target": "features_reporting_failure_diagnostics_bundle",
-      "confidence_score": 1.0
+      "target": "features_reporting_failure_diagnostics_bundle"
     },
     {
       "relation": "contains",
@@ -34936,9 +34936,9 @@
       "source_file": "docs/features/technology.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_features_technology_md",
-      "target": "features_technology_technology",
-      "confidence_score": 1.0
+      "target": "features_technology_technology"
     },
     {
       "relation": "contains",
@@ -34956,9 +34956,9 @@
       "source_file": "docs/features/test-automation-pillars.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_features_test_automation_pillars_mdx",
-      "target": "features_test_automation_pillars_pillars_of_successful_test_automation",
-      "confidence_score": 1.0
+      "target": "features_test_automation_pillars_pillars_of_successful_test_automation"
     },
     {
       "relation": "contains",
@@ -35016,9 +35016,9 @@
       "source_file": "docs/integrations/browserstack.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_integrations_browserstack_md",
-      "target": "integrations_browserstack_browserstack",
-      "confidence_score": 1.0
+      "target": "integrations_browserstack_browserstack"
     },
     {
       "relation": "contains",
@@ -35066,9 +35066,9 @@
       "source_file": "docs/integrations/video.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_integrations_video_md",
-      "target": "integrations_video_video_recording",
-      "confidence_score": 1.0
+      "target": "integrations_video_video_recording"
     },
     {
       "relation": "contains",
@@ -35086,9 +35086,9 @@
       "source_file": "docs/integrations/visual.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_integrations_visual_md",
-      "target": "integrations_visual_visual_testing",
-      "confidence_score": 1.0
+      "target": "integrations_visual_visual_testing"
     },
     {
       "relation": "contains",
@@ -35146,9 +35146,9 @@
       "source_file": "docs/maintainers/agent-guidance.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_agent_guidance_md",
-      "target": "maintainers_agent_guidance_agent_guidance_maintenance",
-      "confidence_score": 1.0
+      "target": "maintainers_agent_guidance_agent_guidance_maintenance"
     },
     {
       "relation": "contains",
@@ -35196,9 +35196,9 @@
       "source_file": "docs/maintainers/ci-failure-investigation.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_ci_failure_investigation_md",
-      "target": "maintainers_ci_failure_investigation_ci_failure_and_allure_artifact_investigation",
-      "confidence_score": 1.0
+      "target": "maintainers_ci_failure_investigation_ci_failure_and_allure_artifact_investigation"
     },
     {
       "relation": "contains",
@@ -35246,9 +35246,9 @@
       "source_file": "docs/maintainers/history-rewrite.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_history_rewrite_md",
-      "target": "maintainers_history_rewrite_repository_history_rewrite",
-      "confidence_score": 1.0
+      "target": "maintainers_history_rewrite_repository_history_rewrite"
     },
     {
       "relation": "contains",
@@ -35336,9 +35336,9 @@
       "source_file": "docs/maintainers/mcp-deployment.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_mcp_deployment_md",
-      "target": "maintainers_mcp_deployment_mcp_publication_and_deployment",
-      "confidence_score": 1.0
+      "target": "maintainers_mcp_deployment_mcp_publication_and_deployment"
     },
     {
       "relation": "contains",
@@ -35376,9 +35376,9 @@
       "source_file": "docs/maintainers/overview.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_overview_md",
-      "target": "maintainers_overview_maintainer_runbooks",
-      "confidence_score": 1.0
+      "target": "maintainers_overview_maintainer_runbooks"
     },
     {
       "relation": "contains",
@@ -35386,9 +35386,9 @@
       "source_file": "docs/maintainers/pilot-release.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_pilot_release_md",
-      "target": "maintainers_pilot_release_shaft_pilot_release",
-      "confidence_score": 1.0
+      "target": "maintainers_pilot_release_shaft_pilot_release"
     },
     {
       "relation": "contains",
@@ -35446,9 +35446,9 @@
       "source_file": "docs/maintainers/publication.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_publication_md",
-      "target": "maintainers_publication_maven_central_publication_contract",
-      "confidence_score": 1.0
+      "target": "maintainers_publication_maven_central_publication_contract"
     },
     {
       "relation": "contains",
@@ -35496,9 +35496,9 @@
       "source_file": "docs/maintainers/reactor.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_reactor_md",
-      "target": "maintainers_reactor_maven_reactor_layout",
-      "confidence_score": 1.0
+      "target": "maintainers_reactor_maven_reactor_layout"
     },
     {
       "relation": "contains",
@@ -35566,9 +35566,9 @@
       "source_file": "docs/maintainers/site-operations.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_site_operations_md",
-      "target": "maintainers_site_operations_documentation_site_operations",
-      "confidence_score": 1.0
+      "target": "maintainers_site_operations_documentation_site_operations"
     },
     {
       "relation": "contains",
@@ -35626,9 +35626,9 @@
       "source_file": "docs/maintainers/visual-provider.md",
       "source_location": "L9",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_maintainers_visual_provider_md",
-      "target": "maintainers_visual_provider_visual_processing_provider_boundary",
-      "confidence_score": 1.0
+      "target": "maintainers_visual_provider_visual_processing_provider_boundary"
     },
     {
       "relation": "contains",
@@ -35656,9 +35656,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_api_key_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_api_key_authentication"
     },
     {
       "relation": "contains",
@@ -35666,9 +35666,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_basic_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_basic_authentication"
     },
     {
       "relation": "contains",
@@ -35676,9 +35676,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L126",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_complete_test_example",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_complete_test_example"
     },
     {
       "relation": "contains",
@@ -35686,9 +35686,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L93",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_cookie_based_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_cookie_based_authentication"
     },
     {
       "relation": "contains",
@@ -35696,9 +35696,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_digest_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_digest_authentication"
     },
     {
       "relation": "contains",
@@ -35706,9 +35706,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_form_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_form_authentication"
     },
     {
       "relation": "contains",
@@ -35716,9 +35716,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_oauth2_bearer_token",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_oauth2_bearer_token"
     },
     {
       "relation": "contains",
@@ -35726,9 +35726,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L106",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_persistent_session_authentication",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_persistent_session_authentication"
     },
     {
       "relation": "contains",
@@ -35736,9 +35736,9 @@
       "source_file": "docs/reference/actions/API/API_Authentication.md",
       "source_location": "L169",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_api_authentication_md",
-      "target": "api_api_authentication_related",
-      "confidence_score": 1.0
+      "target": "api_api_authentication_related"
     },
     {
       "relation": "contains",
@@ -35766,9 +35766,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L137",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_asserting_with_shaft_validations",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_asserting_with_shaft_validations"
     },
     {
       "relation": "contains",
@@ -35776,9 +35776,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L93",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_complete_test_example",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_complete_test_example"
     },
     {
       "relation": "contains",
@@ -35786,9 +35786,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L73",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_query_with_authentication_header",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_query_with_authentication_header"
     },
     {
       "relation": "contains",
@@ -35796,9 +35796,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L54",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_query_with_fragment",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_query_with_fragment"
     },
     {
       "relation": "contains",
@@ -35806,9 +35806,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_query_with_variables",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_query_with_variables"
     },
     {
       "relation": "contains",
@@ -35816,9 +35816,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L167",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_related",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_related"
     },
     {
       "relation": "contains",
@@ -35826,9 +35826,9 @@
       "source_file": "docs/reference/actions/API/GraphQL_Testing.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_graphql_testing_md",
-      "target": "api_graphql_testing_simple_query",
-      "confidence_score": 1.0
+      "target": "api_graphql_testing_simple_query"
     },
     {
       "relation": "contains",
@@ -35836,9 +35836,9 @@
       "source_file": "docs/reference/actions/API/Request_Builder.md",
       "source_location": "L331",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_request_builder_md",
-      "target": "api_request_builder_graphql_api_testing",
-      "confidence_score": 1.0
+      "target": "api_request_builder_graphql_api_testing"
     },
     {
       "relation": "contains",
@@ -35846,9 +35846,9 @@
       "source_file": "docs/reference/actions/API/Request_Builder.md",
       "source_location": "L425",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_request_builder_md",
-      "target": "api_request_builder_related",
-      "confidence_score": 1.0
+      "target": "api_request_builder_related"
     },
     {
       "relation": "contains",
@@ -35856,9 +35856,9 @@
       "source_file": "docs/reference/actions/API/Request_Builder.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_request_builder_md",
-      "target": "api_request_builder_request_builder",
-      "confidence_score": 1.0
+      "target": "api_request_builder_request_builder"
     },
     {
       "relation": "contains",
@@ -35866,9 +35866,9 @@
       "source_file": "docs/reference/actions/API/Request_Builder.md",
       "source_location": "L398",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_request_builder_md",
-      "target": "api_request_builder_sample_code_snippet",
-      "confidence_score": 1.0
+      "target": "api_request_builder_sample_code_snippet"
     },
     {
       "relation": "contains",
@@ -35876,9 +35876,9 @@
       "source_file": "docs/reference/actions/API/Request_Builder.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_request_builder_md",
-      "target": "api_request_builder_shaft_api",
-      "confidence_score": 1.0
+      "target": "api_request_builder_shaft_api"
     },
     {
       "relation": "contains",
@@ -36226,9 +36226,9 @@
       "source_file": "docs/reference/actions/API/Response_Getters.md",
       "source_location": "L97",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_response_getters_md",
-      "target": "api_response_getters_related",
-      "confidence_score": 1.0
+      "target": "api_response_getters_related"
     },
     {
       "relation": "contains",
@@ -36236,9 +36236,9 @@
       "source_file": "docs/reference/actions/API/Response_Getters.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_response_getters_md",
-      "target": "api_response_getters_shaft_api_getters",
-      "confidence_score": 1.0
+      "target": "api_response_getters_shaft_api_getters"
     },
     {
       "relation": "contains",
@@ -36366,9 +36366,9 @@
       "source_file": "docs/reference/actions/API/Response_Validations.md",
       "source_location": "L126",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_response_validations_md",
-      "target": "api_response_validations_related",
-      "confidence_score": 1.0
+      "target": "api_response_validations_related"
     },
     {
       "relation": "contains",
@@ -36376,9 +36376,9 @@
       "source_file": "docs/reference/actions/API/Response_Validations.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_api_response_validations_md",
-      "target": "api_response_validations_shaft_api_response_validations",
-      "confidence_score": 1.0
+      "target": "api_response_validations_shaft_api_response_validations"
     },
     {
       "relation": "contains",
@@ -36546,9 +36546,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L176",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_best_practices",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_best_practices"
     },
     {
       "relation": "contains",
@@ -36556,9 +36556,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L144",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_combining_docker_terminal_with_shaft_api",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_combining_docker_terminal_with_shaft_api"
     },
     {
       "relation": "contains",
@@ -36566,9 +36566,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L76",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_common_use_cases",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_common_use_cases"
     },
     {
       "relation": "contains",
@@ -36576,9 +36576,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_create_a_docker_terminal",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_create_a_docker_terminal"
     },
     {
       "relation": "contains",
@@ -36586,9 +36586,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_execute_commands",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_execute_commands"
     },
     {
       "relation": "contains",
@@ -36596,9 +36596,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_prerequisites",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_prerequisites"
     },
     {
       "relation": "contains",
@@ -36606,9 +36606,9 @@
       "source_file": "docs/reference/actions/CLI/Docker_Terminal.md",
       "source_location": "L186",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_docker_terminal_md",
-      "target": "cli_docker_terminal_related_pages",
-      "confidence_score": 1.0
+      "target": "cli_docker_terminal_related_pages"
     },
     {
       "relation": "contains",
@@ -36676,9 +36676,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L195",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_best_practices",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_best_practices"
     },
     {
       "relation": "contains",
@@ -36686,9 +36686,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_complete_example_download_validate_and_clean_up",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_complete_example_download_validate_and_clean_up"
     },
     {
       "relation": "contains",
@@ -36696,9 +36696,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_copy_file",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_copy_file"
     },
     {
       "relation": "contains",
@@ -36706,9 +36706,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L105",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_delete_file",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_delete_file"
     },
     {
       "relation": "contains",
@@ -36716,9 +36716,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L158",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_file_path_handling",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_file_path_handling"
     },
     {
       "relation": "contains",
@@ -36726,9 +36726,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_getting_a_file_actions_instance",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_getting_a_file_actions_instance"
     },
     {
       "relation": "contains",
@@ -36736,9 +36736,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L169",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_integration_with_file_validations",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_integration_with_file_validations"
     },
     {
       "relation": "contains",
@@ -36746,9 +36746,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L23",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_read_file",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_read_file"
     },
     {
       "relation": "contains",
@@ -36756,9 +36756,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L202",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_related",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_related"
     },
     {
       "relation": "contains",
@@ -36766,9 +36766,9 @@
       "source_file": "docs/reference/actions/CLI/File_Actions.md",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_file_actions_md",
-      "target": "cli_file_actions_write_to_file",
-      "confidence_score": 1.0
+      "target": "cli_file_actions_write_to_file"
     },
     {
       "relation": "contains",
@@ -36816,9 +36816,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L213",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_best_practices",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_best_practices"
     },
     {
       "relation": "contains",
@@ -36826,9 +36826,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_common_use_cases",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_common_use_cases"
     },
     {
       "relation": "contains",
@@ -36836,9 +36836,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_create_an_ssh_terminal",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_create_an_ssh_terminal"
     },
     {
       "relation": "contains",
@@ -36846,9 +36846,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_execute_commands",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_execute_commands"
     },
     {
       "relation": "contains",
@@ -36856,9 +36856,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L79",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_file_transfer",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_file_transfer"
     },
     {
       "relation": "contains",
@@ -36866,9 +36866,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_prerequisites",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_prerequisites"
     },
     {
       "relation": "contains",
@@ -36876,9 +36876,9 @@
       "source_file": "docs/reference/actions/CLI/SSH_Terminal.md",
       "source_location": "L227",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_ssh_terminal_md",
-      "target": "cli_ssh_terminal_related_pages",
-      "confidence_score": 1.0
+      "target": "cli_ssh_terminal_related_pages"
     },
     {
       "relation": "contains",
@@ -36966,9 +36966,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L189",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_best_practices",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_best_practices"
     },
     {
       "relation": "contains",
@@ -36976,9 +36976,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L70",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_common_use_cases",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_common_use_cases"
     },
     {
       "relation": "contains",
@@ -36986,9 +36986,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L158",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_cross_platform_compatibility",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_cross_platform_compatibility"
     },
     {
       "relation": "contains",
@@ -36996,9 +36996,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L23",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_execute_a_single_command",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_execute_a_single_command"
     },
     {
       "relation": "contains",
@@ -37006,9 +37006,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L49",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_execute_multiple_commands",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_execute_multiple_commands"
     },
     {
       "relation": "contains",
@@ -37016,9 +37016,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_getting_a_terminal_instance",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_getting_a_terminal_instance"
     },
     {
       "relation": "contains",
@@ -37026,9 +37026,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L197",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_related",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_related"
     },
     {
       "relation": "contains",
@@ -37036,9 +37036,9 @@
       "source_file": "docs/reference/actions/CLI/Terminal_Actions.md",
       "source_location": "L173",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_cli_terminal_actions_md",
-      "target": "cli_terminal_actions_timeouts_and_reporting",
-      "confidence_score": 1.0
+      "target": "cli_terminal_actions_timeouts_and_reporting"
     },
     {
       "relation": "contains",
@@ -37096,9 +37096,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L357",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_best_practices",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_best_practices"
     },
     {
       "relation": "contains",
@@ -37106,9 +37106,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L333",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_connection_parameters_reference",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_connection_parameters_reference"
     },
     {
       "relation": "contains",
@@ -37116,9 +37116,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L245",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_custom_connection_string_patterns",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_custom_connection_string_patterns"
     },
     {
       "relation": "contains",
@@ -37126,9 +37126,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_jdbc_connection_strings",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_jdbc_connection_strings"
     },
     {
       "relation": "contains",
@@ -37136,9 +37136,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L377",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_related",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_related"
     },
     {
       "relation": "contains",
@@ -37146,9 +37146,9 @@
       "source_file": "docs/reference/actions/DB/Connection_Strings.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_connection_strings_md",
-      "target": "db_connection_strings_standard_connection_string_patterns",
-      "confidence_score": 1.0
+      "target": "db_connection_strings_standard_connection_string_patterns"
     },
     {
       "relation": "contains",
@@ -37476,9 +37476,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L184",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_advanced_usage",
-      "confidence_score": 1.0
+      "target": "db_db_actions_advanced_usage"
     },
     {
       "relation": "contains",
@@ -37486,9 +37486,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L261",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_complete_test_example",
-      "confidence_score": 1.0
+      "target": "db_db_actions_complete_test_example"
     },
     {
       "relation": "contains",
@@ -37496,9 +37496,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_connecting_to_a_database",
-      "confidence_score": 1.0
+      "target": "db_db_actions_connecting_to_a_database"
     },
     {
       "relation": "contains",
@@ -37506,9 +37506,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L308",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_connection_strings_reference",
-      "confidence_score": 1.0
+      "target": "db_db_actions_connection_strings_reference"
     },
     {
       "relation": "contains",
@@ -37516,9 +37516,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L99",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_executing_queries",
-      "confidence_score": 1.0
+      "target": "db_db_actions_executing_queries"
     },
     {
       "relation": "contains",
@@ -37526,9 +37526,9 @@
       "source_file": "docs/reference/actions/DB/DB_Actions.md",
       "source_location": "L312",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_db_actions_md",
-      "target": "db_db_actions_related",
-      "confidence_score": 1.0
+      "target": "db_db_actions_related"
     },
     {
       "relation": "contains",
@@ -37646,9 +37646,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L303",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_additional_dependencies",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_additional_dependencies"
     },
     {
       "relation": "contains",
@@ -37656,9 +37656,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L329",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_best_practices",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_best_practices"
     },
     {
       "relation": "contains",
@@ -37666,9 +37666,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_oracle_jdbc_driver_setup",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_oracle_jdbc_driver_setup"
     },
     {
       "relation": "contains",
@@ -37676,9 +37676,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_prerequisites",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_prerequisites"
     },
     {
       "relation": "contains",
@@ -37686,9 +37686,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L355",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_related",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_related"
     },
     {
       "relation": "contains",
@@ -37696,9 +37696,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L347",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_resources",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_resources"
     },
     {
       "relation": "contains",
@@ -37706,9 +37706,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_step_1_download_oracle_jdbc_driver",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_step_1_download_oracle_jdbc_driver"
     },
     {
       "relation": "contains",
@@ -37716,9 +37716,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_step_2_add_driver_to_your_project",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_step_2_add_driver_to_your_project"
     },
     {
       "relation": "contains",
@@ -37726,9 +37726,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L166",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_step_3_verify_installation",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_step_3_verify_installation"
     },
     {
       "relation": "contains",
@@ -37736,9 +37736,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L205",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_step_4_common_connection_examples",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_step_4_common_connection_examples"
     },
     {
       "relation": "contains",
@@ -37746,9 +37746,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L263",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_troubleshooting",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_troubleshooting"
     },
     {
       "relation": "contains",
@@ -37756,9 +37756,9 @@
       "source_file": "docs/reference/actions/DB/Oracle_JDBC_Setup.md",
       "source_location": "L247",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_db_oracle_jdbc_setup_md",
-      "target": "db_oracle_jdbc_setup_version_compatibility",
-      "confidence_score": 1.0
+      "target": "db_oracle_jdbc_setup_version_compatibility"
     },
     {
       "relation": "contains",
@@ -38016,9 +38016,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_acceptalert",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_acceptalert"
     },
     {
       "relation": "contains",
@@ -38026,9 +38026,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_accessing_alert_actions",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_accessing_alert_actions"
     },
     {
       "relation": "contains",
@@ -38036,9 +38036,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_complete_example",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_complete_example"
     },
     {
       "relation": "contains",
@@ -38046,9 +38046,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_dismissalert",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_dismissalert"
     },
     {
       "relation": "contains",
@@ -38056,9 +38056,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L36",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_getalerttext",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_getalerttext"
     },
     {
       "relation": "contains",
@@ -38066,9 +38066,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_isalertpresent",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_isalertpresent"
     },
     {
       "relation": "contains",
@@ -38076,9 +38076,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L112",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_related",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_related"
     },
     {
       "relation": "contains",
@@ -38086,9 +38086,9 @@
       "source_file": "docs/reference/actions/GUI/Alert_Actions.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_alert_actions_md",
-      "target": "gui_alert_actions_typeintopromptalert",
-      "confidence_score": 1.0
+      "target": "gui_alert_actions_typeintopromptalert"
     },
     {
       "relation": "contains",
@@ -38096,9 +38096,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L132",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_additional_resources",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_additional_resources"
     },
     {
       "relation": "contains",
@@ -38106,9 +38106,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_basic_usage",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_basic_usage"
     },
     {
       "relation": "contains",
@@ -38116,9 +38116,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L73",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_complete_example_registration_form",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_complete_example_registration_form"
     },
     {
       "relation": "contains",
@@ -38126,9 +38126,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_overview",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_overview"
     },
     {
       "relation": "contains",
@@ -38136,9 +38136,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_synchronisation_methods",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_synchronisation_methods"
     },
     {
       "relation": "contains",
@@ -38146,9 +38146,9 @@
       "source_file": "docs/reference/actions/GUI/Async_Element_Actions.md",
       "source_location": "L116",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_async_element_actions_md",
-      "target": "gui_async_element_actions_when_to_use_async_vs_synchronous_actions",
-      "confidence_score": 1.0
+      "target": "gui_async_element_actions_when_to_use_async_vs_synchronous_actions"
     },
     {
       "relation": "contains",
@@ -38176,9 +38176,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L344",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_accessibility_testing",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_accessibility_testing"
     },
     {
       "relation": "contains",
@@ -38186,9 +38186,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L167",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_cookies",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_cookies"
     },
     {
       "relation": "contains",
@@ -38196,9 +38196,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L356",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_fluent_chaining",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_fluent_chaining"
     },
     {
       "relation": "contains",
@@ -38206,9 +38206,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_getting_started",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_getting_started"
     },
     {
       "relation": "contains",
@@ -38216,9 +38216,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L329",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_mobile_context",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_mobile_context"
     },
     {
       "relation": "contains",
@@ -38226,9 +38226,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_navigation",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_navigation"
     },
     {
       "relation": "contains",
@@ -38236,9 +38236,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L297",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_network_interception",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_network_interception"
     },
     {
       "relation": "contains",
@@ -38246,9 +38246,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L371",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_related",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_related"
     },
     {
       "relation": "contains",
@@ -38256,9 +38256,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L217",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_screenshots_and_snapshots",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_screenshots_and_snapshots"
     },
     {
       "relation": "contains",
@@ -38266,9 +38266,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L264",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_wait_actions",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_wait_actions"
     },
     {
       "relation": "contains",
@@ -38276,9 +38276,9 @@
       "source_file": "docs/reference/actions/GUI/Browser_Actions.md",
       "source_location": "L99",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_browser_actions_md",
-      "target": "gui_browser_actions_window_management",
-      "confidence_score": 1.0
+      "target": "gui_browser_actions_window_management"
     },
     {
       "relation": "contains",
@@ -38646,9 +38646,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_custom_capabilities",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_custom_capabilities"
     },
     {
       "relation": "contains",
@@ -38656,9 +38656,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_native_selenium_webdriver",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_native_selenium_webdriver"
     },
     {
       "relation": "contains",
@@ -38666,9 +38666,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L109",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_related",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_related"
     },
     {
       "relation": "contains",
@@ -38676,9 +38676,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L54",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_shadow_dom_locator_builder",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_shadow_dom_locator_builder"
     },
     {
       "relation": "contains",
@@ -38686,9 +38686,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_shaft_locator_builder",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_shaft_locator_builder"
     },
     {
       "relation": "contains",
@@ -38696,9 +38696,9 @@
       "source_file": "docs/reference/actions/GUI/Did_You_Know.md",
       "source_location": "L72",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_did_you_know_md",
-      "target": "gui_did_you_know_using_cookies_in_your_tests",
-      "confidence_score": 1.0
+      "target": "gui_did_you_know_using_cookies_in_your_tests"
     },
     {
       "relation": "contains",
@@ -38716,9 +38716,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L69",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_clicking",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_clicking"
     },
     {
       "relation": "contains",
@@ -38726,9 +38726,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L301",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_clipboard_actions",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_clipboard_actions"
     },
     {
       "relation": "contains",
@@ -38736,9 +38736,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L161",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_drag_and_drop",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_drag_and_drop"
     },
     {
       "relation": "contains",
@@ -38746,9 +38746,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L252",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_dropdowns",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_dropdowns"
     },
     {
       "relation": "contains",
@@ -38756,9 +38756,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L185",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_element_information",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_element_information"
     },
     {
       "relation": "contains",
@@ -38766,9 +38766,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L398",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_fluent_chaining",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_fluent_chaining"
     },
     {
       "relation": "contains",
@@ -38776,9 +38776,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L107",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_hovering",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_hovering"
     },
     {
       "relation": "contains",
@@ -38786,9 +38786,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L274",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_iframes",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_iframes"
     },
     {
       "relation": "contains",
@@ -38796,9 +38796,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L310",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_javascript_actions",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_javascript_actions"
     },
     {
       "relation": "contains",
@@ -38806,9 +38806,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L330",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_native_mobile_commands",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_native_mobile_commands"
     },
     {
       "relation": "contains",
@@ -38816,9 +38816,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L409",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_related",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_related"
     },
     {
       "relation": "contains",
@@ -38826,9 +38826,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L150",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_screenshots",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_screenshots"
     },
     {
       "relation": "contains",
@@ -38836,9 +38836,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_scrolling",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_scrolling"
     },
     {
       "relation": "contains",
@@ -38846,9 +38846,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L386",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_table_data_extraction",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_table_data_extraction"
     },
     {
       "relation": "contains",
@@ -38856,9 +38856,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_typing",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_typing"
     },
     {
       "relation": "contains",
@@ -38866,9 +38866,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Actions.md",
       "source_location": "L363",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_actions_md",
-      "target": "gui_element_actions_wait_methods",
-      "confidence_score": 1.0
+      "target": "gui_element_actions_wait_methods"
     },
     {
       "relation": "contains",
@@ -39196,9 +39196,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L783",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_additional_resources",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_additional_resources"
     },
     {
       "relation": "contains",
@@ -39206,9 +39206,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L649",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_aria_role_based_locators",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_aria_role_based_locators"
     },
     {
       "relation": "contains",
@@ -39216,9 +39216,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L772",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_best_practices",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_best_practices"
     },
     {
       "relation": "contains",
@@ -39226,9 +39226,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L543",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_combining_techniques",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_combining_techniques"
     },
     {
       "relation": "contains",
@@ -39236,9 +39236,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L401",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_interacting_with_iframes",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_interacting_with_iframes"
     },
     {
       "relation": "contains",
@@ -39246,9 +39246,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L298",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_interacting_with_shadow_dom",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_interacting_with_shadow_dom"
     },
     {
       "relation": "contains",
@@ -39256,9 +39256,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_overview",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_overview"
     },
     {
       "relation": "contains",
@@ -39266,9 +39266,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L208",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_relative_location_based_locators",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_relative_location_based_locators"
     },
     {
       "relation": "contains",
@@ -39276,9 +39276,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L161",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_shaft_locator_builder_methods",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_shaft_locator_builder_methods"
     },
     {
       "relation": "contains",
@@ -39286,9 +39286,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L716",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_smart_locators",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_smart_locators"
     },
     {
       "relation": "contains",
@@ -39296,9 +39296,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_supported_locator_types",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_supported_locator_types"
     },
     {
       "relation": "contains",
@@ -39306,9 +39306,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L84",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_traditional_locators_vs_shaft_locator_builder",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_traditional_locators_vs_shaft_locator_builder"
     },
     {
       "relation": "contains",
@@ -39316,9 +39316,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Identification.md",
       "source_location": "L578",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_identification_md",
-      "target": "gui_element_identification_xpath_axis_navigation",
-      "confidence_score": 1.0
+      "target": "gui_element_identification_xpath_axis_navigation"
     },
     {
       "relation": "contains",
@@ -39756,9 +39756,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_assertthat_vs_verifythat",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_assertthat_vs_verifythat"
     },
     {
       "relation": "contains",
@@ -39766,9 +39766,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L100",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_attribute_css_validations",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_attribute_css_validations"
     },
     {
       "relation": "contains",
@@ -39776,9 +39776,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_complete_example",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_complete_example"
     },
     {
       "relation": "contains",
@@ -39786,9 +39786,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_custom_report_messages",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_custom_report_messages"
     },
     {
       "relation": "contains",
@@ -39796,9 +39796,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L75",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_element_state",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_element_state"
     },
     {
       "relation": "contains",
@@ -39806,9 +39806,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_existence_visibility",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_existence_visibility"
     },
     {
       "relation": "contains",
@@ -39816,9 +39816,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L206",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_see_also",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_see_also"
     },
     {
       "relation": "contains",
@@ -39826,9 +39826,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_text_validations",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_text_validations"
     },
     {
       "relation": "contains",
@@ -39836,9 +39836,9 @@
       "source_file": "docs/reference/actions/GUI/Element_Validations.md",
       "source_location": "L119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_element_validations_md",
-      "target": "gui_element_validations_visual_validation",
-      "confidence_score": 1.0
+      "target": "gui_element_validations_visual_validation"
     },
     {
       "relation": "contains",
@@ -39966,9 +39966,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L27",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_basic_usage",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_basic_usage"
     },
     {
       "relation": "contains",
@@ -39976,9 +39976,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_deterministic_planner",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_deterministic_planner"
     },
     {
       "relation": "contains",
@@ -39986,9 +39986,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L90",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_mcp_usage",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_mcp_usage"
     },
     {
       "relation": "contains",
@@ -39996,9 +39996,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_optional_planner_fallback",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_optional_planner_fallback"
     },
     {
       "relation": "contains",
@@ -40006,9 +40006,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L101",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_related",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_related"
     },
     {
       "relation": "contains",
@@ -40016,9 +40016,9 @@
       "source_file": "docs/reference/actions/GUI/Natural_Language_Actions.md",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_natural_language_actions_md",
-      "target": "gui_natural_language_actions_trust_gate",
-      "confidence_score": 1.0
+      "target": "gui_natural_language_actions_trust_gate"
     },
     {
       "relation": "contains",
@@ -40026,9 +40026,9 @@
       "source_file": "docs/reference/actions/GUI/Playwright_Backend.md",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_playwright_backend_md",
-      "target": "gui_playwright_backend_configuration",
-      "confidence_score": 1.0
+      "target": "gui_playwright_backend_configuration"
     },
     {
       "relation": "contains",
@@ -40036,9 +40036,9 @@
       "source_file": "docs/reference/actions/GUI/Playwright_Backend.md",
       "source_location": "L164",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_playwright_backend_md",
-      "target": "gui_playwright_backend_mapping_tree",
-      "confidence_score": 1.0
+      "target": "gui_playwright_backend_mapping_tree"
     },
     {
       "relation": "contains",
@@ -40046,9 +40046,9 @@
       "source_file": "docs/reference/actions/GUI/Playwright_Backend.md",
       "source_location": "L131",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_playwright_backend_md",
-      "target": "gui_playwright_backend_native_access",
-      "confidence_score": 1.0
+      "target": "gui_playwright_backend_native_access"
     },
     {
       "relation": "contains",
@@ -40056,9 +40056,9 @@
       "source_file": "docs/reference/actions/GUI/Playwright_Backend.md",
       "source_location": "L270",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_playwright_backend_md",
-      "target": "gui_playwright_backend_related",
-      "confidence_score": 1.0
+      "target": "gui_playwright_backend_related"
     },
     {
       "relation": "contains",
@@ -40106,9 +40106,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L127",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_app_management",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_app_management"
     },
     {
       "relation": "contains",
@@ -40116,9 +40116,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L167",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_complete_example",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_complete_example"
     },
     {
       "relation": "contains",
@@ -40126,9 +40126,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L98",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_keyboard_actions",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_keyboard_actions"
     },
     {
       "relation": "contains",
@@ -40136,9 +40136,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L204",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_related",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_related"
     },
     {
       "relation": "contains",
@@ -40146,9 +40146,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_swipe_actions",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_swipe_actions"
     },
     {
       "relation": "contains",
@@ -40156,9 +40156,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_tap_actions",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_tap_actions"
     },
     {
       "relation": "contains",
@@ -40166,9 +40166,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L149",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_visual_element_detection",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_visual_element_detection"
     },
     {
       "relation": "contains",
@@ -40176,9 +40176,9 @@
       "source_file": "docs/reference/actions/GUI/Touch_Actions.md",
       "source_location": "L116",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_touch_actions_md",
-      "target": "gui_touch_actions_zoom_actions",
-      "confidence_score": 1.0
+      "target": "gui_touch_actions_zoom_actions"
     },
     {
       "relation": "contains",
@@ -40326,9 +40326,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_available_roles",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_available_roles"
     },
     {
       "relation": "contains",
@@ -40336,9 +40336,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_basic_usage",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_basic_usage"
     },
     {
       "relation": "contains",
@@ -40346,9 +40346,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_benefits_over_traditional_locators",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_benefits_over_traditional_locators"
     },
     {
       "relation": "contains",
@@ -40356,9 +40356,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L67",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_combining_conditions",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_combining_conditions"
     },
     {
       "relation": "contains",
@@ -40366,9 +40366,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L84",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_complete_example"
     },
     {
       "relation": "contains",
@@ -40376,9 +40376,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md",
       "source_location": "L128",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_aria_locators_md",
-      "target": "didyouknow_aria_locators_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_aria_locators_related"
     },
     {
       "relation": "contains",
@@ -40386,9 +40386,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_accessibility_testing_md",
-      "target": "didyouknow_accessibility_testing_available_methods",
-      "confidence_score": 1.0
+      "target": "didyouknow_accessibility_testing_available_methods"
     },
     {
       "relation": "contains",
@@ -40396,9 +40396,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md",
       "source_location": "L67",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_accessibility_testing_md",
-      "target": "didyouknow_accessibility_testing_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_accessibility_testing_complete_example"
     },
     {
       "relation": "contains",
@@ -40406,9 +40406,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_accessibility_testing_md",
-      "target": "didyouknow_accessibility_testing_enabling_axe_core",
-      "confidence_score": 1.0
+      "target": "didyouknow_accessibility_testing_enabling_axe_core"
     },
     {
       "relation": "contains",
@@ -40416,9 +40416,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md",
       "source_location": "L130",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_accessibility_testing_md",
-      "target": "didyouknow_accessibility_testing_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_accessibility_testing_related"
     },
     {
       "relation": "contains",
@@ -40426,9 +40426,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md",
       "source_location": "L114",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_accessibility_testing_md",
-      "target": "didyouknow_accessibility_testing_when_to_use",
-      "confidence_score": 1.0
+      "target": "didyouknow_accessibility_testing_when_to_use"
     },
     {
       "relation": "contains",
@@ -40466,9 +40466,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_async_element_actions_md",
-      "target": "didyouknow_async_element_actions_available_actions",
-      "confidence_score": 1.0
+      "target": "didyouknow_async_element_actions_available_actions"
     },
     {
       "relation": "contains",
@@ -40476,9 +40476,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_async_element_actions_md",
-      "target": "didyouknow_async_element_actions_examples",
-      "confidence_score": 1.0
+      "target": "didyouknow_async_element_actions_examples"
     },
     {
       "relation": "contains",
@@ -40486,9 +40486,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md",
       "source_location": "L130",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_async_element_actions_md",
-      "target": "didyouknow_async_element_actions_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_async_element_actions_related"
     },
     {
       "relation": "contains",
@@ -40496,9 +40496,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md",
       "source_location": "L46",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_async_element_actions_md",
-      "target": "didyouknow_async_element_actions_synchronizing_async_actions",
-      "confidence_score": 1.0
+      "target": "didyouknow_async_element_actions_synchronizing_async_actions"
     },
     {
       "relation": "contains",
@@ -40506,9 +40506,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_async_element_actions_md",
-      "target": "didyouknow_async_element_actions_when_to_use_async_actions",
-      "confidence_score": 1.0
+      "target": "didyouknow_async_element_actions_when_to_use_async_actions"
     },
     {
       "relation": "contains",
@@ -40546,9 +40546,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_available_actions",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_available_actions"
     },
     {
       "relation": "contains",
@@ -40556,9 +40556,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_basic_usage",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_basic_usage"
     },
     {
       "relation": "contains",
@@ -40566,9 +40566,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L134",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_best_practices",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_best_practices"
     },
     {
       "relation": "contains",
@@ -40576,9 +40576,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L67",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_chaining_clipboard_actions",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_chaining_clipboard_actions"
     },
     {
       "relation": "contains",
@@ -40586,9 +40586,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L81",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_common_use_cases",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_common_use_cases"
     },
     {
       "relation": "contains",
@@ -40596,9 +40596,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_import",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_import"
     },
     {
       "relation": "contains",
@@ -40606,9 +40606,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md",
       "source_location": "L143",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_clipboard_actions_md",
-      "target": "didyouknow_clipboard_actions_related_pages",
-      "confidence_score": 1.0
+      "target": "didyouknow_clipboard_actions_related_pages"
     },
     {
       "relation": "contains",
@@ -40696,9 +40696,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_custom_capabilities_md",
-      "target": "didyouknow_custom_capabilities_chrome_examples",
-      "confidence_score": 1.0
+      "target": "didyouknow_custom_capabilities_chrome_examples"
     },
     {
       "relation": "contains",
@@ -40706,9 +40706,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md",
       "source_location": "L146",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_custom_capabilities_md",
-      "target": "didyouknow_custom_capabilities_complete_test_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_custom_capabilities_complete_test_example"
     },
     {
       "relation": "contains",
@@ -40716,9 +40716,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md",
       "source_location": "L130",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_custom_capabilities_md",
-      "target": "didyouknow_custom_capabilities_edge_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_custom_capabilities_edge_example"
     },
     {
       "relation": "contains",
@@ -40726,9 +40726,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md",
       "source_location": "L91",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_custom_capabilities_md",
-      "target": "didyouknow_custom_capabilities_firefox_examples",
-      "confidence_score": 1.0
+      "target": "didyouknow_custom_capabilities_firefox_examples"
     },
     {
       "relation": "contains",
@@ -40736,9 +40736,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md",
       "source_location": "L196",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_custom_capabilities_md",
-      "target": "didyouknow_custom_capabilities_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_custom_capabilities_related"
     },
     {
       "relation": "contains",
@@ -40806,9 +40806,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_explicit_waits_md",
-      "target": "didyouknow_explicit_waits_browser_level_waits",
-      "confidence_score": 1.0
+      "target": "didyouknow_explicit_waits_browser_level_waits"
     },
     {
       "relation": "contains",
@@ -40816,9 +40816,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md",
       "source_location": "L99",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_explicit_waits_md",
-      "target": "didyouknow_explicit_waits_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_explicit_waits_complete_example"
     },
     {
       "relation": "contains",
@@ -40826,9 +40826,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md",
       "source_location": "L145",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_explicit_waits_md",
-      "target": "didyouknow_explicit_waits_custom_condition_wait_lambda",
-      "confidence_score": 1.0
+      "target": "didyouknow_explicit_waits_custom_condition_wait_lambda"
     },
     {
       "relation": "contains",
@@ -40836,9 +40836,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_explicit_waits_md",
-      "target": "didyouknow_explicit_waits_element_level_waits",
-      "confidence_score": 1.0
+      "target": "didyouknow_explicit_waits_element_level_waits"
     },
     {
       "relation": "contains",
@@ -40846,9 +40846,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md",
       "source_location": "L200",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_explicit_waits_md",
-      "target": "didyouknow_explicit_waits_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_explicit_waits_related"
     },
     {
       "relation": "contains",
@@ -40946,9 +40946,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Integrate_JIRA_With_SHAFT_Engine.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_integrate_jira_with_shaft_engine_md",
-      "target": "didyouknow_integrate_jira_with_shaft_engine_integrate_jira_with_shaft_engine",
-      "confidence_score": 1.0
+      "target": "didyouknow_integrate_jira_with_shaft_engine_integrate_jira_with_shaft_engine"
     },
     {
       "relation": "contains",
@@ -40986,9 +40986,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_architecture_overview",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_architecture_overview"
     },
     {
       "relation": "contains",
@@ -40996,9 +40996,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L311",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_best_practices",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_best_practices"
     },
     {
       "relation": "contains",
@@ -41006,9 +41006,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L172",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_customizing_the_deployment",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_customizing_the_deployment"
     },
     {
       "relation": "contains",
@@ -41016,9 +41016,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L245",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_integrating_with_ci_cd",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_integrating_with_ci_cd"
     },
     {
       "relation": "contains",
@@ -41026,9 +41026,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L273",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_monitoring_and_scaling_behavior",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_monitoring_and_scaling_behavior"
     },
     {
       "relation": "contains",
@@ -41036,9 +41036,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L17",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_prerequisites",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_prerequisites"
     },
     {
       "relation": "contains",
@@ -41046,9 +41046,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L322",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_related_pages",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_related_pages"
     },
     {
       "relation": "contains",
@@ -41056,9 +41056,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_step_1_add_helm_repositories",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_step_1_add_helm_repositories"
     },
     {
       "relation": "contains",
@@ -41066,9 +41066,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_step_2_install_keda",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_step_2_install_keda"
     },
     {
       "relation": "contains",
@@ -41076,9 +41076,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L83",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_step_3_deploy_selenium_grid_with_auto_scaling",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_step_3_deploy_selenium_grid_with_auto_scaling"
     },
     {
       "relation": "contains",
@@ -41086,9 +41086,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L113",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_step_4_configure_shaft_to_use_the_kubernetes_grid",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_step_4_configure_shaft_to_use_the_kubernetes_grid"
     },
     {
       "relation": "contains",
@@ -41096,9 +41096,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md",
       "source_location": "L298",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_kubernetes_selenium_grid_md",
-      "target": "didyouknow_kubernetes_selenium_grid_teardown",
-      "confidence_score": 1.0
+      "target": "didyouknow_kubernetes_selenium_grid_teardown"
     },
     {
       "relation": "contains",
@@ -41176,9 +41176,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L488",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_additional_resources",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_additional_resources"
     },
     {
       "relation": "contains",
@@ -41186,9 +41186,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L443",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_best_practices",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_best_practices"
     },
     {
       "relation": "contains",
@@ -41196,9 +41196,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L468",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_combining_grid_with_parallel_execution",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_combining_grid_with_parallel_execution"
     },
     {
       "relation": "contains",
@@ -41206,9 +41206,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L189",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_configuring_shaft_for_local_grid",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_configuring_shaft_for_local_grid"
     },
     {
       "relation": "contains",
@@ -41216,9 +41216,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L284",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_grid_configuration_options",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_grid_configuration_options"
     },
     {
       "relation": "contains",
@@ -41226,9 +41226,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L320",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_monitoring_and_debugging",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_monitoring_and_debugging"
     },
     {
       "relation": "contains",
@@ -41236,9 +41236,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L24",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_prerequisites",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_prerequisites"
     },
     {
       "relation": "contains",
@@ -41246,9 +41246,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_setup_options",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_setup_options"
     },
     {
       "relation": "contains",
@@ -41256,9 +41256,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L371",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_troubleshooting",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_troubleshooting"
     },
     {
       "relation": "contains",
@@ -41266,9 +41266,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md",
       "source_location": "L17",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_local_selenium_grid_execution_md",
-      "target": "didyouknow_local_selenium_grid_execution_what_is_selenium_grid",
-      "confidence_score": 1.0
+      "target": "didyouknow_local_selenium_grid_execution_what_is_selenium_grid"
     },
     {
       "relation": "contains",
@@ -41506,9 +41506,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L146",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_best_practices",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_best_practices"
     },
     {
       "relation": "contains",
@@ -41516,9 +41516,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L104",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_complete_test_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_complete_test_example"
     },
     {
       "relation": "contains",
@@ -41526,9 +41526,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L57",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_custom_device_emulation",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_custom_device_emulation"
     },
     {
       "relation": "contains",
@@ -41536,9 +41536,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_overview",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_overview"
     },
     {
       "relation": "contains",
@@ -41546,9 +41546,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_preset_device_emulation",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_preset_device_emulation"
     },
     {
       "relation": "contains",
@@ -41556,9 +41556,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L155",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_related"
     },
     {
       "relation": "contains",
@@ -41566,9 +41566,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md",
       "source_location": "L86",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_mobile_emulation_md",
-      "target": "didyouknow_mobile_emulation_via_properties_file",
-      "confidence_score": 1.0
+      "target": "didyouknow_mobile_emulation_via_properties_file"
     },
     {
       "relation": "contains",
@@ -41586,9 +41586,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Native_selenium_Webdriver.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_native_selenium_webdriver_md",
-      "target": "didyouknow_native_selenium_webdriver_accessing_the_native_selenium_webdriver",
-      "confidence_score": 1.0
+      "target": "didyouknow_native_selenium_webdriver_accessing_the_native_selenium_webdriver"
     },
     {
       "relation": "contains",
@@ -41596,9 +41596,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Native_selenium_Webdriver.md",
       "source_location": "L66",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_native_selenium_webdriver_md",
-      "target": "didyouknow_native_selenium_webdriver_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_native_selenium_webdriver_related"
     },
     {
       "relation": "contains",
@@ -41606,9 +41606,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Native_selenium_Webdriver.md",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_native_selenium_webdriver_md",
-      "target": "didyouknow_native_selenium_webdriver_wrapping_an_existing_webdriver_instance",
-      "confidence_score": 1.0
+      "target": "didyouknow_native_selenium_webdriver_wrapping_an_existing_webdriver_instance"
     },
     {
       "relation": "contains",
@@ -41626,9 +41626,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L149",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_advanced_predicate_api",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_advanced_predicate_api"
     },
     {
       "relation": "contains",
@@ -41636,9 +41636,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L93",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_complete_example"
     },
     {
       "relation": "contains",
@@ -41646,9 +41646,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_mock_responses",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_mock_responses"
     },
     {
       "relation": "contains",
@@ -41656,9 +41656,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L170",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_related"
     },
     {
       "relation": "contains",
@@ -41666,9 +41666,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L72",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_request_matchers",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_request_matchers"
     },
     {
       "relation": "contains",
@@ -41676,9 +41676,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_use_cases",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_use_cases"
     },
     {
       "relation": "contains",
@@ -41686,9 +41686,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_network_mocking_md",
-      "target": "didyouknow_network_mocking_validate_real_responses",
-      "confidence_score": 1.0
+      "target": "didyouknow_network_mocking_validate_real_responses"
     },
     {
       "relation": "contains",
@@ -41696,9 +41696,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_self_healing_locators_md",
-      "target": "didyouknow_self_healing_locators_available_properties",
-      "confidence_score": 1.0
+      "target": "didyouknow_self_healing_locators_available_properties"
     },
     {
       "relation": "contains",
@@ -41706,9 +41706,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_self_healing_locators_md",
-      "target": "didyouknow_self_healing_locators_configuration",
-      "confidence_score": 1.0
+      "target": "didyouknow_self_healing_locators_configuration"
     },
     {
       "relation": "contains",
@@ -41716,9 +41716,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_self_healing_locators_md",
-      "target": "didyouknow_self_healing_locators_how_it_works",
-      "confidence_score": 1.0
+      "target": "didyouknow_self_healing_locators_how_it_works"
     },
     {
       "relation": "contains",
@@ -41726,9 +41726,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md",
       "source_location": "L123",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_self_healing_locators_md",
-      "target": "didyouknow_self_healing_locators_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_self_healing_locators_related"
     },
     {
       "relation": "contains",
@@ -41736,9 +41736,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md",
       "source_location": "L68",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_self_healing_locators_md",
-      "target": "didyouknow_self_healing_locators_usage_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_self_healing_locators_usage_example"
     },
     {
       "relation": "contains",
@@ -41746,9 +41746,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_basic_syntax",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_basic_syntax"
     },
     {
       "relation": "contains",
@@ -41756,9 +41756,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L142",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_combined_locator_conditions_inside_shadow_dom",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_combined_locator_conditions_inside_shadow_dom"
     },
     {
       "relation": "contains",
@@ -41766,9 +41766,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_interacting_with_form_inputs_in_shadow_dom",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_interacting_with_form_inputs_in_shadow_dom"
     },
     {
       "relation": "contains",
@@ -41776,9 +41776,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_nested_shadow_dom",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_nested_shadow_dom"
     },
     {
       "relation": "contains",
@@ -41786,9 +41786,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L177",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_related_locator_pages",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_related_locator_pages"
     },
     {
       "relation": "contains",
@@ -41796,9 +41796,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_single_level_shadow_dom",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_single_level_shadow_dom"
     },
     {
       "relation": "contains",
@@ -41806,9 +41806,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shadow_dom_locator_builder_md",
-      "target": "didyouknow_shadow_dom_locator_builder_why_shadow_dom_is_tricky",
-      "confidence_score": 1.0
+      "target": "didyouknow_shadow_dom_locator_builder_why_shadow_dom_is_tricky"
     },
     {
       "relation": "contains",
@@ -41816,9 +41816,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L27",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_available_builder_methods",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_available_builder_methods"
     },
     {
       "relation": "contains",
@@ -41826,9 +41826,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_basic_syntax",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_basic_syntax"
     },
     {
       "relation": "contains",
@@ -41836,9 +41836,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L129",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_complete_page_object_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_complete_page_object_example"
     },
     {
       "relation": "contains",
@@ -41846,9 +41846,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L43",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_examples",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_examples"
     },
     {
       "relation": "contains",
@@ -41856,9 +41856,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L193",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_related"
     },
     {
       "relation": "contains",
@@ -41866,9 +41866,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md",
       "source_location": "L176",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_shaft_locator_builder_md",
-      "target": "didyouknow_shaft_locator_builder_when_to_use_shaft_gui_locator_vs_xpath_css",
-      "confidence_score": 1.0
+      "target": "didyouknow_shaft_locator_builder_when_to_use_shaft_gui_locator_vs_xpath_css"
     },
     {
       "relation": "contains",
@@ -41936,9 +41936,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_smart_locators_md",
-      "target": "didyouknow_smart_locators_clickablefield_text",
-      "confidence_score": 1.0
+      "target": "didyouknow_smart_locators_clickablefield_text"
     },
     {
       "relation": "contains",
@@ -41946,9 +41946,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_smart_locators_md",
-      "target": "didyouknow_smart_locators_comparison_with_traditional_locators",
-      "confidence_score": 1.0
+      "target": "didyouknow_smart_locators_comparison_with_traditional_locators"
     },
     {
       "relation": "contains",
@@ -41956,9 +41956,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_smart_locators_md",
-      "target": "didyouknow_smart_locators_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_smart_locators_complete_example"
     },
     {
       "relation": "contains",
@@ -41966,9 +41966,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_smart_locators_md",
-      "target": "didyouknow_smart_locators_inputfield_label",
-      "confidence_score": 1.0
+      "target": "didyouknow_smart_locators_inputfield_label"
     },
     {
       "relation": "contains",
@@ -41976,9 +41976,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md",
       "source_location": "L111",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_smart_locators_md",
-      "target": "didyouknow_smart_locators_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_smart_locators_related"
     },
     {
       "relation": "contains",
@@ -41986,9 +41986,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_using_cookies_in_your_tests_md",
-      "target": "didyouknow_using_cookies_in_your_tests_api_login_to_browser_session",
-      "confidence_score": 1.0
+      "target": "didyouknow_using_cookies_in_your_tests_api_login_to_browser_session"
     },
     {
       "relation": "contains",
@@ -41996,9 +41996,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_using_cookies_in_your_tests_md",
-      "target": "didyouknow_using_cookies_in_your_tests_browser_login_to_api_session",
-      "confidence_score": 1.0
+      "target": "didyouknow_using_cookies_in_your_tests_browser_login_to_api_session"
     },
     {
       "relation": "contains",
@@ -42006,9 +42006,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_using_cookies_in_your_tests_md",
-      "target": "didyouknow_using_cookies_in_your_tests_manual_cookie_reuse",
-      "confidence_score": 1.0
+      "target": "didyouknow_using_cookies_in_your_tests_manual_cookie_reuse"
     },
     {
       "relation": "contains",
@@ -42016,9 +42016,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_using_cookies_in_your_tests_md",
-      "target": "didyouknow_using_cookies_in_your_tests_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_using_cookies_in_your_tests_related"
     },
     {
       "relation": "contains",
@@ -42026,9 +42026,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_visual_testing_md",
-      "target": "didyouknow_visual_testing_comparison_engines",
-      "confidence_score": 1.0
+      "target": "didyouknow_visual_testing_comparison_engines"
     },
     {
       "relation": "contains",
@@ -42036,9 +42036,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md",
       "source_location": "L58",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_visual_testing_md",
-      "target": "didyouknow_visual_testing_complete_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_visual_testing_complete_example"
     },
     {
       "relation": "contains",
@@ -42046,9 +42046,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_visual_testing_md",
-      "target": "didyouknow_visual_testing_matchesreferenceimage",
-      "confidence_score": 1.0
+      "target": "didyouknow_visual_testing_matchesreferenceimage"
     },
     {
       "relation": "contains",
@@ -42056,9 +42056,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md",
       "source_location": "L118",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_visual_testing_md",
-      "target": "didyouknow_visual_testing_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_visual_testing_related"
     },
     {
       "relation": "contains",
@@ -42066,9 +42066,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md",
       "source_location": "L106",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_visual_testing_md",
-      "target": "didyouknow_visual_testing_updating_baselines",
-      "confidence_score": 1.0
+      "target": "didyouknow_visual_testing_updating_baselines"
     },
     {
       "relation": "contains",
@@ -42096,9 +42096,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_common_use_cases",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_common_use_cases"
     },
     {
       "relation": "contains",
@@ -42106,9 +42106,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L42",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_complete_example_payment_form",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_complete_example_payment_form"
     },
     {
       "relation": "contains",
@@ -42116,9 +42116,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L76",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_full_test_example",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_full_test_example"
     },
     {
       "relation": "contains",
@@ -42126,9 +42126,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L132",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_related",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_related"
     },
     {
       "relation": "contains",
@@ -42136,9 +42136,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_switchtodefaultcontent",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_switchtodefaultcontent"
     },
     {
       "relation": "contains",
@@ -42146,9 +42146,9 @@
       "source_file": "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_gui_didyouknow_iframe_handling_md",
-      "target": "didyouknow_iframe_handling_switchtoiframe_by_locator",
-      "confidence_score": 1.0
+      "target": "didyouknow_iframe_handling_switchtoiframe_by_locator"
     },
     {
       "relation": "contains",
@@ -42156,9 +42156,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L658",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_best_practices_for_test_data_management",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_best_practices_for_test_data_management"
     },
     {
       "relation": "contains",
@@ -42166,9 +42166,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L760",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_common_use_cases",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_common_use_cases"
     },
     {
       "relation": "contains",
@@ -42176,9 +42176,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L641",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_comparison_of_test_data_formats",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_comparison_of_test_data_formats"
     },
     {
       "relation": "contains",
@@ -42186,9 +42186,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L152",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_csv_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_csv_test_data"
     },
     {
       "relation": "contains",
@@ -42196,9 +42196,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L264",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_excel_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_excel_test_data"
     },
     {
       "relation": "contains",
@@ -42206,9 +42206,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_json_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_json_test_data"
     },
     {
       "relation": "contains",
@@ -42216,9 +42216,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_overview",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_overview"
     },
     {
       "relation": "contains",
@@ -42226,9 +42226,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L408",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_properties_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_properties_test_data"
     },
     {
       "relation": "contains",
@@ -42236,9 +42236,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L944",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_related_documentation",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_related_documentation"
     },
     {
       "relation": "contains",
@@ -42246,9 +42246,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L923",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_summary",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_summary"
     },
     {
       "relation": "contains",
@@ -42256,9 +42256,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L881",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_troubleshooting",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_troubleshooting"
     },
     {
       "relation": "contains",
@@ -42266,9 +42266,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_why_use_external_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_why_use_external_test_data"
     },
     {
       "relation": "contains",
@@ -42276,9 +42276,9 @@
       "source_file": "docs/reference/actions/TestData_Management.md",
       "source_location": "L541",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_testdata_management_md",
-      "target": "actions_testdata_management_yaml_test_data",
-      "confidence_score": 1.0
+      "target": "actions_testdata_management_yaml_test_data"
     },
     {
       "relation": "contains",
@@ -42696,9 +42696,9 @@
       "source_file": "docs/reference/actions/Validations/Browser.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_browser_md",
-      "target": "validations_browser_attribute",
-      "confidence_score": 1.0
+      "target": "validations_browser_attribute"
     },
     {
       "relation": "contains",
@@ -42706,9 +42706,9 @@
       "source_file": "docs/reference/actions/Validations/Browser.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_browser_md",
-      "target": "validations_browser_related",
-      "confidence_score": 1.0
+      "target": "validations_browser_related"
     },
     {
       "relation": "contains",
@@ -42736,9 +42736,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_attribute",
-      "confidence_score": 1.0
+      "target": "validations_elements_attribute"
     },
     {
       "relation": "contains",
@@ -42746,9 +42746,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L83",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_cssproperty",
-      "confidence_score": 1.0
+      "target": "validations_elements_cssproperty"
     },
     {
       "relation": "contains",
@@ -42756,9 +42756,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_doesnotexist",
-      "confidence_score": 1.0
+      "target": "validations_elements_doesnotexist"
     },
     {
       "relation": "contains",
@@ -42766,9 +42766,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_doesnotmatchreferenceimage",
-      "confidence_score": 1.0
+      "target": "validations_elements_doesnotmatchreferenceimage"
     },
     {
       "relation": "contains",
@@ -42776,9 +42776,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_exists",
-      "confidence_score": 1.0
+      "target": "validations_elements_exists"
     },
     {
       "relation": "contains",
@@ -42786,9 +42786,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_matchesreferenceimage",
-      "confidence_score": 1.0
+      "target": "validations_elements_matchesreferenceimage"
     },
     {
       "relation": "contains",
@@ -42796,9 +42796,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L166",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_related",
-      "confidence_score": 1.0
+      "target": "validations_elements_related"
     },
     {
       "relation": "contains",
@@ -42806,9 +42806,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_state_validations",
-      "confidence_score": 1.0
+      "target": "validations_elements_state_validations"
     },
     {
       "relation": "contains",
@@ -42816,9 +42816,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_text",
-      "confidence_score": 1.0
+      "target": "validations_elements_text"
     },
     {
       "relation": "contains",
@@ -42826,9 +42826,9 @@
       "source_file": "docs/reference/actions/Validations/Elements.md",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_elements_md",
-      "target": "validations_elements_texttrimmed",
-      "confidence_score": 1.0
+      "target": "validations_elements_texttrimmed"
     },
     {
       "relation": "contains",
@@ -42916,9 +42916,9 @@
       "source_file": "docs/reference/actions/Validations/Files.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_files_md",
-      "target": "validations_files_checksum",
-      "confidence_score": 1.0
+      "target": "validations_files_checksum"
     },
     {
       "relation": "contains",
@@ -42926,9 +42926,9 @@
       "source_file": "docs/reference/actions/Validations/Files.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_files_md",
-      "target": "validations_files_content",
-      "confidence_score": 1.0
+      "target": "validations_files_content"
     },
     {
       "relation": "contains",
@@ -42936,9 +42936,9 @@
       "source_file": "docs/reference/actions/Validations/Files.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_files_md",
-      "target": "validations_files_doesnotexist",
-      "confidence_score": 1.0
+      "target": "validations_files_doesnotexist"
     },
     {
       "relation": "contains",
@@ -42946,9 +42946,9 @@
       "source_file": "docs/reference/actions/Validations/Files.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_files_md",
-      "target": "validations_files_exists",
-      "confidence_score": 1.0
+      "target": "validations_files_exists"
     },
     {
       "relation": "contains",
@@ -42956,9 +42956,9 @@
       "source_file": "docs/reference/actions/Validations/Files.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_files_md",
-      "target": "validations_files_related",
-      "confidence_score": 1.0
+      "target": "validations_files_related"
     },
     {
       "relation": "contains",
@@ -42966,9 +42966,9 @@
       "source_file": "docs/reference/actions/Validations/ForceFail.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_forcefail_md",
-      "target": "validations_forcefail_eager_execution",
-      "confidence_score": 1.0
+      "target": "validations_forcefail_eager_execution"
     },
     {
       "relation": "contains",
@@ -42976,9 +42976,9 @@
       "source_file": "docs/reference/actions/Validations/ForceFail.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_forcefail_md",
-      "target": "validations_forcefail_forcefail",
-      "confidence_score": 1.0
+      "target": "validations_forcefail_forcefail"
     },
     {
       "relation": "contains",
@@ -42986,9 +42986,9 @@
       "source_file": "docs/reference/actions/Validations/ForceFail.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_forcefail_md",
-      "target": "validations_forcefail_related",
-      "confidence_score": 1.0
+      "target": "validations_forcefail_related"
     },
     {
       "relation": "contains",
@@ -42996,9 +42996,9 @@
       "source_file": "docs/reference/actions/Validations/ForceFail.md",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_forcefail_md",
-      "target": "validations_forcefail_withcustomreportmessage",
-      "confidence_score": 1.0
+      "target": "validations_forcefail_withcustomreportmessage"
     },
     {
       "relation": "contains",
@@ -43006,9 +43006,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_complete_example",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_complete_example"
     },
     {
       "relation": "contains",
@@ -43016,9 +43016,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_creating_a_json_schema_file",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_creating_a_json_schema_file"
     },
     {
       "relation": "contains",
@@ -43026,9 +43026,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_doesnotmatchschema",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_doesnotmatchschema"
     },
     {
       "relation": "contains",
@@ -43036,9 +43036,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_matchesschema",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_matchesschema"
     },
     {
       "relation": "contains",
@@ -43046,9 +43046,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L151",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_related",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_related"
     },
     {
       "relation": "contains",
@@ -43056,9 +43056,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L123",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_schema_for_a_list_response",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_schema_for_a_list_response"
     },
     {
       "relation": "contains",
@@ -43066,9 +43066,9 @@
       "source_file": "docs/reference/actions/Validations/JSON_Schema_Validation.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_json_schema_validation_md",
-      "target": "validations_json_schema_validation_why_json_schema_validation",
-      "confidence_score": 1.0
+      "target": "validations_json_schema_validation_why_json_schema_validation"
     },
     {
       "relation": "contains",
@@ -43076,9 +43076,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_doesnotequal",
-      "confidence_score": 1.0
+      "target": "validations_nums_doesnotequal"
     },
     {
       "relation": "contains",
@@ -43086,9 +43086,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_isequalto",
-      "confidence_score": 1.0
+      "target": "validations_nums_isequalto"
     },
     {
       "relation": "contains",
@@ -43096,9 +43096,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_isgreaterthan",
-      "confidence_score": 1.0
+      "target": "validations_nums_isgreaterthan"
     },
     {
       "relation": "contains",
@@ -43106,9 +43106,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L37",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_isgreaterthanorequals",
-      "confidence_score": 1.0
+      "target": "validations_nums_isgreaterthanorequals"
     },
     {
       "relation": "contains",
@@ -43116,9 +43116,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L45",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_islessthan",
-      "confidence_score": 1.0
+      "target": "validations_nums_islessthan"
     },
     {
       "relation": "contains",
@@ -43126,9 +43126,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L53",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_islessthanorequals",
-      "confidence_score": 1.0
+      "target": "validations_nums_islessthanorequals"
     },
     {
       "relation": "contains",
@@ -43136,9 +43136,9 @@
       "source_file": "docs/reference/actions/Validations/Nums.md",
       "source_location": "L72",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_nums_md",
-      "target": "validations_nums_related",
-      "confidence_score": 1.0
+      "target": "validations_nums_related"
     },
     {
       "relation": "contains",
@@ -43146,9 +43146,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_contains",
-      "confidence_score": 1.0
+      "target": "validations_objects_contains"
     },
     {
       "relation": "contains",
@@ -43156,9 +43156,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L39",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_doesnotcontain",
-      "confidence_score": 1.0
+      "target": "validations_objects_doesnotcontain"
     },
     {
       "relation": "contains",
@@ -43166,9 +43166,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L21",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_doesnotequal",
-      "confidence_score": 1.0
+      "target": "validations_objects_doesnotequal"
     },
     {
       "relation": "contains",
@@ -43176,9 +43176,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_doesnotequalignoringcasesensitivity",
-      "confidence_score": 1.0
+      "target": "validations_objects_doesnotequalignoringcasesensitivity"
     },
     {
       "relation": "contains",
@@ -43186,9 +43186,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_doesnotmatchregex",
-      "confidence_score": 1.0
+      "target": "validations_objects_doesnotmatchregex"
     },
     {
       "relation": "contains",
@@ -43196,9 +43196,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_equalsignoringcasesensitivity",
-      "confidence_score": 1.0
+      "target": "validations_objects_equalsignoringcasesensitivity"
     },
     {
       "relation": "contains",
@@ -43206,9 +43206,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_isequalto",
-      "confidence_score": 1.0
+      "target": "validations_objects_isequalto"
     },
     {
       "relation": "contains",
@@ -43216,9 +43216,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L103",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_isfalse",
-      "confidence_score": 1.0
+      "target": "validations_objects_isfalse"
     },
     {
       "relation": "contains",
@@ -43226,9 +43226,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L87",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_isnotnull",
-      "confidence_score": 1.0
+      "target": "validations_objects_isnotnull"
     },
     {
       "relation": "contains",
@@ -43236,9 +43236,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L79",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_isnull",
-      "confidence_score": 1.0
+      "target": "validations_objects_isnull"
     },
     {
       "relation": "contains",
@@ -43246,9 +43246,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_istrue",
-      "confidence_score": 1.0
+      "target": "validations_objects_istrue"
     },
     {
       "relation": "contains",
@@ -43256,9 +43256,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L47",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_matchesregex",
-      "confidence_score": 1.0
+      "target": "validations_objects_matchesregex"
     },
     {
       "relation": "contains",
@@ -43266,9 +43266,9 @@
       "source_file": "docs/reference/actions/Validations/Objects.md",
       "source_location": "L120",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_objects_md",
-      "target": "validations_objects_related",
-      "confidence_score": 1.0
+      "target": "validations_objects_related"
     },
     {
       "relation": "contains",
@@ -43276,9 +43276,9 @@
       "source_file": "docs/reference/actions/Validations/Overview.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_overview_md",
-      "target": "validations_overview_assertions_vs_verifications",
-      "confidence_score": 1.0
+      "target": "validations_overview_assertions_vs_verifications"
     },
     {
       "relation": "contains",
@@ -43286,9 +43286,9 @@
       "source_file": "docs/reference/actions/Validations/Overview.md",
       "source_location": "L61",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_overview_md",
-      "target": "validations_overview_related",
-      "confidence_score": 1.0
+      "target": "validations_overview_related"
     },
     {
       "relation": "contains",
@@ -43296,9 +43296,9 @@
       "source_file": "docs/reference/actions/Validations/Overview.md",
       "source_location": "L19",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_overview_md",
-      "target": "validations_overview_supported_validation_targets",
-      "confidence_score": 1.0
+      "target": "validations_overview_supported_validation_targets"
     },
     {
       "relation": "contains",
@@ -43306,9 +43306,9 @@
       "source_file": "docs/reference/actions/Validations/Overview.md",
       "source_location": "L31",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_overview_md",
-      "target": "validations_overview_usage_patterns",
-      "confidence_score": 1.0
+      "target": "validations_overview_usage_patterns"
     },
     {
       "relation": "contains",
@@ -43336,9 +43336,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_containsfilecontent",
-      "confidence_score": 1.0
+      "target": "validations_response_containsfilecontent"
     },
     {
       "relation": "contains",
@@ -43346,9 +43346,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_doesnotcontainfilecontent",
-      "confidence_score": 1.0
+      "target": "validations_response_doesnotcontainfilecontent"
     },
     {
       "relation": "contains",
@@ -43356,9 +43356,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L25",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_doesnotequalfilecontent",
-      "confidence_score": 1.0
+      "target": "validations_response_doesnotequalfilecontent"
     },
     {
       "relation": "contains",
@@ -43366,9 +43366,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_doesnotmatchschema",
-      "confidence_score": 1.0
+      "target": "validations_response_doesnotmatchschema"
     },
     {
       "relation": "contains",
@@ -43376,9 +43376,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L49",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_extractedjsonvalue",
-      "confidence_score": 1.0
+      "target": "validations_response_extractedjsonvalue"
     },
     {
       "relation": "contains",
@@ -43386,9 +43386,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L63",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_extractedjsonvalueaslist",
-      "confidence_score": 1.0
+      "target": "validations_response_extractedjsonvalueaslist"
     },
     {
       "relation": "contains",
@@ -43396,9 +43396,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_isequaltofilecontent",
-      "confidence_score": 1.0
+      "target": "validations_response_isequaltofilecontent"
     },
     {
       "relation": "contains",
@@ -43406,9 +43406,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L71",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_matchesschema",
-      "confidence_score": 1.0
+      "target": "validations_response_matchesschema"
     },
     {
       "relation": "contains",
@@ -43416,9 +43416,9 @@
       "source_file": "docs/reference/actions/Validations/Response.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_response_md",
-      "target": "validations_response_related",
-      "confidence_score": 1.0
+      "target": "validations_response_related"
     },
     {
       "relation": "contains",
@@ -43426,9 +43426,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L62",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_comparison",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_comparison"
     },
     {
       "relation": "contains",
@@ -43436,9 +43436,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L73",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_complete_example",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_complete_example"
     },
     {
       "relation": "contains",
@@ -43446,9 +43446,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_hard_assertions_assertthat",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_hard_assertions_assertthat"
     },
     {
       "relation": "contains",
@@ -43456,9 +43456,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L121",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_related",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_related"
     },
     {
       "relation": "contains",
@@ -43466,9 +43466,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L28",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_soft_assertions_verifythat",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_soft_assertions_verifythat"
     },
     {
       "relation": "contains",
@@ -43476,9 +43476,9 @@
       "source_file": "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_actions_validations_soft_vs_hard_assertions_md",
-      "target": "validations_soft_vs_hard_assertions_standalone_validations",
-      "confidence_score": 1.0
+      "target": "validations_soft_vs_hard_assertions_standalone_validations"
     },
     {
       "relation": "contains",
@@ -43486,9 +43486,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_base_url_and_timeouts",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_base_url_and_timeouts"
     },
     {
       "relation": "contains",
@@ -43496,9 +43496,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_proxy",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_proxy"
     },
     {
       "relation": "contains",
@@ -43506,9 +43506,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L108",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_related",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_related"
     },
     {
       "relation": "contains",
@@ -43516,9 +43516,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L77",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_reliability_retries",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_reliability_retries"
     },
     {
       "relation": "contains",
@@ -43526,9 +43526,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L20",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_target_browser",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_target_browser"
     },
     {
       "relation": "contains",
@@ -43536,9 +43536,9 @@
       "source_file": "docs/reference/configuration/basicConfig.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig_md",
-      "target": "configuration_basicconfig_visual_reporting",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig_visual_reporting"
     },
     {
       "relation": "contains",
@@ -43546,9 +43546,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_android_native_app",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_android_native_app"
     },
     {
       "relation": "contains",
@@ -43556,9 +43556,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L78",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_browserstack_native_apps",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_browserstack_native_apps"
     },
     {
       "relation": "contains",
@@ -43566,9 +43566,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L19",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_common_properties_android_ios",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_common_properties_android_ios"
     },
     {
       "relation": "contains",
@@ -43576,9 +43576,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_ios_native_app",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_ios_native_app"
     },
     {
       "relation": "contains",
@@ -43586,9 +43586,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L101",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_mobile_web_browser_on_device",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_mobile_web_browser_on_device"
     },
     {
       "relation": "contains",
@@ -43596,9 +43596,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L138",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_related",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_related"
     },
     {
       "relation": "contains",
@@ -43606,9 +43606,9 @@
       "source_file": "docs/reference/configuration/basicConfig2.md",
       "source_location": "L116",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig2_md",
-      "target": "configuration_basicconfig2_shaft_mcp_mobile_automation",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig2_shaft_mcp_mobile_automation"
     },
     {
       "relation": "contains",
@@ -43616,9 +43616,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L29",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_automatic_status_code_check",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_automatic_status_code_check"
     },
     {
       "relation": "contains",
@@ -43626,9 +43626,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_connection_timeouts",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_connection_timeouts"
     },
     {
       "relation": "contains",
@@ -43636,9 +43636,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L40",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_proxy",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_proxy"
     },
     {
       "relation": "contains",
@@ -43646,9 +43646,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L88",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_related",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_related"
     },
     {
       "relation": "contains",
@@ -43656,9 +43656,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L59",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_swagger_openapi_contract_validation",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_swagger_openapi_contract_validation"
     },
     {
       "relation": "contains",
@@ -43666,9 +43666,9 @@
       "source_file": "docs/reference/configuration/basicConfig3.md",
       "source_location": "L50",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_basicconfig3_md",
-      "target": "configuration_basicconfig3_test_retries",
-      "confidence_score": 1.0
+      "target": "configuration_basicconfig3_test_retries"
     },
     {
       "relation": "contains",
@@ -43676,9 +43676,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L22",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_1_testng_parallel_execution",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_1_testng_parallel_execution"
     },
     {
       "relation": "contains",
@@ -43686,9 +43686,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L236",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_2_cross_browser_parallel_execution",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_2_cross_browser_parallel_execution"
     },
     {
       "relation": "contains",
@@ -43696,9 +43696,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L323",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_3_threadlocal_driver_pattern",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_3_threadlocal_driver_pattern"
     },
     {
       "relation": "contains",
@@ -43706,9 +43706,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L405",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_best_practices_and_tips",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_best_practices_and_tips"
     },
     {
       "relation": "contains",
@@ -43716,9 +43716,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L514",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_complete_configuration_example",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_complete_configuration_example"
     },
     {
       "relation": "contains",
@@ -43726,9 +43726,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_overview",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_overview"
     },
     {
       "relation": "contains",
@@ -43736,9 +43736,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L496",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_performance_comparison",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_performance_comparison"
     },
     {
       "relation": "contains",
@@ -43746,9 +43746,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L575",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_related_documentation",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_related_documentation"
     },
     {
       "relation": "contains",
@@ -43756,9 +43756,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L586",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_summary",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_summary"
     },
     {
       "relation": "contains",
@@ -43766,9 +43766,9 @@
       "source_file": "docs/reference/configuration/parallelExecution.md",
       "source_location": "L452",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_configuration_parallelexecution_md",
-      "target": "configuration_parallelexecution_troubleshooting",
-      "confidence_score": 1.0
+      "target": "configuration_parallelexecution_troubleshooting"
     },
     {
       "relation": "contains",
@@ -44146,9 +44146,9 @@
       "source_file": "docs/reference/guides/Architecture.md",
       "source_location": "L119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_architecture_md",
-      "target": "guides_architecture_architecture_decision_engine_vs_framework",
-      "confidence_score": 1.0
+      "target": "guides_architecture_architecture_decision_engine_vs_framework"
     },
     {
       "relation": "contains",
@@ -44156,9 +44156,9 @@
       "source_file": "docs/reference/guides/Architecture.md",
       "source_location": "L132",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_architecture_md",
-      "target": "guides_architecture_related",
-      "confidence_score": 1.0
+      "target": "guides_architecture_related"
     },
     {
       "relation": "contains",
@@ -44166,9 +44166,9 @@
       "source_file": "docs/reference/guides/Architecture.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_architecture_md",
-      "target": "guides_architecture_the_layers_of_test_automation",
-      "confidence_score": 1.0
+      "target": "guides_architecture_the_layers_of_test_automation"
     },
     {
       "relation": "contains",
@@ -44176,9 +44176,9 @@
       "source_file": "docs/reference/guides/Architecture.md",
       "source_location": "L34",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_architecture_md",
-      "target": "guides_architecture_what_each_layer_does",
-      "confidence_score": 1.0
+      "target": "guides_architecture_what_each_layer_does"
     },
     {
       "relation": "contains",
@@ -44186,9 +44186,9 @@
       "source_file": "docs/reference/guides/Architecture.md",
       "source_location": "L104",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_architecture_md",
-      "target": "guides_architecture_where_shaft_saves_you_work",
-      "confidence_score": 1.0
+      "target": "guides_architecture_where_shaft_saves_you_work"
     },
     {
       "relation": "contains",
@@ -44246,9 +44246,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L127",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_best_practices"
     },
     {
       "relation": "contains",
@@ -44256,9 +44256,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_example_bdd_style_test_with_allure",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_example_bdd_style_test_with_allure"
     },
     {
       "relation": "contains",
@@ -44266,9 +44266,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L139",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_related",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_related"
     },
     {
       "relation": "contains",
@@ -44276,9 +44276,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L30",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_the_allure_bdd_annotations",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_the_allure_bdd_annotations"
     },
     {
       "relation": "contains",
@@ -44286,9 +44286,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L109",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_what_the_report_looks_like",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_what_the_report_looks_like"
     },
     {
       "relation": "contains",
@@ -44296,9 +44296,9 @@
       "source_file": "docs/reference/guides/BDD_Style_Reports.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_bdd_style_reports_md",
-      "target": "guides_bdd_style_reports_why_allure_annotations_over_cucumber",
-      "confidence_score": 1.0
+      "target": "guides_bdd_style_reports_why_allure_annotations_over_cucumber"
     },
     {
       "relation": "contains",
@@ -44306,9 +44306,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_basic_pipeline_command",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_basic_pipeline_command"
     },
     {
       "relation": "contains",
@@ -44316,9 +44316,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L156",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_best_practices"
     },
     {
       "relation": "contains",
@@ -44326,9 +44326,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L56",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_github_actions_example",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_github_actions_example"
     },
     {
       "relation": "contains",
@@ -44336,9 +44336,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L91",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_jenkins_pipeline_example",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_jenkins_pipeline_example"
     },
     {
       "relation": "contains",
@@ -44346,9 +44346,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L140",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_parameterizing_for_multiple_environments",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_parameterizing_for_multiple_environments"
     },
     {
       "relation": "contains",
@@ -44356,9 +44356,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L35",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_recommended_ci_cd_properties",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_recommended_ci_cd_properties"
     },
     {
       "relation": "contains",
@@ -44366,9 +44366,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L165",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_related",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_related"
     },
     {
       "relation": "contains",
@@ -44376,9 +44376,9 @@
       "source_file": "docs/reference/guides/CI_CD_Integration.md",
       "source_location": "L122",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_ci_cd_integration_md",
-      "target": "guides_ci_cd_integration_running_specific_tests",
-      "confidence_score": 1.0
+      "target": "guides_ci_cd_integration_running_specific_tests"
     },
     {
       "relation": "contains",
@@ -44386,9 +44386,9 @@
       "source_file": "docs/reference/guides/Cross_Platform_Strategy.md",
       "source_location": "L120",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cross_platform_strategy_md",
-      "target": "guides_cross_platform_strategy_decision_guide",
-      "confidence_score": 1.0
+      "target": "guides_cross_platform_strategy_decision_guide"
     },
     {
       "relation": "contains",
@@ -44396,9 +44396,9 @@
       "source_file": "docs/reference/guides/Cross_Platform_Strategy.md",
       "source_location": "L132",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cross_platform_strategy_md",
-      "target": "guides_cross_platform_strategy_recommended_approach",
-      "confidence_score": 1.0
+      "target": "guides_cross_platform_strategy_recommended_approach"
     },
     {
       "relation": "contains",
@@ -44406,9 +44406,9 @@
       "source_file": "docs/reference/guides/Cross_Platform_Strategy.md",
       "source_location": "L140",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cross_platform_strategy_md",
-      "target": "guides_cross_platform_strategy_related",
-      "confidence_score": 1.0
+      "target": "guides_cross_platform_strategy_related"
     },
     {
       "relation": "contains",
@@ -44416,9 +44416,9 @@
       "source_file": "docs/reference/guides/Cross_Platform_Strategy.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cross_platform_strategy_md",
-      "target": "guides_cross_platform_strategy_same_project_when_and_why",
-      "confidence_score": 1.0
+      "target": "guides_cross_platform_strategy_same_project_when_and_why"
     },
     {
       "relation": "contains",
@@ -44426,9 +44426,9 @@
       "source_file": "docs/reference/guides/Cross_Platform_Strategy.md",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cross_platform_strategy_md",
-      "target": "guides_cross_platform_strategy_separate_projects_when_and_why",
-      "confidence_score": 1.0
+      "target": "guides_cross_platform_strategy_separate_projects_when_and_why"
     },
     {
       "relation": "contains",
@@ -44456,9 +44456,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L107",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_adding_custom_step_definitions",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_adding_custom_step_definitions"
     },
     {
       "relation": "contains",
@@ -44466,9 +44466,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L93",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_available_step_packages",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_available_step_packages"
     },
     {
       "relation": "contains",
@@ -44476,9 +44476,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_feature_file_examples",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_feature_file_examples"
     },
     {
       "relation": "contains",
@@ -44486,9 +44486,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_maven_dependency",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_maven_dependency"
     },
     {
       "relation": "contains",
@@ -44496,9 +44496,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L148",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_related",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_related"
     },
     {
       "relation": "contains",
@@ -44506,9 +44506,9 @@
       "source_file": "docs/reference/guides/Cucumber_BDD_Steps.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_cucumber_bdd_steps_md",
-      "target": "guides_cucumber_bdd_steps_test_runner_setup",
-      "confidence_score": 1.0
+      "target": "guides_cucumber_bdd_steps_test_runner_setup"
     },
     {
       "relation": "contains",
@@ -44536,9 +44536,9 @@
       "source_file": "docs/reference/guides/Element_Identification.md",
       "source_location": "L112",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_element_identification_md",
-      "target": "guides_element_identification_best_practices_summary",
-      "confidence_score": 1.0
+      "target": "guides_element_identification_best_practices_summary"
     },
     {
       "relation": "contains",
@@ -44546,9 +44546,9 @@
       "source_file": "docs/reference/guides/Element_Identification.md",
       "source_location": "L78",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_element_identification_md",
-      "target": "guides_element_identification_cross_platform_locators_android_and_ios",
-      "confidence_score": 1.0
+      "target": "guides_element_identification_cross_platform_locators_android_and_ios"
     },
     {
       "relation": "contains",
@@ -44556,9 +44556,9 @@
       "source_file": "docs/reference/guides/Element_Identification.md",
       "source_location": "L49",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_element_identification_md",
-      "target": "guides_element_identification_dynamic_element_identification",
-      "confidence_score": 1.0
+      "target": "guides_element_identification_dynamic_element_identification"
     },
     {
       "relation": "contains",
@@ -44566,9 +44566,9 @@
       "source_file": "docs/reference/guides/Element_Identification.md",
       "source_location": "L120",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_element_identification_md",
-      "target": "guides_element_identification_related",
-      "confidence_score": 1.0
+      "target": "guides_element_identification_related"
     },
     {
       "relation": "contains",
@@ -44576,9 +44576,9 @@
       "source_file": "docs/reference/guides/Element_Identification.md",
       "source_location": "L16",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_element_identification_md",
-      "target": "guides_element_identification_use_by_objects_not_findby",
-      "confidence_score": 1.0
+      "target": "guides_element_identification_use_by_objects_not_findby"
     },
     {
       "relation": "contains",
@@ -44606,9 +44606,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L92",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_best_practices"
     },
     {
       "relation": "contains",
@@ -44616,9 +44616,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L52",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_chaining_actions_with_validations",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_chaining_actions_with_validations"
     },
     {
       "relation": "contains",
@@ -44626,9 +44626,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L39",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_how_it_works",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_how_it_works"
     },
     {
       "relation": "contains",
@@ -44636,9 +44636,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L103",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_related",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_related"
     },
     {
       "relation": "contains",
@@ -44646,9 +44646,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_switching_between_action_types",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_switching_between_action_types"
     },
     {
       "relation": "contains",
@@ -44656,9 +44656,9 @@
       "source_file": "docs/reference/guides/Fluent_Design.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_fluent_design_md",
-      "target": "guides_fluent_design_why_fluent_design",
-      "confidence_score": 1.0
+      "target": "guides_fluent_design_why_fluent_design"
     },
     {
       "relation": "contains",
@@ -44666,9 +44666,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L128",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_class_level_driver_shared_instance",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_class_level_driver_shared_instance"
     },
     {
       "relation": "contains",
@@ -44676,9 +44676,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L115",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_junit_vs_testng_comparison",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_junit_vs_testng_comparison"
     },
     {
       "relation": "contains",
@@ -44686,9 +44686,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_maven_dependency",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_maven_dependency"
     },
     {
       "relation": "contains",
@@ -44696,9 +44696,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L181",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_related",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_related"
     },
     {
       "relation": "contains",
@@ -44706,9 +44706,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_runtime_registration",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_runtime_registration"
     },
     {
       "relation": "contains",
@@ -44716,9 +44716,9 @@
       "source_file": "docs/reference/guides/JUnit5_Integration.md",
       "source_location": "L74",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_junit5_integration_md",
-      "target": "guides_junit5_integration_test_class_structure",
-      "confidence_score": 1.0
+      "target": "guides_junit5_integration_test_class_structure"
     },
     {
       "relation": "contains",
@@ -44726,9 +44726,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L113",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_anonymous_inline_style",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_anonymous_inline_style"
     },
     {
       "relation": "contains",
@@ -44736,9 +44736,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_base_class_with_inheritance",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_base_class_with_inheritance"
     },
     {
       "relation": "contains",
@@ -44746,9 +44746,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L215",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_best_practices"
     },
     {
       "relation": "contains",
@@ -44756,9 +44756,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L188",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_combining_patterns",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_combining_patterns"
     },
     {
       "relation": "contains",
@@ -44766,9 +44766,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L60",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_fluent_page_object_method_chaining",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_fluent_page_object_method_chaining"
     },
     {
       "relation": "contains",
@@ -44776,9 +44776,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_page_object_model_pom",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_page_object_model_pom"
     },
     {
       "relation": "contains",
@@ -44786,9 +44786,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L177",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_pattern_comparison",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_pattern_comparison"
     },
     {
       "relation": "contains",
@@ -44796,9 +44796,9 @@
       "source_file": "docs/reference/guides/Solution_Design.md",
       "source_location": "L223",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_solution_design_md",
-      "target": "guides_solution_design_related",
-      "confidence_score": 1.0
+      "target": "guides_solution_design_related"
     },
     {
       "relation": "contains",
@@ -44906,9 +44906,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L149",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_best_practices"
     },
     {
       "relation": "contains",
@@ -44916,9 +44916,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L157",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_related",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_related"
     },
     {
       "relation": "contains",
@@ -44926,9 +44926,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_test_cases_isolated_and_independent",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_test_cases_isolated_and_independent"
     },
     {
       "relation": "contains",
@@ -44936,9 +44936,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L65",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_test_scenarios_dependent_steps",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_test_scenarios_dependent_steps"
     },
     {
       "relation": "contains",
@@ -44946,9 +44946,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L140",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_when_to_use_each_approach",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_when_to_use_each_approach"
     },
     {
       "relation": "contains",
@@ -44956,9 +44956,9 @@
       "source_file": "docs/reference/guides/Test_Structure.md",
       "source_location": "L119",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_test_structure_md",
-      "target": "guides_test_structure_why_not_use_priority",
-      "confidence_score": 1.0
+      "target": "guides_test_structure_why_not_use_priority"
     },
     {
       "relation": "contains",
@@ -44976,9 +44976,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L64",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_applying_the_pyramid_to_your_strategy",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_applying_the_pyramid_to_your_strategy"
     },
     {
       "relation": "contains",
@@ -44986,9 +44986,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L141",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_best_practices"
     },
     {
       "relation": "contains",
@@ -44996,9 +44996,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L149",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_related",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_related"
     },
     {
       "relation": "contains",
@@ -45006,9 +45006,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_the_pyramid",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_the_pyramid"
     },
     {
       "relation": "contains",
@@ -45016,9 +45016,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L123",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_where_shaft_fits_in_the_pyramid",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_where_shaft_fits_in_the_pyramid"
     },
     {
       "relation": "contains",
@@ -45026,9 +45026,9 @@
       "source_file": "docs/reference/guides/Testing_Pyramid.md",
       "source_location": "L33",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_testing_pyramid_md",
-      "target": "guides_testing_pyramid_why_the_pyramid_matters",
-      "confidence_score": 1.0
+      "target": "guides_testing_pyramid_why_the_pyramid_matters"
     },
     {
       "relation": "contains",
@@ -45096,9 +45096,9 @@
       "source_file": "docs/reference/guides/Tool_Selection.md",
       "source_location": "L117",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_tool_selection_md",
-      "target": "guides_tool_selection_best_practices",
-      "confidence_score": 1.0
+      "target": "guides_tool_selection_best_practices"
     },
     {
       "relation": "contains",
@@ -45106,9 +45106,9 @@
       "source_file": "docs/reference/guides/Tool_Selection.md",
       "source_location": "L102",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_tool_selection_md",
-      "target": "guides_tool_selection_comparison_at_a_glance",
-      "confidence_score": 1.0
+      "target": "guides_tool_selection_comparison_at_a_glance"
     },
     {
       "relation": "contains",
@@ -45116,9 +45116,9 @@
       "source_file": "docs/reference/guides/Tool_Selection.md",
       "source_location": "L14",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_tool_selection_md",
-      "target": "guides_tool_selection_key_selection_criteria",
-      "confidence_score": 1.0
+      "target": "guides_tool_selection_key_selection_criteria"
     },
     {
       "relation": "contains",
@@ -45126,9 +45126,9 @@
       "source_file": "docs/reference/guides/Tool_Selection.md",
       "source_location": "L124",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_guides_tool_selection_md",
-      "target": "guides_tool_selection_related",
-      "confidence_score": 1.0
+      "target": "guides_tool_selection_related"
     },
     {
       "relation": "contains",
@@ -45216,9 +45216,9 @@
       "source_file": "docs/reference/overview.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_overview_md",
-      "target": "reference_overview_reference",
-      "confidence_score": 1.0
+      "target": "reference_overview_reference"
     },
     {
       "relation": "contains",
@@ -45236,9 +45236,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L457",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_10_screenshot_and_video_recording_configuration",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_10_screenshot_and_video_recording_configuration"
     },
     {
       "relation": "contains",
@@ -45246,9 +45246,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L15",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_1_run_tests_in_headless_mode_on_firefox_browser",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_1_run_tests_in_headless_mode_on_firefox_browser"
     },
     {
       "relation": "contains",
@@ -45256,9 +45256,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L51",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_2_run_tests_on_chrome_with_mobile_emulation",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_2_run_tests_on_chrome_with_mobile_emulation"
     },
     {
       "relation": "contains",
@@ -45266,9 +45266,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L87",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_3_remote_execution_on_selenium_grid",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_3_remote_execution_on_selenium_grid"
     },
     {
       "relation": "contains",
@@ -45276,9 +45276,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_4_browserstack_execution",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_4_browserstack_execution"
     },
     {
       "relation": "contains",
@@ -45286,9 +45286,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L189",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_5_native_mobile_app_testing_android",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_5_native_mobile_app_testing_android"
     },
     {
       "relation": "contains",
@@ -45296,9 +45296,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L250",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_6_mobile_web_testing",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_6_mobile_web_testing"
     },
     {
       "relation": "contains",
@@ -45306,9 +45306,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L333",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_7_enable_maximum_performance_mode",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_7_enable_maximum_performance_mode"
     },
     {
       "relation": "contains",
@@ -45316,9 +45316,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L370",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_8_cross_browser_testing",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_8_cross_browser_testing"
     },
     {
       "relation": "contains",
@@ -45326,9 +45326,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L416",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_example_9_api_testing_with_swagger_validation_and_openapi_coverage",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_example_9_api_testing_with_swagger_validation_and_openapi_coverage"
     },
     {
       "relation": "contains",
@@ -45336,9 +45336,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L506",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_more_resources",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_more_resources"
     },
     {
       "relation": "contains",
@@ -45346,9 +45346,9 @@
       "source_file": "docs/reference/properties/CommonExamples.mdx",
       "source_location": "L512",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_commonexamples_mdx",
-      "target": "properties_commonexamples_related",
-      "confidence_score": 1.0
+      "target": "properties_commonexamples_related"
     },
     {
       "relation": "contains",
@@ -45356,9 +45356,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L55",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_behaviour_flags",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_behaviour_flags"
     },
     {
       "relation": "contains",
@@ -45366,9 +45366,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L80",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_complete_example",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_complete_example"
     },
     {
       "relation": "contains",
@@ -45376,9 +45376,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L131",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_dynamic_configuration_use_case",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_dynamic_configuration_use_case"
     },
     {
       "relation": "contains",
@@ -45386,9 +45386,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L67",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_reading_current_values",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_reading_current_values"
     },
     {
       "relation": "contains",
@@ -45396,9 +45396,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L154",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_related",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_related"
     },
     {
       "relation": "contains",
@@ -45406,9 +45406,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L32",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_timeout_properties",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_timeout_properties"
     },
     {
       "relation": "contains",
@@ -45416,9 +45416,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L44",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_visual_reporting_properties",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_visual_reporting_properties"
     },
     {
       "relation": "contains",
@@ -45426,9 +45426,9 @@
       "source_file": "docs/reference/properties/Programmatic_Config.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_programmatic_config_md",
-      "target": "properties_programmatic_config_web_browser_properties",
-      "confidence_score": 1.0
+      "target": "properties_programmatic_config_web_browser_properties"
     },
     {
       "relation": "contains",
@@ -45686,9 +45686,9 @@
       "source_file": "docs/reference/properties/PropertyTypes.md",
       "source_location": "L95",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_propertytypes_md",
-      "target": "properties_propertytypes_cli_based",
-      "confidence_score": 1.0
+      "target": "properties_propertytypes_cli_based"
     },
     {
       "relation": "contains",
@@ -45696,9 +45696,9 @@
       "source_file": "docs/reference/properties/PropertyTypes.md",
       "source_location": "L41",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_propertytypes_md",
-      "target": "properties_propertytypes_code_based",
-      "confidence_score": 1.0
+      "target": "properties_propertytypes_code_based"
     },
     {
       "relation": "contains",
@@ -45706,9 +45706,9 @@
       "source_file": "docs/reference/properties/PropertyTypes.md",
       "source_location": "L18",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_propertytypes_md",
-      "target": "properties_propertytypes_file_based",
-      "confidence_score": 1.0
+      "target": "properties_propertytypes_file_based"
     },
     {
       "relation": "contains",
@@ -45716,9 +45716,9 @@
       "source_file": "docs/reference/properties/PropertyTypes.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_propertytypes_md",
-      "target": "properties_propertytypes_priority_hierarchy",
-      "confidence_score": 1.0
+      "target": "properties_propertytypes_priority_hierarchy"
     },
     {
       "relation": "contains",
@@ -45726,9 +45726,9 @@
       "source_file": "docs/reference/properties/PropertyTypes.md",
       "source_location": "L112",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_propertytypes_md",
-      "target": "properties_propertytypes_related",
-      "confidence_score": 1.0
+      "target": "properties_propertytypes_related"
     },
     {
       "relation": "contains",
@@ -45736,9 +45736,9 @@
       "source_file": "docs/reference/properties/custom-properties-generator.mdx",
       "source_location": "L26",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_properties_custom_properties_generator_mdx",
-      "target": "properties_custom_properties_generator_related",
-      "confidence_score": 1.0
+      "target": "properties_custom_properties_generator_related"
     },
     {
       "relation": "contains",
@@ -45746,9 +45746,9 @@
       "source_file": "docs/reference/reporting/Custom_Report_Messages.md",
       "source_location": "L171",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_reporting_custom_report_messages_md",
-      "target": "reporting_custom_report_messages_best_practices",
-      "confidence_score": 1.0
+      "target": "reporting_custom_report_messages_best_practices"
     },
     {
       "relation": "contains",
@@ -45756,9 +45756,9 @@
       "source_file": "docs/reference/reporting/Custom_Report_Messages.md",
       "source_location": "L136",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_reporting_custom_report_messages_md",
-      "target": "reporting_custom_report_messages_combining_both_approaches",
-      "confidence_score": 1.0
+      "target": "reporting_custom_report_messages_combining_both_approaches"
     },
     {
       "relation": "contains",
@@ -45766,9 +45766,9 @@
       "source_file": "docs/reference/reporting/Custom_Report_Messages.md",
       "source_location": "L17",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_reporting_custom_report_messages_md",
-      "target": "reporting_custom_report_messages_custom_messages_on_validations",
-      "confidence_score": 1.0
+      "target": "reporting_custom_report_messages_custom_messages_on_validations"
     },
     {
       "relation": "contains",
@@ -45776,9 +45776,9 @@
       "source_file": "docs/reference/reporting/Custom_Report_Messages.md",
       "source_location": "L181",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_reporting_custom_report_messages_md",
-      "target": "reporting_custom_report_messages_related_pages",
-      "confidence_score": 1.0
+      "target": "reporting_custom_report_messages_related_pages"
     },
     {
       "relation": "contains",
@@ -45786,9 +45786,9 @@
       "source_file": "docs/reference/reporting/Custom_Report_Messages.md",
       "source_location": "L85",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_reference_reporting_custom_report_messages_md",
-      "target": "reporting_custom_report_messages_shaft_report_programmatic_api",
-      "confidence_score": 1.0
+      "target": "reporting_custom_report_messages_shaft_report_programmatic_api"
     },
     {
       "relation": "contains",
@@ -45986,9 +45986,9 @@
       "source_file": "docs/reference/reporting/reporting.mdx",
       "source_location": "L38",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "reporting_reporting_allure_report",
-      "target": "reporting_reporting_failure_trace_viewer",
-      "confidence_score": 1.0
+      "target": "reporting_reporting_failure_trace_viewer"
     },
     {
       "relation": "contains",
@@ -46106,9 +46106,9 @@
       "source_file": "docs/start/installation.mdx",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_start_installation_mdx",
-      "target": "start_installation_install_shaft",
-      "confidence_score": 1.0
+      "target": "start_installation_install_shaft"
     },
     {
       "relation": "contains",
@@ -46156,9 +46156,9 @@
       "source_file": "docs/start/overview.mdx",
       "source_location": "L13",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_start_overview_mdx",
-      "target": "start_overview_one_engine_every_test_surface",
-      "confidence_score": 1.0
+      "target": "start_overview_one_engine_every_test_surface"
     },
     {
       "relation": "contains",
@@ -46206,9 +46206,9 @@
       "source_file": "docs/start/quick-start.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_start_quick_start_md",
-      "target": "start_quick_start_quick_start",
-      "confidence_score": 1.0
+      "target": "start_quick_start_quick_start"
     },
     {
       "relation": "contains",
@@ -46316,9 +46316,9 @@
       "source_file": "docs/start/upgrade.mdx",
       "source_location": "L12",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_start_upgrade_mdx",
-      "target": "start_upgrade_upgrade_to_modular_shaft",
-      "confidence_score": 1.0
+      "target": "start_upgrade_upgrade_to_modular_shaft"
     },
     {
       "relation": "contains",
@@ -46736,9 +46736,9 @@
       "source_file": "docs/superpowers/plans/2026-06-24-flakiness-guide.md",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_superpowers_plans_2026_06_24_flakiness_guide_md",
-      "target": "plans_2026_06_24_flakiness_guide_flakiness_guide_implementation_plan",
-      "confidence_score": 1.0
+      "target": "plans_2026_06_24_flakiness_guide_flakiness_guide_implementation_plan"
     },
     {
       "relation": "contains",
@@ -46756,9 +46756,9 @@
       "source_file": "docs/superpowers/plans/2026-06-24-test-automation-pillars-guide.md",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_superpowers_plans_2026_06_24_test_automation_pillars_guide_md",
-      "target": "plans_2026_06_24_test_automation_pillars_guide_test_automation_pillars_guide_implementation_plan",
-      "confidence_score": 1.0
+      "target": "plans_2026_06_24_test_automation_pillars_guide_test_automation_pillars_guide_implementation_plan"
     },
     {
       "relation": "contains",
@@ -46796,9 +46796,9 @@
       "source_file": "docs/testing/api.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_api_mdx",
-      "target": "testing_api_api_testing",
-      "confidence_score": 1.0
+      "target": "testing_api_api_testing"
     },
     {
       "relation": "contains",
@@ -46816,9 +46816,9 @@
       "source_file": "docs/testing/cli.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_cli_md",
-      "target": "testing_cli_cli_testing",
-      "confidence_score": 1.0
+      "target": "testing_cli_cli_testing"
     },
     {
       "relation": "contains",
@@ -46836,9 +46836,9 @@
       "source_file": "docs/testing/database.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_database_md",
-      "target": "testing_database_database_testing",
-      "confidence_score": 1.0
+      "target": "testing_database_database_testing"
     },
     {
       "relation": "contains",
@@ -46856,9 +46856,9 @@
       "source_file": "docs/testing/flakiness.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_flakiness_mdx",
-      "target": "testing_flakiness_how_shaft_reduces_flakiness",
-      "confidence_score": 1.0
+      "target": "testing_flakiness_how_shaft_reduces_flakiness"
     },
     {
       "relation": "contains",
@@ -46926,9 +46926,9 @@
       "source_file": "docs/testing/mobile.md",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_mobile_md",
-      "target": "testing_mobile_mobile_and_flutter_testing",
-      "confidence_score": 1.0
+      "target": "testing_mobile_mobile_and_flutter_testing"
     },
     {
       "relation": "contains",
@@ -47246,9 +47246,9 @@
       "source_file": "docs/testing/web.mdx",
       "source_location": "L10",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "c_users_mohab_appdata_local_temp_shaft_graphify_296d0974617c4a82be15489de85d7b02_shafthq_github_io_docs_testing_web_mdx",
-      "target": "testing_web_web_testing",
-      "confidence_score": 1.0
+      "target": "testing_web_web_testing"
     },
     {
       "relation": "contains",
@@ -47272,5 +47272,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "76b30cf20e5dc63c39fa1c8c253fb86b9b32aec1"
+  "built_at_commit": "3b9fb8b5a130a66d9210f5b48eed63dd93c30d96"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -460,8 +460,8 @@
     "semantic_hash": ""
   },
   "docs/agentic/doctor.mdx": {
-    "mtime": 1782378881.905576,
-    "ast_hash": "0c33fef73b4989c9a2d746a68d30a71c",
+    "mtime": 1782387866.3880603,
+    "ast_hash": "05fda173d3df228004cdf685ecaac1bc",
     "semantic_hash": ""
   },
   "docs/agentic/examples.md": {
@@ -620,8 +620,8 @@
     "semantic_hash": ""
   },
   "docs/features/reporting.md": {
-    "mtime": 1782378881.9045756,
-    "ast_hash": "5a4298d7b11ef254e3aff078a3fc4efb",
+    "mtime": 1782388333.9456935,
+    "ast_hash": "9b926b2cb24adccd237ed71d28d3309e",
     "semantic_hash": ""
   },
   "docs/features/technology.md": {
@@ -1055,8 +1055,8 @@
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertiesList.mdx": {
-    "mtime": 1782378881.9075775,
-    "ast_hash": "63bd99708dd1331242994cf34b2ef09b",
+    "mtime": 1782387941.738113,
+    "ast_hash": "5984a721136306a8e4d90cc839408e7c",
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertyTypes.md": {
@@ -1075,8 +1075,8 @@
     "semantic_hash": ""
   },
   "docs/reference/reporting/reporting.mdx": {
-    "mtime": 1782374589.650254,
-    "ast_hash": "b85b63ff2973e8f753bf7ae93f466cfc",
+    "mtime": 1782388333.9466934,
+    "ast_hash": "302c964170abb4ad7be27720b8e5aa89",
     "semantic_hash": ""
   },
   "docs/start/installation.mdx": {


### PR DESCRIPTION
Docs for ShaftHQ/SHAFT_ENGINE#3067.

Summary:
- Document the new shaft.locatorHealth.* settings, scoring, selector smells, recommendations, Allure attachments, and trace JSON snapshot.
- Update reporting guides, reporting reference, properties catalog, and graphify output.

Validation:
- yarn test
- yarn typecheck
- yarn build
- yarn test:playwright
- git diff --check