### PR TITLE
[codex] Document DPI-tolerant image actions

### DIFF
--- a/docs/integrations/visual.md
+++ b/docs/integrations/visual.md
@@ -61,6 +61,7 @@ flowchart TD
 | `matchesReferenceImage(VisualValidationEngine)`                | OpenCV, Shutterbug, or Eyes comparison selected by the enum. Playwright routes `Locator.screenshot()` bytes through the provider; Shutterbug requests fall back to OpenCV because Shutterbug is Selenium-backed. |
 | `doesNotMatchReferenceImage()` and its overload                | Negative OpenCV/visual-engine comparison.                    |
 | `TouchActions.tap(String)`                                     | Finds and taps an image inside the current screen.           |
+| `TouchActions.type(String, ...)`                               | Finds an image, taps it, then types into the active field.   |
 | `TouchActions.waitUntilElementIsVisible(String)`               | Waits for an image match.                                    |
 | `TouchActions.waitUntilElementIsNotVisible(String)`            | Waits until an image match disappears from the screen.       |
 | `TouchActions.swipeElementIntoView(String, ...)`               | Swipes until the reference image is found.                   |
@@ -68,6 +69,11 @@ flowchart TD
 | `ImageProcessingActions.compareAgainstBaseline(...)`           | Direct baseline comparison.                                  |
 | `ImageProcessingActions.loadOpenCV()`                          | Explicit provider/native-library loading.                    |
 | Built-in Cucumber OpenCV, Shutterbug, and Eyes assertion steps | Delegates to the same provider.                              |
+
+Image-path touch actions compare against viewport screenshots and return
+viewport-relative coordinates for Selenium/Appium pointer actions. OpenCV
+matching is scale-tolerant, so a cropped reference image can be captured at a
+different DPI or display scale than the current app screenshot.
 
 The bundled TestNG/JUnit web samples use:
 

--- a/docs/maintainers/visual-provider.md
+++ b/docs/maintainers/visual-provider.md
@@ -27,9 +27,15 @@ optional computer-vision behavior out of `shaft-engine` without moving screensho
 
 Public fluent APIs that reach the provider include
 `matchesReferenceImage(...)`, `doesNotMatchReferenceImage(...)`,
-`TouchActions.tap(String)`, `TouchActions.waitUntilElementIsVisible(String)`,
-and the image-path `swipeElementIntoView(...)` overloads. The focused
+`TouchActions.tap(String)`, `TouchActions.type(String, ...)`,
+`TouchActions.waitUntilElementIsVisible(String)`, and the image-path
+`swipeElementIntoView(...)` overloads. The focused
 [visual module guide](/docs/integrations/visual) is the consumer-facing reference.
+
+Image-path touch actions must pass viewport screenshot bytes into
+`findImageWithinCurrentPage`, because Selenium/Appium coordinate actions target
+the viewport. The OpenCV provider handles DPI/display-scale drift by matching
+scaled reference templates and returning the matched center point.
 
 `ScreenshotManager`, Selenium screenshot capture, and Healenium integration remain outside this provider boundary.
 

--- a/docs/reference/actions/GUI/Touch_Actions.md
+++ b/docs/reference/actions/GUI/Touch_Actions.md
@@ -24,6 +24,21 @@ By loginButton = By.id("login_btn");
 driver.touch().tap(loginButton);
 ```
 
+Reference-image taps use `shaft-visual` to find the image in the current
+viewport, then execute a Selenium/Appium pointer action at the matched center:
+
+```java title="ImageTapExample.java"
+driver.touch().tap("src/test/resources/dynamicObjectRepository/login-button.png");
+```
+
+### type()
+
+Taps a field found by reference image, then types into the focused field.
+
+```java title="ImageTypeExample.java"
+driver.touch().type("src/test/resources/dynamicObjectRepository/search-field.png", "SHAFT Engine");
+```
+
 ### doubleTap()
 
 Double-taps an element on a touch-enabled screen.
@@ -78,6 +93,16 @@ You can also specify a scrollable container:
 By scrollableContainer = By.id("list_view");
 By targetElement = By.id("item_50");
 driver.touch().swipeElementIntoView(scrollableContainer, targetElement, TouchActions.SwipeDirection.DOWN);
+```
+
+Image-path overloads scroll until the reference image is visible in the
+viewport. Selenium sessions use headless-safe page or element scrolling; Appium
+native sessions use Appium scroll gestures.
+
+```java title="ImageSwipeIntoViewExample.java"
+driver.touch().swipeElementIntoView(
+        "src/test/resources/dynamicObjectRepository/pay-now.png",
+        TouchActions.SwipeDirection.DOWN);
 ```
 
 ### swipeToEndOfView()
@@ -147,6 +172,10 @@ driver.touch().activateAppFromBackground("com.example.myapp");
 ```
 
 ## Visual Element Detection
+
+Image-path touch actions support cropped reference screenshots captured at a
+different DPI or display scale than the current app screenshot when
+`shaft-visual` is on the runtime classpath.
 
 ### waitUntilElementIsVisible()
 


### PR DESCRIPTION
## Summary
- document `TouchActions.type(String, ...)`
- document DPI/display-scale tolerant reference-image matching through `shaft-visual`
- update maintainer notes for viewport screenshots and scaled reference templates

## Validation
- `git diff --check --cached`
- `yarn install --frozen-lockfile`
- `npm run test:docs`
