### PR TITLE
[codex] Document IntelliJ onboarding sample generation updates

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -33,11 +33,11 @@ Use the Capture commands on
 the runnable MCP command reference and classpath notes.
 
 Use `--runtime-dir <path>` on every command to isolate control files. `stop`
-also accepts `--discard`. Only one recorder may own a runtime directory at a
-time. The daemon control endpoint is bound to loopback, requires a generated
-bearer token, and removes its token and descriptor at shutdown. Browser
-profiles are temporary and removed after normal stop or interruption unless
-`--user-data-dir <path>` is supplied.
+also accepts `--discard` (same as `capture_stop` with `discard=true`). Only one
+recorder may own a runtime directory at a time. The daemon control endpoint is
+bound to loopback, requires a generated bearer token, and removes its token and
+descriptor at shutdown. Browser profiles are temporary and removed after normal
+stop or interruption unless `--user-data-dir <path>` is supplied.
 
 `capture start` also accepts Playwright-codegen-shaped options where SHAFT can
 map them safely: `--viewport-size`, `--device`, `--color-scheme`,
@@ -127,7 +127,9 @@ For agent-driven MCP flows, the intended handoff is: call `capture_start` or
 `capture_start_codegen`, let the user interact with the visible browser, wait
 for either `capture_stop` or a browser-panel stop to complete, then call
 `capture_code_blocks` for WebDriver or `playwright_capture_code_blocks` for
-Playwright. The agent should show the generated result and ask whether the user
+Playwright. If a focus or click mistake pollutes the recording, the Assistant
+discard/re-record commands stop with `discard=true` before starting a fresh
+capture. The agent should show the generated result and ask whether the user
 wants the complete Java snippet or wants the agent to insert the code into the
 current repository. Snippet mode uses the returned Java full-class block,
 including imports, setup, inline `SHAFT.GUI.Locator.*` locators, SHAFT

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -153,9 +153,14 @@ current-session tool evidence when exporting for issue review.
 
 ## Onboarding recording notes
 
-Use this preferred launch path for the recording workflow:
+Use this preferred launch path for the recording workflow from a clean, disposable
+IntelliJ sandbox/profile so onboarding state stays isolated:
 
 `gradle -p shaft-intellij runIde --args C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE`
+
+On Windows JDK21 onboarding, SHAFT now ensures `%JAVA_HOME%\Packages` exists
+before instrumentation starts. The flow shows explicit diagnostics for missing,
+invalid, or unwritable `JAVA_HOME` values instead of opaque startup failures.
 
 Use the same onboarding MCP flow: CODEX + CLI, Route = LOCAL, and Mode = AGENT.
 `Allow source edits` stays off for DuckDuckGo/browser flow and is enabled when the run
@@ -163,6 +168,9 @@ must change source files. If the step is expressed as "open the first result,"
 use the scoped 1-indexed XPath (`(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']`) for the first result.
 For deterministic verification, finish with a final page title and page-specific
 text check after opening that result before approving generated capture output.
+Use `discard recording` or `re-record` when a focus or click mistake pollutes
+the capture; the Assistant stops the current Capture session with
+`discard=true` before restarting.
 
 For recordings, dismiss sandbox-only low-memory or script-launcher warning balloons
 without suppressing normal production IDE warnings. IntelliJ Trust Project may

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -120,9 +120,22 @@ and say when the guide does not contain enough evidence for an answer.
 ## Project creation and upgrade
 
 Use `shaft_project_create` to create a new SHAFT Maven project from the same
-example templates, runner/platform choices, optional module rules, GitHub
-Actions workflow templates, and Dependabot template used by the guide project
-generator.
+example templates, runner/platform choices, optional module rules, GitHub Actions
+workflow templates, and Dependabot template used by the guide project generator.
+
+`shaft_project_create` now accepts optional `shaftVersion`. Non-blank values
+override the generated `<shaft.version>` directly. Blank or null values default to
+the latest published stable `shaft-engine` from Maven Central. Bundled examples
+inside the SHAFT repository remain reactor-versioned; generated project POMs are
+rewritten during creation.
+
+```json
+{"tool": "shaft_project_create", "arguments": {"outputDirectory": "demo-web", "runner": "TestNG", "platform": "web", "shaftVersion": "10.3.0"}}
+```
+
+```json
+{"tool": "shaft_project_create", "arguments": {"outputDirectory": "demo-web", "runner": "TestNG", "platform": "web", "shaftVersion": ""}}
+```
 
 Use `shaft_project_upgrade` on an existing Java/Maven project to run the
 modular SHAFT upgrader script. Start with `dryRun: true`; applying changes

--- a/docs/start/quick-start.mdx
+++ b/docs/start/quick-start.mdx
@@ -161,7 +161,8 @@ database, CLI, screenshots, reporting, and test data workflows use
 {
   "searchQuery": "SHAFT_Engine",
   "expectedTitle": "DuckDuckGo",
-  "unexpectedInFirstResult": "Nope"
+  "expectedResultTitle": "SHAFT Engine",
+  "expectedResultText": "SHAFT Engine"
 }
 ```
 
@@ -206,7 +207,8 @@ public class TestClass {
 
   By logo = By.xpath("//div[contains(@class,'container_fullWidth__1H_L8')]//img");
   By searchBox = Locator.hasAnyTagName().hasAttribute("name", "q").build();
-  By firstSearchResult = Locator.hasTagName("article").isFirst().build();
+  By firstSearchResult = By.xpath(
+          "(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']");
 
   @Test
   public void navigateToDuckDuckGoAndAssertBrowserTitleIsDisplayedCorrectly() {
@@ -221,10 +223,12 @@ public class TestClass {
   }
 
   @Test
-  public void searchForQueryAndAssert() {
+  public void searchForQueryAndOpenFirstResultAndAssertTitleAndText() {
     driver.browser().navigateToURL(targetUrl)
             .and().element().type(searchBox, testData.get("searchQuery") + Keys.ENTER)
-            .and().assertThat(firstSearchResult).text().doesNotEqual(testData.get("unexpectedInFirstResult"));
+            .and().element().click(firstSearchResult)
+            .and().assertThat().title().contains(testData.get("expectedResultTitle"))
+            .and().element().assertThat(By.tagName("body")).text().contains(testData.get("expectedResultText"));
   }
 
   @BeforeClass
@@ -275,7 +279,8 @@ public class TestClass {
 
   By logo = By.xpath("//div[contains(@class,'container_fullWidth__1H_L8')]//img");
   By searchBox = Locator.hasAnyTagName().hasAttribute("name", "q").build();
-  By firstSearchResult = Locator.hasTagName("article").isFirst().build();
+  By firstSearchResult = By.xpath(
+          "(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']");
 
   @Test
   public void navigateToDuckDuckGoAndAssertBrowserTitleIsDisplayedCorrectly() {
@@ -290,10 +295,12 @@ public class TestClass {
   }
 
   @Test
-  public void searchForQueryAndAssert() {
+  public void searchForQueryAndOpenFirstResultAndAssertTitleAndText() {
     driver.browser().navigateToURL(targetUrl)
             .and().element().type(searchBox, testData.get("searchQuery") + Keys.ENTER)
-            .and().assertThat(firstSearchResult).text().doesNotEqual(testData.get("unexpectedInFirstResult"));
+            .and().element().click(firstSearchResult)
+            .and().assertThat().title().contains(testData.get("expectedResultTitle"))
+            .and().element().assertThat(By.tagName("body")).text().contains(testData.get("expectedResultText"));
   }
 
   @BeforeAll
@@ -369,6 +376,17 @@ public class StepDefinitions {
     driver.assertThat().browser().title().contains(expectedTitle);
   }
 
+  @Then("I open the first result")
+  public void i_open_the_first_result() {
+    driver.element().click(
+            By.xpath("(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']"));
+  }
+
+  @Then("I should see the page text contains {string}")
+  public void i_should_see_the_page_text_contains(String expectedText) {
+    driver.element().assertThat(By.tagName("body")).text().contains(expectedText);
+  }
+
   @Then("I close the browser")
   public void i_close_the_browser() {
     driver.quit();
@@ -386,6 +404,9 @@ Feature: Search functionality
     When I navigate to "https://duckduckgo.com/"
     Then I should see the page title contains "DuckDuckGo"
     When I search for "SHAFT_Engine"
+    Then I open the first result
+    Then I should see the page title contains "SHAFT Engine"
+    And I should see the page text contains "SHAFT Engine"
     Then I close the browser
 ```
 

--- a/docs/start/upgrade.mdx
+++ b/docs/start/upgrade.mdx
@@ -726,8 +726,10 @@ public void beforeMethod() {
 public void searchForQueryAndAssert() {
     driver.browser().navigateToURL(targetUrl)
             .and().element().type(searchBox, testData.get("searchQuery") + Keys.ENTER)
-            .and().assertThat(firstSearchResult).text()
-            .doesNotEqual(testData.get("unexpectedInFirstResult"));
+            .and().element().click(firstSearchResult)
+            .and().assertThat().title().contains(testData.get("expectedResultTitle"))
+            .and().element().assertThat(By.tagName("body")).text()
+            .contains(testData.get("expectedResultText"));
 }
 ```
 


### PR DESCRIPTION
## Summary
- Document IntelliJ onboarding preflight diagnostics, clean recording workflow, and discard/re-record commands.
- Document `shaft_project_create.shaftVersion` behavior and generated project version defaults.
- Update guide web samples to search DuckDuckGo, open the first result, and assert the destination title/body text.

## Validation
- `yarn test:docs`
- `yarn build`

Companion docs update for ShaftHQ/SHAFT_ENGINE#3244.