### PR TITLE
Document lazy-loading readiness waits

### DIFF
--- a/docs/reference/configuration/basicConfig.md
+++ b/docs/reference/configuration/basicConfig.md
@@ -47,6 +47,18 @@ defaultElementIdentificationTimeout=30
 # Time (seconds) for default UI state waits such as driver.element().waitUntil(...)
 waitForUiStateTimeout=600
 
+# Enable SHAFT's browser readiness wait before browser and element actions
+waitForLazyLoading=true
+
+# Time (seconds) to wait for document, JS framework, and network readiness
+waitForLazyLoadingTimeout=30
+
+# Initial network quiet window when no activity has been observed yet
+lazyLoadingNetworkIdleInitialObservationMillis=200
+
+# Required network quiet window after observed XHR/fetch/resource activity
+lazyLoadingNetworkIdleQuietWindowMillis=500
+
 # Time (seconds) to wait for a page navigation to complete
 browserNavigationTimeout=60
 

--- a/docs/testing/flakiness.mdx
+++ b/docs/testing/flakiness.mdx
@@ -77,12 +77,18 @@ Most flaky UI tests fail because they click before the browser is ready. SHAFT
 element actions use a configured fluent wait, poll for retriable Selenium
 states, scroll the element into view, and then perform the action. Browser and
 element actions also call lazy-loading synchronization where applicable: SHAFT
-waits for document readiness, active `fetch`/XHR quiet time, jQuery activity,
-and Angular readiness when those signals exist on the page.
+waits for document readiness, active `fetch`/XHR quiet time, resource timing
+changes, jQuery activity, and Angular readiness when those signals exist on the
+page. For native user actions, SHAFT re-locates the element after this
+synchronization and verifies that the final target is displayed and enabled
+before acting on it.
 
 The default element lookup budget comes from
 `defaultElementIdentificationTimeout`; condition-specific waits use
-`waitForUiStateTimeout` unless you pass a shorter `Duration`.
+`waitForUiStateTimeout` unless you pass a shorter `Duration`. Lazy-loading
+synchronization uses `waitForLazyLoadingTimeout`; its network quiet behavior can
+be tuned with `lazyLoadingNetworkIdleInitialObservationMillis` and
+`lazyLoadingNetworkIdleQuietWindowMillis`.
 
 ```java title="ExplicitStateWait.java"
 driver.browser().navigateToURL("https://example.test/orders")

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - shafthq.github.io-landing-consistency  (2026-06-27)
+# Graph Report - codex-readiness-network-idle-docs  (2026-06-27)
 
 ## Corpus Check
-- 225 files · ~319,506 words
+- 225 files · ~319,598 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -10,7 +10,7 @@
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `855e7d4e`
+- Built from commit: `71f73bd4`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19587,7 +19587,7 @@
       "label": "Visual Reporting",
       "file_type": "document",
       "source_file": "docs/reference/configuration/basicConfig.md",
-      "source_location": "L59",
+      "source_location": "L71",
       "_origin": "ast",
       "id": "configuration_basicconfig_visual_reporting",
       "community": 125,
@@ -19597,7 +19597,7 @@
       "label": "Reliability & Retries",
       "file_type": "document",
       "source_file": "docs/reference/configuration/basicConfig.md",
-      "source_location": "L80",
+      "source_location": "L92",
       "_origin": "ast",
       "id": "configuration_basicconfig_reliability_retries",
       "community": 125,
@@ -19607,7 +19607,7 @@
       "label": "Proxy",
       "file_type": "document",
       "source_file": "docs/reference/configuration/basicConfig.md",
-      "source_location": "L101",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "configuration_basicconfig_proxy",
       "community": 125,
@@ -19617,7 +19617,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/reference/configuration/basicConfig.md",
-      "source_location": "L114",
+      "source_location": "L126",
       "_origin": "ast",
       "id": "configuration_basicconfig_related",
       "community": 125,
@@ -23657,7 +23657,7 @@
       "label": "Retry With Evidence",
       "file_type": "document",
       "source_file": "docs/testing/flakiness.mdx",
-      "source_location": "L100",
+      "source_location": "L106",
       "_origin": "ast",
       "id": "testing_flakiness_retry_with_evidence",
       "community": 219,
@@ -23667,7 +23667,7 @@
       "label": "Flake Profiler",
       "file_type": "document",
       "source_file": "docs/testing/flakiness.mdx",
-      "source_location": "L128",
+      "source_location": "L134",
       "_origin": "ast",
       "id": "testing_flakiness_flake_profiler",
       "community": 219,
@@ -23677,7 +23677,7 @@
       "label": "Optional Self Healing",
       "file_type": "document",
       "source_file": "docs/testing/flakiness.mdx",
-      "source_location": "L151",
+      "source_location": "L157",
       "_origin": "ast",
       "id": "testing_flakiness_optional_self_healing",
       "community": 219,
@@ -23687,7 +23687,7 @@
       "label": "What To Use First",
       "file_type": "document",
       "source_file": "docs/testing/flakiness.mdx",
-      "source_location": "L175",
+      "source_location": "L181",
       "_origin": "ast",
       "id": "testing_flakiness_what_to_use_first",
       "community": 219,
@@ -23697,7 +23697,7 @@
       "label": "Related",
       "file_type": "document",
       "source_file": "docs/testing/flakiness.mdx",
-      "source_location": "L186",
+      "source_location": "L192",
       "_origin": "ast",
       "id": "testing_flakiness_related",
       "community": 219,
@@ -27207,9 +27207,9 @@
       "source_file": "src/theme/Root.tsx",
       "source_location": "L5",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "theme_root",
-      "target": "theme_root_hash_scroll_retry_delays_ms",
-      "confidence_score": 1.0
+      "target": "theme_root_hash_scroll_retry_delays_ms"
     },
     {
       "relation": "contains",
@@ -27217,9 +27217,9 @@
       "source_file": "src/theme/Root.tsx",
       "source_location": "L62",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "theme_root",
-      "target": "theme_root_hashtargetscrollsync",
-      "confidence_score": 1.0
+      "target": "theme_root_hashtargetscrollsync"
     },
     {
       "relation": "contains",
@@ -27551,9 +27551,9 @@
       "source_file": "tests/e2e/homepage.spec.js",
       "source_location": "L3",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "e2e_homepage_spec",
-      "target": "e2e_homepage_spec_expectanchorbelownavbar",
-      "confidence_score": 1.0
+      "target": "e2e_homepage_spec_expectanchorbelownavbar"
     },
     {
       "relation": "imports_from",
@@ -27602,9 +27602,9 @@
       "source_file": "tests/homepage-performance.test.js",
       "source_location": "L6",
       "weight": 1.0,
+      "confidence_score": 1.0,
       "source": "tests_homepage_performance_test",
-      "target": "tests_homepage_performance_test_customstyles",
-      "confidence_score": 1.0
+      "target": "tests_homepage_performance_test_customstyles"
     },
     {
       "relation": "contains",
@@ -48467,5 +48467,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "855e7d4ef46d17730d69b82619d5a7533947888a"
+  "built_at_commit": "71f73bd486e644f8287f2463a1c99ae8e8674a57"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,1381 +1,1381 @@
 {
   "babel.config.js": {
-    "mtime": 1782562830.6575532,
+    "mtime": 1782568238.4034393,
     "ast_hash": "319feac2fd3850e21aa4834fab5cdb46",
     "semantic_hash": ""
   },
   "demo-autobot-approach.mjs": {
-    "mtime": 1782562830.6685514,
+    "mtime": 1782568238.416954,
     "ast_hash": "8c336441fffbaf2f417474bc27644f5e",
     "semantic_hash": ""
   },
   "docusaurus.config.js": {
-    "mtime": 1782562830.726555,
+    "mtime": 1782568238.4901047,
     "ast_hash": "28d93b8dfc486cfcacce62c8322280ca",
     "semantic_hash": ""
   },
   "functions/api/gemini-proxy.js": {
-    "mtime": 1782562830.7275505,
+    "mtime": 1782568238.4911053,
     "ast_hash": "50d09aefbe3e2499bb404a9ed952306b",
     "semantic_hash": ""
   },
   "netlify/functions/autobot-core.mjs": {
-    "mtime": 1782562830.743555,
+    "mtime": 1782568238.5096211,
     "ast_hash": "ac69e64e4bfa562b41bac3bed1a5c3e4",
     "semantic_hash": ""
   },
   "netlify/functions/constants.mjs": {
-    "mtime": 1782562830.743555,
+    "mtime": 1782568238.5106218,
     "ast_hash": "1d99ec839e81b17054d9938b2d9122f7",
     "semantic_hash": ""
   },
   "netlify/functions/docs-loader.mjs": {
-    "mtime": 1782562830.7445567,
+    "mtime": 1782568238.511623,
     "ast_hash": "344e7ea2d7fa3802506f8a8b5f109aac",
     "semantic_hash": ""
   },
   "netlify/functions/docs-retrieval.mjs": {
-    "mtime": 1782562830.7445567,
+    "mtime": 1782568238.511623,
     "ast_hash": "f4e4d4183f921c478bbdf1a9aec4fa33",
     "semantic_hash": ""
   },
   "netlify/functions/gemini-proxy.mjs": {
-    "mtime": 1782562830.7445567,
+    "mtime": 1782568238.5126202,
     "ast_hash": "b5ae4c20bcd1dcbf078c819eb2f7ac85",
     "semantic_hash": ""
   },
   "netlify/functions/github-context.mjs": {
-    "mtime": 1782562830.7455554,
+    "mtime": 1782568238.5126202,
     "ast_hash": "315f9c46e52a2df11a933c590ce28d42",
     "semantic_hash": ""
   },
   "package.json": {
-    "mtime": 1782562830.748554,
+    "mtime": 1782568238.5176196,
     "ast_hash": "0158601933bc8317f5b1dfa7af7940e8",
     "semantic_hash": ""
   },
   "playwright.config.js": {
-    "mtime": 1782562830.7495549,
+    "mtime": 1782568238.5186205,
     "ast_hash": "747b1e41b794168d3bfb7430072509e9",
     "semantic_hash": ""
   },
   "scripts/build-autobot-index.mjs": {
-    "mtime": 1782562830.7505565,
+    "mtime": 1782568238.5196204,
     "ast_hash": "2f58ec4e957a74dd66883bab1f60baa2",
     "semantic_hash": ""
   },
   "scripts/check-doc-duplicates.mjs": {
-    "mtime": 1782562830.7505565,
+    "mtime": 1782568238.5196204,
     "ast_hash": "e16b88e21e33e87c6c7df4b05ec1fff5",
     "semantic_hash": ""
   },
   "scripts/prune-search-index.mjs": {
-    "mtime": 1782562830.7515554,
+    "mtime": 1782568238.5196204,
     "ast_hash": "cdfc97593baaa1ca2ee4bb4f40137ce2",
     "semantic_hash": ""
   },
   "scripts/run-shaft-tests.mjs": {
-    "mtime": 1782562830.7515554,
+    "mtime": 1782568238.5211253,
     "ast_hash": "4a81904c720af93da79392c240c2e09b",
     "semantic_hash": ""
   },
   "scripts/verify-models.js": {
-    "mtime": 1782562830.7515554,
+    "mtime": 1782568238.5211253,
     "ast_hash": "cdcff0adb4994356e7ed5b08fbeaca74",
     "semantic_hash": ""
   },
   "sidebars.js": {
-    "mtime": 1782562830.7525566,
+    "mtime": 1782568238.5211253,
     "ast_hash": "01b3102d9517dbfc8febf5c00426639e",
     "semantic_hash": ""
   },
   "src/components/AutoBot/index.tsx": {
-    "mtime": 1782562830.7535558,
+    "mtime": 1782568238.522131,
     "ast_hash": "7975dce5717eead8da723d4472c8f490",
     "semantic_hash": ""
   },
   "src/components/DocSnippets/McpApplications.tsx": {
-    "mtime": 1782562830.754555,
+    "mtime": 1782568238.5241358,
     "ast_hash": "7493f2c6528d9c242d594ab4913916a5",
     "semantic_hash": ""
   },
   "src/components/DocSnippets/index.tsx": {
-    "mtime": 1782562830.7555556,
+    "mtime": 1782568238.5241358,
     "ast_hash": "5791cbafa70fbacfd79ac48a7cb701c5",
     "semantic_hash": ""
   },
   "src/components/HomepageFeatures/FeatureBackgrounds.tsx": {
-    "mtime": 1782562830.7555556,
+    "mtime": 1782568238.5251362,
     "ast_hash": "4fa49a43a19f4f1f67e2079ae296bf93",
     "semantic_hash": ""
   },
   "src/components/HomepageFeatures/index.tsx": {
-    "mtime": 1782562830.7565553,
+    "mtime": 1782568238.5251362,
     "ast_hash": "5b99e529e9b2845c25a9c4a11ab0fda1",
     "semantic_hash": ""
   },
   "src/components/ParticleBackground/index.tsx": {
-    "mtime": 1782562830.7576225,
+    "mtime": 1782568238.5271375,
     "ast_hash": "489886836f8fa84cebce38144befd98f",
     "semantic_hash": ""
   },
   "src/components/ParticleBackground/particleWorker.ts": {
-    "mtime": 1782562830.7576225,
+    "mtime": 1782568238.528137,
     "ast_hash": "70e9fff4dc3ec55d6e4d1c39308310f0",
     "semantic_hash": ""
   },
   "src/components/PropertiesGenerator/index.tsx": {
-    "mtime": 1782562830.7586217,
+    "mtime": 1782568238.5291364,
     "ast_hash": "911d71385f2fea0d0a2418d6b7b44b57",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/App.js": {
-    "mtime": 1782562830.7596223,
+    "mtime": 1782568238.5301378,
     "ast_hash": "44124ccb59fba90f62126e831f1b34c6",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/index.tsx": {
-    "mtime": 1782562830.7596223,
+    "mtime": 1782568238.5301378,
     "ast_hash": "44de1ebbd9c06b5ca3dacdf2407522ff",
     "semantic_hash": ""
   },
   "src/components/RoiCalculator/input.js": {
-    "mtime": 1782562830.7596223,
+    "mtime": 1782568238.5301378,
     "ast_hash": "6bf8c53d395442428888bb5a97b0508f",
     "semantic_hash": ""
   },
   "src/components/ShaftRobot/index.tsx": {
-    "mtime": 1782562830.7606237,
+    "mtime": 1782568238.5321374,
     "ast_hash": "eb4a12e2a8c0c65063524f57d0221886",
     "semantic_hash": ""
   },
   "src/data/properties-catalog.json": {
-    "mtime": 1782562830.7626233,
+    "mtime": 1782568238.5341358,
     "ast_hash": "e0390f9b8ef0ce1cdd94afb9f7d4cadb",
     "semantic_hash": ""
   },
   "src/data/releases.json": {
-    "mtime": 1782562830.7626233,
+    "mtime": 1782568238.5341358,
     "ast_hash": "19856109549d8f7c2abb581cb9701256",
     "semantic_hash": ""
   },
   "src/data/snippets.json": {
-    "mtime": 1782562830.7636228,
+    "mtime": 1782568238.5341358,
     "ast_hash": "683878efafbac681fee32d25ff354200",
     "semantic_hash": ""
   },
   "src/pages/index.tsx": {
-    "mtime": 1782562830.7646222,
+    "mtime": 1782568238.535138,
     "ast_hash": "bac82aabe0b1641bfeb0a2abafc8bda0",
     "semantic_hash": ""
   },
   "src/pages/project-generator.tsx": {
-    "mtime": 1782562830.765623,
+    "mtime": 1782568238.5361357,
     "ast_hash": "0c410aae1b311698ceefefa2cc446b27",
     "semantic_hash": ""
   },
   "src/theme/DocItem/Metadata/index.tsx": {
-    "mtime": 1782562830.7666223,
+    "mtime": 1782568238.5381358,
     "ast_hash": "383e8539fbd126cf1f66341a400365b5",
     "semantic_hash": ""
   },
   "src/theme/MDXComponents.js": {
-    "mtime": 1782562830.7666223,
+    "mtime": 1782568238.5381358,
     "ast_hash": "d80ac4bbba95ec956cfcfd83865e6be0",
     "semantic_hash": ""
   },
   "src/theme/Root.tsx": {
-    "mtime": 1782563952.0122705,
-    "ast_hash": "96eb26001ee6d0e4a51615b2102322a7",
+    "mtime": 1782568238.538641,
+    "ast_hash": "ac9789c6d66fb49220d50ccf96806c87",
     "semantic_hash": ""
   },
   "src/types/jsx-namespace.d.ts": {
-    "mtime": 1782562830.767623,
+    "mtime": 1782568238.538641,
     "ast_hash": "85fbc9e8f1a5e8998143b93be1085e49",
     "semantic_hash": ""
   },
   "static/examples/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1782562830.7696235,
+    "mtime": 1782568238.5406513,
     "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "static/examples/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1782562830.7696235,
+    "mtime": 1782568238.5416508,
     "ast_hash": "0afabccf31612085d45b67e2b4d94490",
     "semantic_hash": ""
   },
   "tests/chat-history.test.js": {
-    "mtime": 1782562830.8196218,
+    "mtime": 1782568238.6052084,
     "ast_hash": "cd4331cbc09f106efa9b5ce5a094257b",
     "semantic_hash": ""
   },
   "tests/chatbot-api.test.js": {
-    "mtime": 1782562830.820623,
+    "mtime": 1782568238.606216,
     "ast_hash": "b6f45713490fa5d29ac52d0358f0e95f",
     "semantic_hash": ""
   },
   "tests/cloudflare-autobot.test.js": {
-    "mtime": 1782562830.820623,
+    "mtime": 1782568238.606216,
     "ast_hash": "8abf051640dceeb15f3e35f4a2555b63",
     "semantic_hash": ""
   },
   "tests/docs-loader.test.js": {
-    "mtime": 1782562830.820623,
+    "mtime": 1782568238.607221,
     "ast_hash": "8cd316f2463c44d394be605b3ade25f0",
     "semantic_hash": ""
   },
   "tests/docs-quality.test.js": {
-    "mtime": 1782562830.8216226,
+    "mtime": 1782568238.607221,
     "ast_hash": "554169f88c7152078be701fed0f1d551",
     "semantic_hash": ""
   },
   "tests/e2e/homepage.spec.js": {
-    "mtime": 1782563793.6083474,
-    "ast_hash": "4a00bde01ce122f0584b19bdd991b0c2",
+    "mtime": 1782568238.60822,
+    "ast_hash": "2119a79b8d3f07373b91a92555abd908",
     "semantic_hash": ""
   },
   "tests/enhanced-instruction.test.js": {
-    "mtime": 1782562830.8226228,
+    "mtime": 1782568238.60822,
     "ast_hash": "1a1b7ea74cf96b3d554a5f91209f5d37",
     "semantic_hash": ""
   },
   "tests/homepage-performance.test.js": {
-    "mtime": 1782563705.3786373,
-    "ast_hash": "a0a527e2412e256dde7c10ae5a5a2cc7",
+    "mtime": 1782568238.6092215,
+    "ast_hash": "7c377137722b92fb6ef1aa4294d414ac",
     "semantic_hash": ""
   },
   "tests/properties-catalog.test.js": {
-    "mtime": 1782562830.8226228,
+    "mtime": 1782568238.6092215,
     "ast_hash": "fb069219b6994aea7fef28ca20c4f076",
     "semantic_hash": ""
   },
   "tests/release-blog-template.test.js": {
-    "mtime": 1782562830.823623,
+    "mtime": 1782568238.6102216,
     "ast_hash": "367c242f98f431ee822c157446afccf1",
     "semantic_hash": ""
   },
   "tests/run-all-tests.js": {
-    "mtime": 1782562830.823623,
+    "mtime": 1782568238.6102216,
     "ast_hash": "f5003560f9018c49cc6e7a185b3c444e",
     "semantic_hash": ""
   },
   "tests/shaft/src/test/java/net/shaftengine/docs/SiteRenderTest.java": {
-    "mtime": 1782562830.8266218,
+    "mtime": 1782568238.6132214,
     "ast_hash": "aff957ee4ac62df9e217266f43392f16",
     "semantic_hash": ""
   },
   "tsconfig.json": {
-    "mtime": 1782562830.8266218,
+    "mtime": 1782568238.6142209,
     "ast_hash": "60c815b8f748b78547a76ef6aa4b2c9d",
     "semantic_hash": ""
   },
   "versions.json": {
-    "mtime": 1782562830.8266218,
+    "mtime": 1782568238.6142209,
     "ast_hash": "d751713988987e9331980363e24189ce",
     "semantic_hash": ""
   },
   "worker/index.js": {
-    "mtime": 1782562830.8276236,
+    "mtime": 1782568238.6142209,
     "ast_hash": "40a5cb7392ddc9201c1faaec21ab8f82",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1782562830.6510336,
+    "mtime": 1782568238.3974397,
     "ast_hash": "12222b1d973f8eabde048aee1aa3fe40",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1782562830.6520338,
+    "mtime": 1782568238.3974397,
     "ast_hash": "09cac864013c81959c13ff2c7c8ab0ed",
     "semantic_hash": ""
   },
   ".github/workflows/automated-release-blog-post.yml": {
-    "mtime": 1782562830.6520338,
+    "mtime": 1782568238.3984392,
     "ast_hash": "e9b2fd65ffa8265e9d0940e382146d3b",
     "semantic_hash": ""
   },
   ".github/workflows/deploy.yml": {
-    "mtime": 1782562830.6530344,
+    "mtime": 1782568238.3984392,
     "ast_hash": "48f16a6a2588abc7b5e5e87aa0bb07fd",
     "semantic_hash": ""
   },
   ".github/workflows/update-sitemap.yml": {
-    "mtime": 1782562830.6530344,
+    "mtime": 1782568238.3984392,
     "ast_hash": "cc010aac3430c8f227b26a9154780b96",
     "semantic_hash": ""
   },
   ".vscode/ltex.dictionary.en-US.txt": {
-    "mtime": 1782562830.6550367,
+    "mtime": 1782568238.401439,
     "ast_hash": "d012e95e452c1e3b48053a142929fa26",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1782562830.6550367,
+    "mtime": 1782568238.401439,
     "ast_hash": "2f8286328336b05322dd8338f2fef200",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1782562830.6565447,
+    "mtime": 1782568238.4024396,
     "ast_hash": "a1503e8e0b5719635106523963b66fba",
     "semantic_hash": ""
   },
   "DESIGN_LANGUAGE.md": {
-    "mtime": 1782562830.6565447,
+    "mtime": 1782568238.4024396,
     "ast_hash": "c8f794809d5b3fcc39553b8e617878dc",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1782562830.6575532,
+    "mtime": 1782568238.4034393,
     "ast_hash": "75446b068ecd0706f858204dce52ab93",
     "semantic_hash": ""
   },
   "blog/2023-01-21-welcome/index.md": {
-    "mtime": 1782562830.6585524,
+    "mtime": 1782568238.4049432,
     "ast_hash": "4c12009dac1a2da01d134954c18f9327",
     "semantic_hash": ""
   },
   "blog/2023-01-24-selenium-ecosystem.md": {
-    "mtime": 1782562830.6585524,
+    "mtime": 1782568238.4049432,
     "ast_hash": "40c854cc054134eca54e703fea7a967c",
     "semantic_hash": ""
   },
   "blog/2023-02-12-self-managed-appium-execution.md": {
-    "mtime": 1782562830.6595502,
+    "mtime": 1782568238.405949,
     "ast_hash": "aa81634b4bcc6d898258f3c2e943a5bb",
     "semantic_hash": ""
   },
   "blog/2023-02-28-we-need-your-support.md": {
-    "mtime": 1782562830.6595502,
+    "mtime": 1782568238.405949,
     "ast_hash": "efb1d8b9c08b34d1aff7efc0f9522294",
     "semantic_hash": ""
   },
   "blog/2023-03-10-release_announcement.md": {
-    "mtime": 1782562830.6595502,
+    "mtime": 1782568238.4069548,
     "ast_hash": "d007f4c24f31daacd1ff54eb22739b04",
     "semantic_hash": ""
   },
   "blog/2023-04-27-bingAI.md": {
-    "mtime": 1782562830.6605506,
+    "mtime": 1782568238.4069548,
     "ast_hash": "552affe93e34e4c10c8ca4eb135deb42",
     "semantic_hash": ""
   },
   "blog/2024-01-27-virtual-threads-release.md": {
-    "mtime": 1782562830.6605506,
+    "mtime": 1782568238.4069548,
     "ast_hash": "e9a3af37b48ca6fb5d192b1a11eb083e",
     "semantic_hash": ""
   },
   "blog/2025-03-27-swagger-validation.md": {
-    "mtime": 1782562830.661552,
+    "mtime": 1782568238.4079554,
     "ast_hash": "6f27e2b1e36363272e8362de96b85efe",
     "semantic_hash": ""
   },
   "blog/2026-03-24-release-10.1.20260324.md": {
-    "mtime": 1782562830.661552,
+    "mtime": 1782568238.4089544,
     "ast_hash": "654f8736540808936270ee7db97b5e5d",
     "semantic_hash": ""
   },
   "blog/2026-03-31-release-10.1.20260331.md": {
-    "mtime": 1782562830.662552,
+    "mtime": 1782568238.4089544,
     "ast_hash": "051b1b7c7f73531117b774515b38333f",
     "semantic_hash": ""
   },
   "blog/2026-05-02-release-10.2.20260501.md": {
-    "mtime": 1782562830.662552,
+    "mtime": 1782568238.4099543,
     "ast_hash": "c8020deebd5950f7c29c06de7adf4fd7",
     "semantic_hash": ""
   },
   "blog/2026-05-05-release-10.2.20260505.md": {
-    "mtime": 1782562830.662552,
+    "mtime": 1782568238.4099543,
     "ast_hash": "570a5c34e124c43fbf40c95db80e70a1",
     "semantic_hash": ""
   },
   "blog/2026-05-06-release-10.2.20260506.md": {
-    "mtime": 1782562830.6635506,
+    "mtime": 1782568238.4099543,
     "ast_hash": "ca7b9d38d13c1c1936f94fc15e5c1f40",
     "semantic_hash": ""
   },
   "blog/2026-06-05-release-10.2.20260605.md": {
-    "mtime": 1782562830.6635506,
+    "mtime": 1782568238.4109545,
     "ast_hash": "0f90017918e7e254fa751da939f52013",
     "semantic_hash": ""
   },
   "blog/2026-06-10-release-10.2.20260610.md": {
-    "mtime": 1782562830.6635506,
+    "mtime": 1782568238.4109545,
     "ast_hash": "6765363149528f006b51b8a7f340fe87",
     "semantic_hash": ""
   },
   "blog/2026-06-12-release-10.2.20260612.md": {
-    "mtime": 1782562830.6645508,
+    "mtime": 1782568238.4119549,
     "ast_hash": "ee2cb8a322ac718ffd87699edd763397",
     "semantic_hash": ""
   },
   "blog/2026-06-14-release-10.2.20260614.md": {
-    "mtime": 1782562830.6645508,
+    "mtime": 1782568238.4119549,
     "ast_hash": "741def4c2b94eb0562568e9944fb3974",
     "semantic_hash": ""
   },
   "blog/2026-06-15-release-10.2.20260615.md": {
-    "mtime": 1782562830.6655507,
+    "mtime": 1782568238.4119549,
     "ast_hash": "20fe58f70f1ef343c56122f23488b08b",
     "semantic_hash": ""
   },
   "blog/2026-06-17-release-10.2.20260617.md": {
-    "mtime": 1782562830.6655507,
+    "mtime": 1782568238.412955,
     "ast_hash": "d6f70b6f410ce41d956b03826f81e10f",
     "semantic_hash": ""
   },
   "blog/2026-06-18-release-10.2.20260618.md": {
-    "mtime": 1782562830.6655507,
+    "mtime": 1782568238.412955,
     "ast_hash": "555586e796f33504423243dacd09ba3b",
     "semantic_hash": ""
   },
   "blog/2026-06-19-release-10.2.20260620.md": {
-    "mtime": 1782562830.6665504,
+    "mtime": 1782568238.4139545,
     "ast_hash": "a7a9d29618a74b4480ca36f492a0c9a6",
     "semantic_hash": ""
   },
   "blog/2026-06-21-release-10.2.20260621.md": {
-    "mtime": 1782562830.6665504,
+    "mtime": 1782568238.4139545,
     "ast_hash": "d231d492a7b16e2601d70790de98ae01",
     "semantic_hash": ""
   },
   "blog/2026-06-22-release-10.2.20260622.md": {
-    "mtime": 1782562830.6665504,
+    "mtime": 1782568238.4139545,
     "ast_hash": "c331469e36d4c2307cbc4137a3f1e512",
     "semantic_hash": ""
   },
   "blog/authors.yml": {
-    "mtime": 1782562830.6675515,
+    "mtime": 1782568238.4159544,
     "ast_hash": "4463638287b65c50badbf15a8c238ed3",
     "semantic_hash": ""
   },
   "demo-output.txt": {
-    "mtime": 1782562830.6685514,
+    "mtime": 1782568238.416954,
     "ast_hash": "487656e0a23181cb1ba53136a6045cfd",
     "semantic_hash": ""
   },
   "docs/agentic/capture.md": {
-    "mtime": 1782563538.9867816,
+    "mtime": 1782568238.4189565,
     "ast_hash": "88d381f41e39341a795d74bb1070cc25",
     "semantic_hash": ""
   },
   "docs/agentic/doctor.mdx": {
-    "mtime": 1782562830.6695504,
+    "mtime": 1782568238.4199548,
     "ast_hash": "5f11923b142400a96d555a221cf844ee",
     "semantic_hash": ""
   },
   "docs/agentic/examples.md": {
-    "mtime": 1782562830.670552,
+    "mtime": 1782568238.4199548,
     "ast_hash": "c01251bdd620a93c945654dcd578313c",
     "semantic_hash": ""
   },
   "docs/agentic/heal.mdx": {
-    "mtime": 1782562830.670552,
+    "mtime": 1782568238.4199548,
     "ast_hash": "fc4e8ac5f7fe1b9ccf76b9de298be753",
     "semantic_hash": ""
   },
   "docs/agentic/mcp-manual.mdx": {
-    "mtime": 1782562830.670552,
+    "mtime": 1782568238.4199548,
     "ast_hash": "a10ca66873d170a13c67196671915f50",
     "semantic_hash": ""
   },
   "docs/agentic/mcp.mdx": {
-    "mtime": 1782563538.9877815,
+    "mtime": 1782568238.4214618,
     "ast_hash": "34fb6b2792f1a4a587ae063fcfd87c80",
     "semantic_hash": ""
   },
   "docs/agentic/overview.mdx": {
-    "mtime": 1782562830.671551,
+    "mtime": 1782568238.4224706,
     "ast_hash": "d2df9d5f48bc80188c143e954fc83827",
     "semantic_hash": ""
   },
   "docs/agentic/pilot.md": {
-    "mtime": 1782562830.6725504,
+    "mtime": 1782568238.4224706,
     "ast_hash": "fc001ef5e65797c8cbe7fc4faa389698",
     "semantic_hash": ""
   },
   "docs/agentic/providers.md": {
-    "mtime": 1782562830.6725504,
+    "mtime": 1782568238.4224706,
     "ast_hash": "3eb19467a226f81fc59513f794e903bd",
     "semantic_hash": ""
   },
   "docs/archive/engine/2026-05-08-actions-run-25572054507.md": {
-    "mtime": 1782562830.6735513,
+    "mtime": 1782568238.4234784,
     "ast_hash": "f8e7bf85b2d015bbe355c10b0ef5d5a1",
     "semantic_hash": ""
   },
   "docs/archive/engine/2026-05-08-agent-knowledge-migration.md": {
-    "mtime": 1782562830.6735513,
+    "mtime": 1782568238.4244783,
     "ast_hash": "e4204073a7f6705f37392b85ec17ce37",
     "semantic_hash": ""
   },
   "docs/archive/engine/ci-coverage-readiness.md": {
-    "mtime": 1782562830.6735513,
+    "mtime": 1782568238.4244783,
     "ast_hash": "b4a224846a43e2ea9f4aebbdea8ee037",
     "semantic_hash": ""
   },
   "docs/archive/engine/contributors-history.md": {
-    "mtime": 1782562830.6745493,
+    "mtime": 1782568238.4244783,
     "ast_hash": "85aad4e221541f075f2d78fa3cffc4ec",
     "semantic_hash": ""
   },
   "docs/archive/engine/history-rewrite-validation.md": {
-    "mtime": 1782562830.6745493,
+    "mtime": 1782568238.425478,
     "ast_hash": "e66ed83424e99e2cd610cf002eb7e7a8",
     "semantic_hash": ""
   },
   "docs/archive/engine/mcp-history-import.md": {
-    "mtime": 1782562830.6755512,
+    "mtime": 1782568238.425478,
     "ast_hash": "d564daadffa41fa98de394798002db75",
     "semantic_hash": ""
   },
   "docs/archive/engine/modular-dependency-report.md": {
-    "mtime": 1782562830.6755512,
+    "mtime": 1782568238.4264786,
     "ast_hash": "59c8c5df43de702530df31c976c1db89",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/SKILL.md": {
-    "mtime": 1782562830.6755512,
+    "mtime": 1782568238.4264786,
     "ast_hash": "70ef4ed39f3e960abbc92d102c2da8b1",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/code-analysis-and-optimization.md": {
-    "mtime": 1782562830.676551,
+    "mtime": 1782568238.4274783,
     "ast_hash": "010cbbd4466601c21dc21e4509d69740",
     "semantic_hash": ""
   },
   "docs/archive/engine/retired-agent-skill/overview.md": {
-    "mtime": 1782562830.676551,
+    "mtime": 1782568238.4274783,
     "ast_hash": "d8d7d444539e796e19dd4683a6195b30",
     "semantic_hash": ""
   },
   "docs/archive/engine/tink-design-journal.md": {
-    "mtime": 1782562830.676551,
+    "mtime": 1782568238.4284787,
     "ast_hash": "6e2545fb06ae6db4ed8be694e2ac271d",
     "semantic_hash": ""
   },
   "docs/archive/overview.md": {
-    "mtime": 1782562830.677552,
+    "mtime": 1782568238.4284787,
     "ast_hash": "96f79fbdabc02d655d8edff9cd0a6b39",
     "semantic_hash": ""
   },
   "docs/archive/site/autobot-optimization-summary.md": {
-    "mtime": 1782562830.677552,
+    "mtime": 1782568238.4294786,
     "ast_hash": "92be1145ef00cec1799361fd5838be07",
     "semantic_hash": ""
   },
   "docs/archive/site/chatbot-testing.md": {
-    "mtime": 1782562830.67855,
+    "mtime": 1782568238.4294786,
     "ast_hash": "97a854b9d78e5802c362ebd1c7e2f6e1",
     "semantic_hash": ""
   },
   "docs/archive/site/configuration-verification.md": {
-    "mtime": 1782562830.67855,
+    "mtime": 1782568238.4304776,
     "ast_hash": "4062aade28b856313e6f85dbb1371fd8",
     "semantic_hash": ""
   },
   "docs/archive/site/deployment-checklist.md": {
-    "mtime": 1782562830.6795514,
+    "mtime": 1782568238.4304776,
     "ast_hash": "7e64842a64765b741f1c606ebad3bf2d",
     "semantic_hash": ""
   },
   "docs/archive/site/e2e-test-results.md": {
-    "mtime": 1782562830.6795514,
+    "mtime": 1782568238.4314783,
     "ast_hash": "a074c0d6bed5f80c973a5e51d11c3330",
     "semantic_hash": ""
   },
   "docs/archive/site/final-summary.md": {
-    "mtime": 1782562830.680551,
+    "mtime": 1782568238.4314783,
     "ast_hash": "42e299ac6fe753b6d63a772c02971784",
     "semantic_hash": ""
   },
   "docs/archive/site/github-actions-test-setup.md": {
-    "mtime": 1782562830.680551,
+    "mtime": 1782568238.4324782,
     "ast_hash": "4178400a49d83a71ca43e2b6fed915a9",
     "semantic_hash": ""
   },
   "docs/archive/site/netlify-migration-guide.md": {
-    "mtime": 1782562830.680551,
+    "mtime": 1782568238.4334772,
     "ast_hash": "e2beb4b4e7b9aa1615fe1df241d4dcd9",
     "semantic_hash": ""
   },
   "docs/archive/site/security-fix-summary.md": {
-    "mtime": 1782562830.6815507,
+    "mtime": 1782568238.4334772,
     "ast_hash": "3f0119a5cc347eb8109fc413711c2918",
     "semantic_hash": ""
   },
   "docs/features/architecture.md": {
-    "mtime": 1782562830.6815507,
+    "mtime": 1782568238.434476,
     "ast_hash": "d8865d7a44bb5b3630b5f41b28b60652",
     "semantic_hash": ""
   },
   "docs/features/modules.md": {
-    "mtime": 1782562830.6825502,
+    "mtime": 1782568238.4354775,
     "ast_hash": "2d84bac5d10f356cd3ad504af1a444f3",
     "semantic_hash": ""
   },
   "docs/features/partners.md": {
-    "mtime": 1782562830.6825502,
+    "mtime": 1782568238.4354775,
     "ast_hash": "d7ccfd92176ca55d15fa2a0923e7a10a",
     "semantic_hash": ""
   },
   "docs/features/reporting.md": {
-    "mtime": 1782562830.6825502,
+    "mtime": 1782568238.4364765,
     "ast_hash": "ab0c5c54aaa4f42af31f08733bfca557",
     "semantic_hash": ""
   },
   "docs/features/technology.md": {
-    "mtime": 1782562830.6835506,
+    "mtime": 1782568238.4364765,
     "ast_hash": "bd517694557a7744f1ebe89de1381196",
     "semantic_hash": ""
   },
   "docs/integrations/browserstack.md": {
-    "mtime": 1782562830.68455,
+    "mtime": 1782568238.4379816,
     "ast_hash": "7730a0995261efa42a538b96d22bd5a7",
     "semantic_hash": ""
   },
   "docs/integrations/video.md": {
-    "mtime": 1782562830.68455,
+    "mtime": 1782568238.43899,
     "ast_hash": "c5a168298e3a0034164b719d059cd344",
     "semantic_hash": ""
   },
   "docs/integrations/visual.md": {
-    "mtime": 1782562830.68455,
+    "mtime": 1782568238.43899,
     "ast_hash": "97ada9f8191884da840bfa75b778edb3",
     "semantic_hash": ""
   },
   "docs/maintainers/agent-guidance.md": {
-    "mtime": 1782562830.6855505,
+    "mtime": 1782568238.4399953,
     "ast_hash": "444c4b07e9d347947eb7ed402a8a9866",
     "semantic_hash": ""
   },
   "docs/maintainers/ci-failure-investigation.md": {
-    "mtime": 1782562830.6855505,
+    "mtime": 1782568238.4399953,
     "ast_hash": "92c53bc7be0f4bc12bc7651662a182d2",
     "semantic_hash": ""
   },
   "docs/maintainers/history-rewrite.md": {
-    "mtime": 1782562830.6865504,
+    "mtime": 1782568238.440995,
     "ast_hash": "d45826fb4a4b1761f1c18456960ff08e",
     "semantic_hash": ""
   },
   "docs/maintainers/mcp-deployment.md": {
-    "mtime": 1782562830.6865504,
+    "mtime": 1782568238.440995,
     "ast_hash": "def4d269b70adb35f4579cb15ada7a25",
     "semantic_hash": ""
   },
   "docs/maintainers/overview.md": {
-    "mtime": 1782562830.6865504,
+    "mtime": 1782568238.440995,
     "ast_hash": "6d8541c0686c2dedcca528e3e1052a97",
     "semantic_hash": ""
   },
   "docs/maintainers/pilot-release.md": {
-    "mtime": 1782562830.6875508,
+    "mtime": 1782568238.4419956,
     "ast_hash": "792cba3bd1f4d747908fa210acd5b92b",
     "semantic_hash": ""
   },
   "docs/maintainers/publication.md": {
-    "mtime": 1782562830.6875508,
+    "mtime": 1782568238.4419956,
     "ast_hash": "c50db868122c5e68aa3aa2bb7efcbcad",
     "semantic_hash": ""
   },
   "docs/maintainers/reactor.md": {
-    "mtime": 1782562830.6875508,
+    "mtime": 1782568238.442996,
     "ast_hash": "c6a0cad254f0be1b580393e51bb8b5d5",
     "semantic_hash": ""
   },
   "docs/maintainers/site-operations.md": {
-    "mtime": 1782562830.6885512,
+    "mtime": 1782568238.442996,
     "ast_hash": "0626e0cbe38034a30d9f3eb0adcb0adf",
     "semantic_hash": ""
   },
   "docs/maintainers/visual-provider.md": {
-    "mtime": 1782562830.6885512,
+    "mtime": 1782568238.443994,
     "ast_hash": "44ff03d3eaaf85573c233da6f3c1a875",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/API_Authentication.md": {
-    "mtime": 1782562830.6895509,
+    "mtime": 1782568238.4450018,
     "ast_hash": "a99080386a02b9904c7731e9cb017004",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/GraphQL_Testing.md": {
-    "mtime": 1782562830.6895509,
+    "mtime": 1782568238.4450018,
     "ast_hash": "5acc0ba8ae31807163a2dc1f4f031367",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Request_Builder.md": {
-    "mtime": 1782562830.6905518,
+    "mtime": 1782568238.4450018,
     "ast_hash": "63f80951d53c433863a5d6cd0cccb6e3",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Response_Getters.md": {
-    "mtime": 1782562830.6905518,
+    "mtime": 1782568238.445995,
     "ast_hash": "eb212a23a31a07d634c49dbbb554665e",
     "semantic_hash": ""
   },
   "docs/reference/actions/API/Response_Validations.md": {
-    "mtime": 1782562830.6905518,
+    "mtime": 1782568238.4469967,
     "ast_hash": "e024d75f119b51db063176bf304e8089",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/Docker_Terminal.md": {
-    "mtime": 1782562830.6915498,
+    "mtime": 1782568238.4469967,
     "ast_hash": "83ba508b0dfe6cf54986a0d0a7648833",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/File_Actions.md": {
-    "mtime": 1782562830.6915498,
+    "mtime": 1782568238.447995,
     "ast_hash": "86eca4e871423a8b8f3379f665e0f4d2",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/SSH_Terminal.md": {
-    "mtime": 1782562830.6925504,
+    "mtime": 1782568238.4489942,
     "ast_hash": "ad2acb12ad60a7f0dd8bfb8f7995cbeb",
     "semantic_hash": ""
   },
   "docs/reference/actions/CLI/Terminal_Actions.md": {
-    "mtime": 1782562830.6925504,
+    "mtime": 1782568238.4489942,
     "ast_hash": "d47e8b6063f8bbdbdb5372da8735da82",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/Connection_Strings.md": {
-    "mtime": 1782562830.6935508,
+    "mtime": 1782568238.4499953,
     "ast_hash": "6518d156d692623f088a8aa0623b16af",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/DB_Actions.md": {
-    "mtime": 1782562830.6935508,
+    "mtime": 1782568238.4499953,
     "ast_hash": "2d0e13fddb17dcf33d5c26ca604439e0",
     "semantic_hash": ""
   },
   "docs/reference/actions/DB/Oracle_JDBC_Setup.md": {
-    "mtime": 1782562830.6935508,
+    "mtime": 1782568238.4509966,
     "ast_hash": "2688d27b7eeafad3767edcf62f9963ef",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Alert_Actions.md": {
-    "mtime": 1782562830.6945496,
+    "mtime": 1782568238.451995,
     "ast_hash": "91bc6269bcff898aea5ea1d27a2fda54",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Async_Element_Actions.md": {
-    "mtime": 1782562830.6945496,
+    "mtime": 1782568238.451995,
     "ast_hash": "03fa9f78d1242f6db3acc610282e0cad",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Browser_Actions.md": {
-    "mtime": 1782562830.6955514,
+    "mtime": 1782568238.451995,
     "ast_hash": "213e330a739fb82f1c176b65ec245ccf",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Did_You_Know.md": {
-    "mtime": 1782562830.6955514,
+    "mtime": 1782568238.4529948,
     "ast_hash": "26e991c7d1b405d9608dfe052d310e6b",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Actions.md": {
-    "mtime": 1782562830.6965518,
+    "mtime": 1782568238.4529948,
     "ast_hash": "86315db9dbc720658c336fba5c3ce928",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Identification.md": {
-    "mtime": 1782562830.6965518,
+    "mtime": 1782568238.4529948,
     "ast_hash": "40ff98a7639559d194e00dc75a9909ca",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Element_Validations.md": {
-    "mtime": 1782562830.6965518,
+    "mtime": 1782568238.4544995,
     "ast_hash": "c44e3358c3d6f294a975efb0050b5c82",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Natural_Language_Actions.md": {
-    "mtime": 1782562830.6975508,
+    "mtime": 1782568238.4544995,
     "ast_hash": "c3d45a73794b074f0533803d4469ef88",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Playwright_Backend.md": {
-    "mtime": 1782562830.6975508,
+    "mtime": 1782568238.4544995,
     "ast_hash": "2e5cc466c3b8eda259b124f9eb7adfdc",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/Touch_Actions.md": {
-    "mtime": 1782562830.6975508,
+    "mtime": 1782568238.4555051,
     "ast_hash": "b3db8adc5eecccf9fe184885103ff1a8",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/ARIA_Locators.md": {
-    "mtime": 1782562830.6985505,
+    "mtime": 1782568238.4555051,
     "ast_hash": "f679c221d416da847b47e8d43c819da5",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Accessibility_Testing.md": {
-    "mtime": 1782562830.6985505,
+    "mtime": 1782568238.4565103,
     "ast_hash": "add6d9310d0b9dc8c398af7914958447",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Async_Element_Actions.md": {
-    "mtime": 1782562830.6995518,
+    "mtime": 1782568238.4565103,
     "ast_hash": "e879f24d5a6e8d264855e3d930f9e40a",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Clipboard_Actions.md": {
-    "mtime": 1782562830.6995518,
+    "mtime": 1782568238.4575095,
     "ast_hash": "1683b153d24b8029daff9f000179cc93",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Custom_Capabilities.md": {
-    "mtime": 1782562830.6995518,
+    "mtime": 1782568238.4575095,
     "ast_hash": "577c4ecc43c196464508ceab69264200",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Explicit_Waits.md": {
-    "mtime": 1782562830.7005496,
+    "mtime": 1782568238.4575095,
     "ast_hash": "86fb7d2efe6e51f09cfb068bc89bba5c",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Integrate_JIRA_With_SHAFT_Engine.md": {
-    "mtime": 1782562830.7005496,
+    "mtime": 1782568238.4585104,
     "ast_hash": "7856ec48c3191ef7ee79d75d6547cd76",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Kubernetes_Selenium_Grid.md": {
-    "mtime": 1782562830.7005496,
+    "mtime": 1782568238.4585104,
     "ast_hash": "121a549a8d2650182324c2cad14fbf62",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Local_Selenium_Grid_Execution.md": {
-    "mtime": 1782562830.7015502,
+    "mtime": 1782568238.4585104,
     "ast_hash": "fe2da77d088372dee503b2ff37ae3972",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Mobile_Emulation.md": {
-    "mtime": 1782562830.7015502,
+    "mtime": 1782568238.45951,
     "ast_hash": "3dbd4bc2af4a0c0e4457f8dd70fb3d63",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Native_selenium_Webdriver.md": {
-    "mtime": 1782562830.7015502,
+    "mtime": 1782568238.4605098,
     "ast_hash": "6cfffeb9614a4009a196c6a1c5094f38",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Network_Mocking.md": {
-    "mtime": 1782562830.7025504,
+    "mtime": 1782568238.4605098,
     "ast_hash": "e1e05129a8a669a301465b9e922fc9b0",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Self_Healing_Locators.md": {
-    "mtime": 1782562830.7025504,
+    "mtime": 1782568238.4605098,
     "ast_hash": "73a78c3362dd9e389ae1c8a4de6e2120",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Shadow_Dom_Locator_Builder.md": {
-    "mtime": 1782562830.7035503,
+    "mtime": 1782568238.4615102,
     "ast_hash": "51096ad86850c47247dab8475de4934a",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder.md": {
-    "mtime": 1782562830.7035503,
+    "mtime": 1782568238.4615102,
     "ast_hash": "bfc0af12555aeb2733b7fa5d57c880ba",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Smart_Locators.md": {
-    "mtime": 1782562830.7035503,
+    "mtime": 1782568238.4615102,
     "ast_hash": "e9c4f4ab95292f8bdaeb418cae2cbd74",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md": {
-    "mtime": 1782562830.704552,
+    "mtime": 1782568238.4625103,
     "ast_hash": "60e66185a54f5b26d3a011e89941769c",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/Visual_Testing.md": {
-    "mtime": 1782562830.704552,
+    "mtime": 1782568238.4625103,
     "ast_hash": "59a7ecebed41952d1bd53bff4ccafa57",
     "semantic_hash": ""
   },
   "docs/reference/actions/GUI/didYouKnow/iFrame_Handling.md": {
-    "mtime": 1782562830.704552,
+    "mtime": 1782568238.4635117,
     "ast_hash": "e5e4709cbec473793ca2ac56bd89741e",
     "semantic_hash": ""
   },
   "docs/reference/actions/TestData_Management.md": {
-    "mtime": 1782562830.7055535,
+    "mtime": 1782568238.4635117,
     "ast_hash": "0203e3c310886cb80901bc132fcf81a3",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Browser.md": {
-    "mtime": 1782562830.7055535,
+    "mtime": 1782568238.464513,
     "ast_hash": "75bccc797afeac565a60a871ad56bc94",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Elements.md": {
-    "mtime": 1782562830.7065506,
+    "mtime": 1782568238.4655118,
     "ast_hash": "cf09d1e04846e8304b03730d368a2d72",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Files.md": {
-    "mtime": 1782562830.7065506,
+    "mtime": 1782568238.4655118,
     "ast_hash": "c3c0d57ed3d5a923f9d0404a65eebb01",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/ForceFail.md": {
-    "mtime": 1782562830.7065506,
+    "mtime": 1782568238.4655118,
     "ast_hash": "45a25fd37095702977ede2259528b496",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/JSON_Schema_Validation.md": {
-    "mtime": 1782562830.7075512,
+    "mtime": 1782568238.4665146,
     "ast_hash": "76e02d9db46cfa48b92b399eb949de3b",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Nums.md": {
-    "mtime": 1782562830.7075512,
+    "mtime": 1782568238.4665146,
     "ast_hash": "787b1223b5980d1c4aa6930423c6994e",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Objects.md": {
-    "mtime": 1782562830.7085502,
+    "mtime": 1782568238.4675145,
     "ast_hash": "4068bb1313a3cbd5da264765f7d7b00d",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Overview.md": {
-    "mtime": 1782562830.7085502,
+    "mtime": 1782568238.4675145,
     "ast_hash": "5694838b5e8ad855a2e6e79d0e2c003b",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Response.md": {
-    "mtime": 1782562830.7085502,
+    "mtime": 1782568238.4675145,
     "ast_hash": "2c9df47adcbab052cdb8402e37ebf21e",
     "semantic_hash": ""
   },
   "docs/reference/actions/Validations/Soft_vs_Hard_Assertions.md": {
-    "mtime": 1782562830.7095506,
+    "mtime": 1782568238.4685142,
     "ast_hash": "de25ff960dd3aeb8302cdcbfb54cd001",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig.md": {
-    "mtime": 1782562830.7095506,
-    "ast_hash": "b09f7e73c5a57118d4d757984548e9aa",
+    "mtime": 1782568263.0786972,
+    "ast_hash": "41726b8b5254de90386c5f8d0b869317",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig2.md": {
-    "mtime": 1782562830.7105505,
+    "mtime": 1782568238.4695146,
     "ast_hash": "a0aa8c409b01842e842b412918b4857b",
     "semantic_hash": ""
   },
   "docs/reference/configuration/basicConfig3.md": {
-    "mtime": 1782562830.7105505,
+    "mtime": 1782568238.4695146,
     "ast_hash": "3ed52dc1c072889cff2496ac5bedf0ff",
     "semantic_hash": ""
   },
   "docs/reference/configuration/parallelExecution.md": {
-    "mtime": 1782562830.7105505,
+    "mtime": 1782568238.4705138,
     "ast_hash": "54f5e27ab50d7ed23b3dd6c17f3a2b28",
     "semantic_hash": ""
   },
   "docs/reference/guides/Architecture.md": {
-    "mtime": 1782562830.7115505,
+    "mtime": 1782568238.4705138,
     "ast_hash": "23839503a280197e0fb80984e09fcae4",
     "semantic_hash": ""
   },
   "docs/reference/guides/BDD_Style_Reports.md": {
-    "mtime": 1782562830.7115505,
+    "mtime": 1782568238.4715142,
     "ast_hash": "1ac07b7d8fe95f36ed7c6ca3ed58ddc1",
     "semantic_hash": ""
   },
   "docs/reference/guides/CI_CD_Integration.md": {
-    "mtime": 1782562830.7125516,
+    "mtime": 1782568238.4715142,
     "ast_hash": "85df642c49d020d969e9850ad1b2fb41",
     "semantic_hash": ""
   },
   "docs/reference/guides/Cross_Platform_Strategy.md": {
-    "mtime": 1782562830.7125516,
+    "mtime": 1782568238.4715142,
     "ast_hash": "7419fbeccf4a23f050c55ae29c046c2d",
     "semantic_hash": ""
   },
   "docs/reference/guides/Cucumber_BDD_Steps.md": {
-    "mtime": 1782562830.7135568,
+    "mtime": 1782568238.4730446,
     "ast_hash": "6e5075ad337e26345760be40bdf9e4a8",
     "semantic_hash": ""
   },
   "docs/reference/guides/Element_Identification.md": {
-    "mtime": 1782562830.7135568,
+    "mtime": 1782568238.4740562,
     "ast_hash": "d08e71b238fb4ddaed3ec39c732903c6",
     "semantic_hash": ""
   },
   "docs/reference/guides/Fluent_Design.md": {
-    "mtime": 1782562830.7135568,
+    "mtime": 1782568238.4740562,
     "ast_hash": "de73ea88d2d812c5dcc28494bcc8225b",
     "semantic_hash": ""
   },
   "docs/reference/guides/JUnit5_Integration.md": {
-    "mtime": 1782562830.714555,
+    "mtime": 1782568238.4740562,
     "ast_hash": "8bf454d914ab312c4ddb8e3b176cf5af",
     "semantic_hash": ""
   },
   "docs/reference/guides/Solution_Design.md": {
-    "mtime": 1782562830.714555,
+    "mtime": 1782568238.4750555,
     "ast_hash": "f60d8e095a5c7befaea9491c8acf9f5d",
     "semantic_hash": ""
   },
   "docs/reference/guides/Test_Artifacts.md": {
-    "mtime": 1782562830.714555,
+    "mtime": 1782568238.4750555,
     "ast_hash": "3c35f334722be8a05a323f0bef91861a",
     "semantic_hash": ""
   },
   "docs/reference/guides/Test_Structure.md": {
-    "mtime": 1782562830.7155557,
+    "mtime": 1782568238.476056,
     "ast_hash": "a867d468628b5e29e3b868b5299066f5",
     "semantic_hash": ""
   },
   "docs/reference/guides/Testing_Pyramid.md": {
-    "mtime": 1782562830.7155557,
+    "mtime": 1782568238.476056,
     "ast_hash": "7b6745e7b75c04da46b6802734c3b9ef",
     "semantic_hash": ""
   },
   "docs/reference/guides/Tool_Selection.md": {
-    "mtime": 1782562830.7165563,
+    "mtime": 1782568238.476056,
     "ast_hash": "704b6983fe0527aa422f690fcf78e41f",
     "semantic_hash": ""
   },
   "docs/reference/overview.md": {
-    "mtime": 1782562830.7165563,
+    "mtime": 1782568238.4770558,
     "ast_hash": "26bc45e46edb47f1b8e8239b949f54e7",
     "semantic_hash": ""
   },
   "docs/reference/properties/CommonExamples.mdx": {
-    "mtime": 1782562830.7175555,
+    "mtime": 1782568238.4780562,
     "ast_hash": "5dfe069a48fa36e5198d31bd33be51c4",
     "semantic_hash": ""
   },
   "docs/reference/properties/Programmatic_Config.md": {
-    "mtime": 1782562830.7175555,
+    "mtime": 1782568238.4780562,
     "ast_hash": "c3b255af9826d00b071cb937f5804549",
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertiesList.mdx": {
-    "mtime": 1782562830.7185564,
+    "mtime": 1782568238.4800563,
     "ast_hash": "9bdfaa9c7af9c6ccdbf65a81690cfe65",
     "semantic_hash": ""
   },
   "docs/reference/properties/PropertyTypes.md": {
-    "mtime": 1782562830.7185564,
+    "mtime": 1782568238.4800563,
     "ast_hash": "b1107ffb2638546976fc7335a33a99b9",
     "semantic_hash": ""
   },
   "docs/reference/properties/custom-properties-generator.mdx": {
-    "mtime": 1782562830.7195542,
+    "mtime": 1782568238.4800563,
     "ast_hash": "298e62b3e809eed6646ab188a5e1d260",
     "semantic_hash": ""
   },
   "docs/reference/reporting/Custom_Report_Messages.md": {
-    "mtime": 1782562830.7195542,
+    "mtime": 1782568238.4810576,
     "ast_hash": "ed23940cdf10b241b73c0b813dda84d6",
     "semantic_hash": ""
   },
   "docs/reference/reporting/reporting.mdx": {
-    "mtime": 1782562830.7205546,
+    "mtime": 1782568238.4820566,
     "ast_hash": "b79e60b161691fef814f61f29ecce666",
     "semantic_hash": ""
   },
   "docs/start/installation.mdx": {
-    "mtime": 1782562830.7205546,
+    "mtime": 1782568238.4820566,
     "ast_hash": "bda8ce33a70fd7d71fb7d8fb842b20a8",
     "semantic_hash": ""
   },
   "docs/start/overview.mdx": {
-    "mtime": 1782562830.7215517,
+    "mtime": 1782568238.4830563,
     "ast_hash": "8d51c21b827b287c923bc36f031da01c",
     "semantic_hash": ""
   },
   "docs/start/upgrade.mdx": {
-    "mtime": 1782562830.7225559,
+    "mtime": 1782568238.4840565,
     "ast_hash": "ee2db856ed9d77101935424beb4ec1aa",
     "semantic_hash": ""
   },
   "docs/testing/api.mdx": {
-    "mtime": 1782562830.7245548,
+    "mtime": 1782568238.4870555,
     "ast_hash": "47bb0628a2c29beee12e51c5b4df96c3",
     "semantic_hash": ""
   },
   "docs/testing/cli.md": {
-    "mtime": 1782562830.7245548,
+    "mtime": 1782568238.4870555,
     "ast_hash": "5020720f108444d72bf6597afd5e1a53",
     "semantic_hash": ""
   },
   "docs/testing/database.md": {
-    "mtime": 1782562830.7255547,
+    "mtime": 1782568238.4880567,
     "ast_hash": "2e8599fc5d0f32f1c3f33e30858e019f",
     "semantic_hash": ""
   },
   "docs/testing/mobile.md": {
-    "mtime": 1782562830.726555,
+    "mtime": 1782568238.489094,
     "ast_hash": "38443c6165c6ef8ea8ffbf9297121467",
     "semantic_hash": ""
   },
   "docs/testing/web.mdx": {
-    "mtime": 1782562830.726555,
+    "mtime": 1782568238.4901047,
     "ast_hash": "eb5a0122118a012991dc78483787dc03",
     "semantic_hash": ""
   },
   "static/google7a9ed995e574e7e9.html": {
-    "mtime": 1782562830.7726233,
+    "mtime": 1782568238.5446515,
     "ast_hash": "4d0d5c52c1d5a466c2516742d98b05ee",
     "semantic_hash": ""
   },
   "static/robots.txt": {
-    "mtime": 1782562830.8156219,
+    "mtime": 1782568238.6007018,
     "ast_hash": "a17931d0ec73cff4d3be5ed847888e16",
     "semantic_hash": ""
   },
   "static/img/JIRA/Account_settings.png": {
-    "mtime": 1782562830.7736228,
+    "mtime": 1782568238.5456533,
     "ast_hash": "758be0c1dc99b4d464b788d3ee0f21db",
     "semantic_hash": ""
   },
   "static/img/JIRA/Label.png": {
-    "mtime": 1782562830.775623,
+    "mtime": 1782568238.5476515,
     "ast_hash": "b3531e26b8bafb25064e46a0358125c0",
     "semantic_hash": ""
   },
   "static/img/JIRA/Security_Tap.png": {
-    "mtime": 1782562830.7766228,
+    "mtime": 1782568238.5486517,
     "ast_hash": "8c949453e0b50763fa301efea3325a98",
     "semantic_hash": ""
   },
   "static/img/autobot-avatar.svg": {
-    "mtime": 1782562830.7776232,
+    "mtime": 1782568238.5496514,
     "ast_hash": "ee9b4ef90bf10f6db0e44aa164442b4f",
     "semantic_hash": ""
   },
   "static/img/code.svg": {
-    "mtime": 1782562830.778623,
+    "mtime": 1782568238.5516522,
     "ast_hash": "c2450ac71613aa602e1a05a674a41183",
     "semantic_hash": ""
   },
   "static/img/easy.svg": {
-    "mtime": 1782562830.7796226,
+    "mtime": 1782568238.5526516,
     "ast_hash": "60e67f962686803fa3b43c2fa42900ba",
     "semantic_hash": ""
   },
   "static/img/logo.svg": {
-    "mtime": 1782562830.7806234,
+    "mtime": 1782568238.5536516,
     "ast_hash": "aef5dff11792d8a1fcc61d8aca9e5025",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/claude.svg": {
-    "mtime": 1782562830.7806234,
+    "mtime": 1782568238.5536516,
     "ast_hash": "46486fd772561b765651afd11d9baffc",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/github-copilot.svg": {
-    "mtime": 1782562830.781623,
+    "mtime": 1782568238.5546517,
     "ast_hash": "e7370db8dcbb829fd83d8df43c697fef",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/intellij-idea.svg": {
-    "mtime": 1782562830.781623,
+    "mtime": 1782568238.5551572,
     "ast_hash": "de44a4b672f84126d8d99502fafce366",
     "semantic_hash": ""
   },
   "static/img/mcp-clients/openai.svg": {
-    "mtime": 1782562830.782623,
+    "mtime": 1782568238.5551572,
     "ast_hash": "0f750d4f4f5f84bb042ced00f295bb66",
     "semantic_hash": ""
   },
   "static/img/png/code.png": {
-    "mtime": 1782562830.782623,
+    "mtime": 1782568238.5561638,
     "ast_hash": "34340deb5105399edca4c36c4abeddf7",
     "semantic_hash": ""
   },
   "static/img/png/easy.png": {
-    "mtime": 1782562830.7836225,
+    "mtime": 1782568238.5561638,
     "ast_hash": "ae2716ac04b4d420c8b23777c0adf9a9",
     "semantic_hash": ""
   },
   "static/img/png/logo.png": {
-    "mtime": 1782562830.7836225,
+    "mtime": 1782568238.5581691,
     "ast_hash": "130e29551be112933a2710dd3c61fa4d",
     "semantic_hash": ""
   },
   "static/img/png/mindmap.png": {
-    "mtime": 1782562830.7876227,
+    "mtime": 1782568238.5621676,
     "ast_hash": "cc63ad8937c730036e5a7e503de73d6b",
     "semantic_hash": ""
   },
   "static/img/png/selenium.png": {
-    "mtime": 1782562830.7876227,
+    "mtime": 1782568238.5631692,
     "ast_hash": "a9af07deef806c3739c976e707cbcb11",
     "semantic_hash": ""
   },
   "static/img/png/shaft.png": {
-    "mtime": 1782562830.7876227,
+    "mtime": 1782568238.5631692,
     "ast_hash": "130e29551be112933a2710dd3c61fa4d",
     "semantic_hash": ""
   },
   "static/img/png/shaft_bg.png": {
-    "mtime": 1782562830.7886229,
+    "mtime": 1782568238.5641687,
     "ast_hash": "5a81c90f9ccba7b82ee864cfadf318a5",
     "semantic_hash": ""
   },
   "static/img/pr/release-contributor-avatars-32px.png": {
-    "mtime": 1782562830.7896225,
+    "mtime": 1782568238.5651693,
     "ast_hash": "aba4c4b64bf43f240d2b1a7af26a216a",
     "semantic_hash": ""
   },
   "static/img/pr/release-resources-links-updated.png": {
-    "mtime": 1782562830.7916253,
+    "mtime": 1782568238.5681698,
     "ast_hash": "602ef3b80f494b2841896cf2be509988",
     "semantic_hash": ""
   },
   "static/img/selenium.svg": {
-    "mtime": 1782562830.8106222,
+    "mtime": 1782568238.5937016,
     "ast_hash": "b648a25671137e687b2c574a8b4e3b5b",
     "semantic_hash": ""
   },
   "static/img/shaft-automation-hero.png": {
-    "mtime": 1782562830.8126216,
+    "mtime": 1782568238.5977,
     "ast_hash": "67b14d3e88001929554cd9cb9f343ef4",
     "semantic_hash": ""
   },
   "static/img/shaft-automation-hero.webp": {
-    "mtime": 1782562830.8136241,
+    "mtime": 1782568238.5987022,
     "ast_hash": "4c185fe996dd86fc76874aec08e1c865",
     "semantic_hash": ""
   },
   "static/img/shaft.svg": {
-    "mtime": 1782562830.8146226,
+    "mtime": 1782568238.5997024,
     "ast_hash": "64e523a48c02aed838b2fc5b5aed8b09",
     "semantic_hash": ""
   },
   "static/img/shaft_bg.svg": {
-    "mtime": 1782562830.8146226,
+    "mtime": 1782568238.5997024,
     "ast_hash": "02fbab86799674757030d187d263d3ec",
     "semantic_hash": ""
   },
   "static/img/shaft_white.svg": {
-    "mtime": 1782562830.8156219,
+    "mtime": 1782568238.6007018,
     "ast_hash": "bb879f9ab9e674ae6aff9f2be911b17a",
     "semantic_hash": ""
   },
   "blog/2026-06-23-release-10.2.20260623.md": {
-    "mtime": 1782562830.6675515,
+    "mtime": 1782568238.4149547,
     "ast_hash": "18304f4b938951eaeaecb38516f04d02",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-06-24-flakiness-guide.md": {
-    "mtime": 1782562830.7225559,
+    "mtime": 1782568238.485056,
     "ast_hash": "e444393d7f2437a2d60d17b225425a1a",
     "semantic_hash": ""
   },
   "docs/testing/flakiness.mdx": {
-    "mtime": 1782562830.7255547,
-    "ast_hash": "94d168c69d9835681b6b2c3c509f7436",
+    "mtime": 1782568257.6317756,
+    "ast_hash": "b1aaec3470d04ce40e3ecfbf0fe6cd2c",
     "semantic_hash": ""
   },
   "docs/features/test-automation-pillars.mdx": {
-    "mtime": 1782562830.6835506,
+    "mtime": 1782568238.4379816,
     "ast_hash": "4a9359c91b22d69c1e1e67a47cd4bd23",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-06-24-test-automation-pillars-guide.md": {
-    "mtime": 1782562830.7235556,
+    "mtime": 1782568238.486056,
     "ast_hash": "53a97943d6ca600585c6f6459f83f9be",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-landing-ux-desktop.png": {
-    "mtime": 1782562830.8086216,
+    "mtime": 1782568238.591701,
     "ast_hash": "322381dc3abf225156821248107282f3",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-landing-ux-mobile.png": {
-    "mtime": 1782562830.809625,
+    "mtime": 1782568238.5927017,
     "ast_hash": "2a54041852a20e679d6577f475d45308",
     "semantic_hash": ""
   },
   "docs/start/quick-start.mdx": {
-    "mtime": 1782562830.7215517,
+    "mtime": 1782568238.4830563,
     "ast_hash": "bf45a3633f37e5c5560391899163ce32",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-06-25-user-guide-growth-conversion.md": {
-    "mtime": 1782562830.7235556,
+    "mtime": 1782568238.486056,
     "ast_hash": "57a7bc099290b1e1983f617f01ef46e4",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-01-properties-reference.png": {
-    "mtime": 1782562830.7926216,
+    "mtime": 1782568238.570169,
     "ast_hash": "ce200fe34b8e5a6fb3c7ee404e89ec65",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-02-install-first-run.png": {
-    "mtime": 1782562830.7936225,
+    "mtime": 1782568238.5711691,
     "ast_hash": "fc10a990c91657bef1d8ea2d777abe9a",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-03-task-guides-web.png": {
-    "mtime": 1782562830.7946222,
+    "mtime": 1782568238.571674,
     "ast_hash": "8d2eaf7727388bad319662e46cccf389",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-04-upgrade-scan-first.png": {
-    "mtime": 1782562830.7966232,
+    "mtime": 1782568238.5751846,
     "ast_hash": "004649eafd572a8d2db36c493fd401cd",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-05-reference-router.png": {
-    "mtime": 1782562830.7976234,
+    "mtime": 1782568238.5771856,
     "ast_hash": "6af99a33bd5232033c0327075dd68e3f",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-06-version-baseline.png": {
-    "mtime": 1782562830.7986238,
+    "mtime": 1782568238.578186,
     "ast_hash": "15cc3b6b19114842131a9860d7b0ea09",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-07-locator-strategy.png": {
-    "mtime": 1782562830.7996237,
+    "mtime": 1782568238.580185,
     "ast_hash": "7b8cbb692acafc6e5a62f21f1ebb2d2f",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-08-snippets-overview.png": {
-    "mtime": 1782562830.800624,
+    "mtime": 1782568238.5811858,
     "ast_hash": "75732a95a248952b463e1a601a23c6c5",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-09-homepage-conversion-desktop.png": {
-    "mtime": 1782562830.8036218,
+    "mtime": 1782568238.5851843,
     "ast_hash": "eb485caae0825fd556d868e72f516218",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-09-homepage-conversion-mobile.png": {
-    "mtime": 1782562830.8046248,
+    "mtime": 1782568238.5871854,
     "ast_hash": "7c505065e00a6c50d0c02721e7248f3c",
     "semantic_hash": ""
   },
   "static/img/pr/userguide-growth/story-10-quick-win-star.png": {
-    "mtime": 1782562830.8056254,
+    "mtime": 1782568238.5881853,
     "ast_hash": "f841d1b686f2bcdffec2b1b8f77f85ea",
     "semantic_hash": ""
   },
   "docs/testing/contracts.mdx": {
-    "mtime": 1782562830.7245548,
+    "mtime": 1782568238.4880567,
     "ast_hash": "c60626cdf71092ed6103abb3598bf824",
     "semantic_hash": ""
   },
   "static/img/capture-assertion-mode.png": {
-    "mtime": 1782562830.7776232,
+    "mtime": 1782568238.5506523,
     "ast_hash": "914057cc72caee261a428e4438a3c3e1",
     "semantic_hash": ""
   },
   "static/img/capture-locator-picker.png": {
-    "mtime": 1782562830.778623,
+    "mtime": 1782568238.5516522,
     "ast_hash": "4a40cbc52c67685521ae022733a12b0e",
     "semantic_hash": ""
   },
   "static/img/allure3_main_light.png": {
-    "mtime": 1782562830.7766228,
+    "mtime": 1782568238.5496514,
     "ast_hash": "2e12ba57c35301fde1f6a6a0566c85a4",
     "semantic_hash": ""
   }


### PR DESCRIPTION
## Summary
- document lazy-loading readiness signals, post-wait native action checks, and new network idle tuning keys
- update the basic configuration timeout example
- refresh Graphify output

## Validation
- npm run test:docs
- npm run build
- graphify update .

Note: docs validation used the existing main checkout node_modules via an ignored junction in this isolated worktree. The build emitted existing Docusaurus blog truncation warnings.