### PR TITLE
docs: document refreshed SHAFT HTML report UI

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -67,7 +67,10 @@ English while the user clicks, types, selects, uploads, or navigates. Its
 controls pause or resume action capture, add a user checkpoint, edit the visible
 action text by recording an edit checkpoint, and stop the recording. Pressing
 stop from the panel requests a normal SHAFT stop, closes the managed browser,
-and leaves the session in `COMPLETED` status for generation.
+and leaves the session in `COMPLETED` status for generation. The browser panel
+and generated capture workbench follow the same SHAFT report visual language as
+Allure-attached HTML reports, including status chips and wrapping layouts that
+avoid horizontal scrolling during review.
 
 For agent-driven MCP flows, the intended handoff is: call `capture_start` or
 `capture_start_codegen`, let the user interact with the visible browser, wait

--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -23,6 +23,12 @@ using [properties](/docs/reference/properties/PropertyTypes).
 | **Allure Report** | Deep debugging — step-by-step logs, screenshots, videos | ✅ Opens automatically after execution |
 | **Execution Summary** | Quick supplemental feedback — fast, portable, no setup | ⚙️ Opt-in via property |
 
+SHAFT-generated HTML report attachments use a shared SHAFT report theme across
+execution summaries, performance reports, accessibility reports, locator health,
+failure briefs, failure traces, and flake profiles. The same theme gives each
+surface consistent headers, status chips, metric cards, table wrapping, and
+dark-mode behavior whether opened directly or from Allure.
+
 ---
 
 ## Allure Report
@@ -398,6 +404,11 @@ Common `allure.groupBy` presets include:
 | Module hierarchy | `module,parentSuite,suite,subSuite` | Multi-module projects |
 
 Full-page image attachments open at the available modal width in SHAFT-generated Allure 3 reports. Use the modal scrollbar to inspect the rest of tall screenshots.
+
+HTML attachments created through SHAFT's attachment reporter are also fitted to
+the available Allure preview width. SHAFT injects lightweight containment rules
+so wide tables, preformatted blocks, and long values wrap instead of forcing a
+horizontal page scroll.
 
 ### Troubleshoot Allure CLI Generation
 


### PR DESCRIPTION
## Summary
- Documents the shared SHAFT report visual language for generated HTML report attachments.
- Notes that SHAFT-fitted HTML attachments wrap wide tables, preformatted blocks, and long values in Allure instead of forcing horizontal page scroll.
- Documents that the Capture browser panel and generated workbench now follow the same report styling and wrapping behavior.

## Related
- Engine PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3105

## Validation
- `yarn install --frozen-lockfile`
- `yarn build`
- `git diff --check`

## Graphify
- Attempted `graphify . --update --no-viz`.
- Blocked by missing LLM backend credentials: `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or another supported graphify key is required for 216 changed doc/image files.