### PR TITLE
docs: add guide pathfinder to user guide landing

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -366,6 +366,12 @@
   padding: clamp(4rem, 8vw, 7rem) 0;
 }
 
+.pathSection {
+  background:
+    linear-gradient(90deg, rgba(var(--site-color-primary-rgb), 0.07), transparent 58%),
+    var(--ifm-background-color);
+}
+
 .sectionHeading {
   max-width: 760px;
   margin-bottom: 2.5rem;
@@ -385,6 +391,63 @@
 .agentIntro p {
   color: var(--ifm-font-color-base);
   font-size: var(--site-font-body);
+}
+
+.pathGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.pathCard {
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  padding: 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-top: 4px solid var(--site-color-primary);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  box-shadow: 0 14px 34px rgba(var(--site-color-deep-alt-rgb), 0.06);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.pathCard:hover {
+  border-color: var(--site-color-primary);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  transform: translateY(-3px);
+  box-shadow: 0 20px 45px rgba(var(--site-color-deep-alt-rgb), 0.1);
+}
+
+.pathCard small {
+  margin-bottom: 0.85rem;
+  color: var(--site-color-primary);
+  font-size: var(--site-font-caption);
+  font-weight: var(--site-font-weight-bold);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.pathCard strong {
+  margin-bottom: 0.75rem;
+  font-size: var(--site-font-card-title-md);
+  font-weight: var(--site-font-weight-bold);
+}
+
+.pathCard span {
+  flex: 1;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.pathCard em {
+  margin-top: 1.2rem;
+  color: var(--site-color-primary);
+  font-size: var(--site-font-label);
+  font-style: normal;
+  font-weight: var(--site-font-weight-bold);
 }
 
 .decisionGrid {
@@ -834,6 +897,10 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .pathGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .surfaceMapPanel {
     grid-template-columns: 1fr;
   }
@@ -912,6 +979,14 @@
     grid-template-columns: 1fr;
   }
 
+  .pathGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pathCard {
+    min-height: 210px;
+  }
+
   .heroChecklist {
     grid-template-columns: 1fr;
   }
@@ -959,6 +1034,7 @@
   .surfaceCard,
   .surfaceLane,
   .proofCard,
+  .pathCard,
   .heroEngineStrip a {
     transition: none;
   }
@@ -966,6 +1042,7 @@
   .surfaceCard:hover,
   .surfaceLane:hover,
   .proofCard:hover,
+  .pathCard:hover,
   .heroEngineStrip a:hover {
     transform: none;
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -112,6 +112,37 @@ const onboardingSteps = [
   },
 ];
 
+const guidePaths = [
+  {
+    audience: 'First run',
+    title: 'Generate a runnable project',
+    description: 'Install SHAFT, create a Maven project, and run one passing web flow.',
+    label: 'Open installation',
+    to: '/docs/start/installation',
+  },
+  {
+    audience: 'Migration',
+    title: 'Compare native-engine fit',
+    description: 'Keep Selenium, Appium, Playwright browser, REST Assured, TestNG, JUnit, and Cucumber choices visible while evaluating framework tradeoffs.',
+    label: 'Open technology map',
+    to: '/docs/features/technology',
+  },
+  {
+    audience: 'Expansion',
+    title: 'Add coverage beyond the browser',
+    description: 'Connect mobile, API, database, CLI, Grid, and reporting guides around one evidence model.',
+    label: 'Review surfaces',
+    to: '#testing-surfaces',
+  },
+  {
+    audience: 'Agentic',
+    title: 'Connect MCP after the basics',
+    description: 'Expose browser, Capture, Doctor, and Heal tools to agents after the suite has deterministic evidence.',
+    label: 'Set up MCP',
+    to: '/docs/agentic/mcp',
+  },
+];
+
 const stackPills = [
   'Selenium WebDriver',
   'Playwright browser',
@@ -316,6 +347,33 @@ driver.browser().navigateToURL("https://duckduckgo.com/")
         </div>
       </div>
     </header>
+  );
+}
+
+function GuidePathSection(): JSX.Element {
+  return (
+    <section className={`${styles.section} ${styles.pathSection}`} data-testid="landing-pathfinder" id="guide-paths">
+      <div className="container">
+        <div className={styles.sectionHeading}>
+          <span className={styles.eyebrow}>Pick the work in front of you</span>
+          <Heading as="h2" id="guide-paths-heading">Land on the guide path that matches your suite.</Heading>
+          <p>
+            Choose the next decision: first run, migration research, broader coverage,
+            or AI-assisted triage.
+          </p>
+        </div>
+        <div className={styles.pathGrid} aria-labelledby="guide-paths-heading">
+          {guidePaths.map((path) => (
+            <Link className={styles.pathCard} to={path.to} key={path.title}>
+              <small>{path.audience}</small>
+              <strong>{path.title}</strong>
+              <span>{path.description}</span>
+              <em>{path.label}</em>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -529,6 +587,7 @@ export default function Home(): JSX.Element {
     >
       <Hero />
       <main data-testid="landing-main">
+        <GuidePathSection />
         <ProofSection />
         <SurfaceSection />
         <ComparisonSection />

--- a/tests/e2e/homepage.spec.js
+++ b/tests/e2e/homepage.spec.js
@@ -31,6 +31,10 @@ test('landing page exposes clear onboarding links with stable hooks', async ({pa
 
   await page.goto('/');
   await expect(onboardingSteps).toHaveCount(4);
+  const pathfinder = page.getByTestId('landing-pathfinder');
+  await expect(pathfinder).toBeVisible();
+  await expect(pathfinder.getByRole('link', {name: /Generate a runnable project/})).toHaveAttribute('href', '/docs/start/installation');
+  await expect(pathfinder.getByRole('link', {name: /Review surfaces/})).toHaveAttribute('href', '#testing-surfaces');
   await expect(page.getByTestId('hero-onboarding-step-3')).toBeVisible();
   await expect(page.getByTestId('hero-onboarding-step-4')).toBeVisible();
   await expect(page.getByTestId('landing-cta-install')).toHaveAttribute('href', '/docs/start/installation');

--- a/tests/homepage-performance.test.js
+++ b/tests/homepage-performance.test.js
@@ -37,6 +37,7 @@ assert(
 assert(index.includes('Maven Central'), 'Homepage claims must link to evidence.');
 assert(!index.includes('40,000'), 'Homepage must not contain unsupported adoption claims.');
 assert(index.includes('data-testid="landing-hero"'), 'Homepage must expose a stable hero test hook.');
+assert(index.includes('data-testid="landing-pathfinder"'), 'Homepage must expose a guide pathfinder hook.');
 assert(index.includes('data-testid="landing-comparison"'), 'Homepage must expose comparison-section test hooks.');
 assert(index.includes('data-testid="landing-agent"'), 'Homepage must expose an agent-section test hook.');
 assert(index.includes('data-testid="landing-final"'), 'Homepage must expose final CTA test hook.');
@@ -50,6 +51,7 @@ assert(index.includes('hero-onboarding-step-2'), 'Landing hero should expose onb
 assert(index.includes('hero-onboarding-step-3'), 'Landing hero should expose onboarding step 3 hook.');
 assert(index.includes('hero-onboarding-step-4'), 'Landing hero should expose onboarding step 4 hook.');
 assert(index.includes('id="proof-section"'), 'Landing proof section must expose a stable anchor.');
+assert(index.includes('id="guide-paths"'), 'Landing guide path section must expose a stable anchor.');
 assert(index.includes('id="surface-section"'), 'Landing surface section must expose a stable anchor.');
 assert(index.includes('id="comparison-section"'), 'Landing comparison section must expose a stable anchor.');
 assert(index.includes('id="workflow-section"'), 'Landing workflow section must expose a stable anchor.');


### PR DESCRIPTION
## Summary
- Add a Creative Production-informed guide pathfinder after the hero so visitors can choose by intent: first run, migration, expansion, or agentic triage.
- Add responsive card styling and homepage assertions for the new section and its key links.

## Validation
- `npm run test:homepage`
- `npm run typecheck`
- `npm run test`
- `npm run build` (passes; existing warnings about untruncated blog posts and missing `GEMINI_API_KEY` log remain)
- `npm run test:playwright`
- Browser QA on `http://127.0.0.1:3000/`: desktop and mobile pathfinder render, no console warnings, no horizontal overflow, `Review surfaces` lands on `#testing-surfaces`.

## Graphify
- Attempted `graphify . --update`; blocked because the CLI detected semantic corpus changes and no `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or other supported graphify backend key was configured. Worktree stayed clean.