### PR TITLE
Document flake profiler reporting

### DIFF
--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -133,6 +133,30 @@ a score threshold only after the suite has a stable baseline. The older
 viewer is enabled, failed-test trace JSON also includes the current locator
 health snapshot.
 
+## Flake and auto-wait profiler
+
+Enable the flake profiler when you need action-level timing in Allure without
+turning every wait into custom test code.
+
+```properties title="src/main/resources/properties/custom.properties"
+shaft.flakeProfiler.enabled=true
+shaft.flakeProfiler.attachPerTest=true
+shaft.flakeProfiler.failOnSevereFlakeRisk=false
+shaft.flakeProfiler.slowActionThresholdMs=2000
+```
+
+When enabled, SHAFT attaches `flake-profile.json` and `Flake Profile` HTML to
+Allure for tests that produce profiler signals. The profile records element
+actions, assertions, verifications, retry attempts, locator lookup counts,
+match counts, wait polling loops, stale/healing signals, and slow or wait-heavy
+actions. Screenshot capture, page snapshots, and report attachment time are
+tracked as evidence costs so element action duration is not inflated by report
+generation.
+
+Keep `shaft.flakeProfiler.failOnSevereFlakeRisk=false` while establishing a
+baseline. Turn it on only after the suite has known thresholds for slow,
+wait-heavy, stale, healed, or failing actions.
+
 ## Related
 
 - [Architecture](/docs/features/architecture)

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -500,6 +500,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   var captureElementName = SHAFT.Properties.reporting.captureElementName();
   var locatorHealthEnabled = SHAFT.Properties.reporting.locatorHealthEnabled();
   var locatorHealthWarnBelowScore = SHAFT.Properties.reporting.locatorHealthWarnBelowScore();
+  var flakeProfilerEnabled = SHAFT.Properties.reporting.flakeProfilerEnabled();
   var diagnosticsBundleEnabled = SHAFT.Properties.reporting.diagnosticsBundleEnabled();
   var traceMode = SHAFT.Properties.reporting.traceMode();
 
@@ -512,6 +513,10 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
       .locatorHealthFailBelowScore(-1)
       .slowLocatorThresholdMillis(750)
       .failOnLocatorHealthWarnings(false)
+      .flakeProfilerEnabled(true)
+      .flakeProfilerAttachPerTest(true)
+      .flakeProfilerFailOnSevereFlakeRisk(false)
+      .flakeProfilerSlowActionThresholdMs(2000)
       .diagnosticsBundleEnabled(true)
       .diagnosticsMaxArtifactMb(50)
       .traceEnabled(true)
@@ -541,6 +546,10 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | shaft.locatorHealth.failBelowScore            | `-1`          | `-1` or `0` to `100` | • Fail the run when any locator score is below this threshold; `-1` disables score-based failure. |
 | slowLocatorThresholdMillis                    | `750`         | Integer milliseconds | • Mark locator lookups at or above this duration as slow warnings. |
 | failOnLocatorHealthWarnings                   | `false`       | `true`, `false` | • Fail the run when locator health warnings are present. |
+| shaft.flakeProfiler.enabled                   | `false`       | `true`, `false` | • Attach opt-in flake and auto-wait timing profiles to Allure. |
+| shaft.flakeProfiler.attachPerTest             | `true`        | `true`, `false` | • Attach each test's JSON/HTML profile when profiler signals exist. |
+| shaft.flakeProfiler.failOnSevereFlakeRisk     | `false`       | `true`, `false` | • Fail the run when severe flake-risk actions are found. |
+| shaft.flakeProfiler.slowActionThresholdMs     | `2000`        | Integer milliseconds | • Duration threshold used to flag slow and severe-risk actions. |
 | shaft.diagnostics.enabled                     | `true`        | `true`, `false` | • Attach `shaft-diagnostics.zip` with sanitized `diagnostics.json` for failed and broken tests. |
 | shaft.diagnostics.maxArtifactMb               | `50`          | Integer megabytes | • Maximum size for a single diagnostics ZIP entry. |
 | shaft.trace.enabled                           | `true`        | `true`, `false` | • Attach SHAFT failure trace viewer artifacts to Allure. |

--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -396,6 +396,58 @@ baseline. The legacy `locatorHealthReportEnabled=true` and
 
 ---
 
+## Flake and Auto-Wait Profiler
+
+The **Flake and Auto-Wait Profiler** is disabled by default. Enable it when you
+want Allure attachments that explain slow element actions, assertions, retries,
+wait polling, locator churn, and evidence overhead.
+
+SHAFT attaches `flake-profile.json` and `Flake Profile` HTML for tests that
+produce profiler signals. The suite-level profile is attached during engine
+tear down. Element action duration excludes screenshot capture and report
+attachment time; those costs are recorded separately as screenshot, page
+snapshot, and report attachment evidence. Assertion and verification duration
+is measured around the validation step itself.
+
+<Tabs groupId="configMethod">
+  <TabItem value="file" label="File-based">
+
+```properties title="src/main/resources/properties/custom.properties"
+shaft.flakeProfiler.enabled=true
+shaft.flakeProfiler.attachPerTest=true
+shaft.flakeProfiler.failOnSevereFlakeRisk=false
+shaft.flakeProfiler.slowActionThresholdMs=2000
+```
+
+  </TabItem>
+  <TabItem value="cli" label="CLI-based">
+
+```bash
+mvn test -Dshaft.flakeProfiler.enabled=true -Dshaft.flakeProfiler.slowActionThresholdMs=2000
+```
+
+  </TabItem>
+  <TabItem value="code" label="Code-based">
+
+```java
+import com.shaft.driver.SHAFT;
+
+SHAFT.Properties.reporting.set()
+    .flakeProfilerEnabled(true)
+    .flakeProfilerAttachPerTest(true)
+    .flakeProfilerFailOnSevereFlakeRisk(false)
+    .flakeProfilerSlowActionThresholdMs(2000);
+```
+
+  </TabItem>
+</Tabs>
+
+Keep `shaft.flakeProfiler.failOnSevereFlakeRisk=false` while collecting a
+baseline. Turn it on only after the suite has a realistic slow-action
+threshold.
+
+---
+
 ## Video Recording
 
 SHAFT can record a video of every test session and automatically attach it to the Allure report. There is no code change required — it is purely a property:
@@ -577,6 +629,10 @@ Key properties quick reference:
 | `shaft.locatorHealth.failBelowScore` | `-1` | Fail the run when any locator score is below this threshold; `-1` disables score-based failure |
 | `slowLocatorThresholdMillis` | `750` | Lookup duration that marks a locator as slow |
 | `failOnLocatorHealthWarnings` | `false` | Fail the run when locator health warnings are present |
+| `shaft.flakeProfiler.enabled` | `false` | Attach opt-in flake and auto-wait timing profiles to Allure |
+| `shaft.flakeProfiler.attachPerTest` | `true` | Attach each test's JSON/HTML profile when profiler signals exist |
+| `shaft.flakeProfiler.failOnSevereFlakeRisk` | `false` | Fail the run when severe flake-risk actions are found |
+| `shaft.flakeProfiler.slowActionThresholdMs` | `2000` | Duration threshold used to flag slow and severe-risk actions |
 | `shaft.trace.enabled` | `true` | Attach the SHAFT failure trace viewer artifacts |
 | `shaft.trace.mode` | `failure` | Trace mode: `failure`, `retry`, or `always` |
 | `shaft.trace.includeCodeContext` | `true` | Include the best matching source-code frame and snippet |

--- a/docs/testing/flakiness.mdx
+++ b/docs/testing/flakiness.mdx
@@ -117,6 +117,29 @@ Keep the retry budget small. A pass-after-retry is still a flaky signal that
 should be reviewed; the value is that the retry attempt carries enough evidence
 to tell timing, locator, environment, and product failures apart.
 
+## Flake Profiler
+
+The flake profiler is disabled by default. Enable it when you need a run-level
+and per-test view of where time is going during element actions, assertions,
+wait polling, retries, and evidence capture.
+
+```properties title="src/main/resources/properties/custom.properties"
+shaft.flakeProfiler.enabled=true
+shaft.flakeProfiler.attachPerTest=true
+shaft.flakeProfiler.failOnSevereFlakeRisk=false
+shaft.flakeProfiler.slowActionThresholdMs=2000
+```
+
+The Allure attachments show slow actions, wait-heavy actions, locator lookup
+counts, match counts, stale element retries, healing attempts, retry history,
+and evidence costs. Element action duration excludes screenshot capture and
+report attachment time, while assertion and verification duration is measured
+around the validation step itself.
+
+Leave `shaft.flakeProfiler.failOnSevereFlakeRisk=false` during investigation.
+Use the JSON profile to set a realistic `shaft.flakeProfiler.slowActionThresholdMs`
+before making severe flake risk fail the run.
+
 ## Optional Self Healing
 
 For web locator churn that survives the locator strategy above, SHAFT Heal can
@@ -147,6 +170,7 @@ show why a candidate was accepted or rejected.
 | --- | --- | --- |
 | Generated IDs, wrapper markup, or CSS churn | Smart Locators and ARIA locators | Tests follow user-facing meaning instead of DOM implementation. |
 | Clicks before render, XHR, or framework settling | Built-in synchronization and explicit waits | Timing policy lives in one engine path. |
+| Unknown action or assertion slowdown | Flake profiler | Allure shows action, wait, retry, and evidence timings separately. |
 | Intermittent CI browser or infrastructure blips | Small retry budget with retry evidence | The suite can classify a transient failure without losing the original signal. |
 | A known web locator changed after a release | SHAFT Heal | Recovery is bounded, trust-gated, and reported. |
 | Hard-to-triage failures | Allure evidence, Doctor, and retry diagnostics | The failure carries screenshots, logs, source snapshots, and retry context. |


### PR DESCRIPTION
## Summary
- Document the opt-in flake and auto-wait profiler in reporting and flakiness guides
- Add reference coverage for the new reporting properties and CLI/property examples
- Call out that element/assertion durations exclude screenshot, page snapshot, and report attachment overhead

## Validation
- npm run test:docs
- git diff --check
- graphify update . (generated graphify-out restored, not committed)

Companion engine PR: ShaftHQ/SHAFT_ENGINE#3087