### PR TITLE
Document recorder persistence and copyable commands

### DIFF
--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -153,6 +153,8 @@ the current file or known project artifacts are available.
 A single JetBrains-style command-help icon appears in the composer. Hover it to
 view the tested command families without filling the chat with command
 documentation. The command picker also shows each command summary and example.
+Command-help output renders each example on its own line as a fenced command
+block, so the IDE copy button can copy one runnable command at a time.
 The visible palette includes `/codegen`, `/record-web`, `/record-mobile`,
 `/doctor`, `/guide`, `/guardrails`, `/browser`, `/mobile`, and `/project`.
 
@@ -199,11 +201,13 @@ Common examples:
 Responses render as Markdown. Known SHAFT responses, including local agent runs,
 provider chat, local client discovery, MCP `content[].text` envelopes, JSON
 payloads, and Java snippets, are parsed into readable sections, tables, or
-fenced code blocks. Unknown structured responses are formatted through the
-selected Assistant route when possible; if no formatter is available, the plugin
-falls back to a local Markdown-safe JSON/code rendering. Use the copy actions
-for rendered Markdown, raw support diagnostics, or the full transcript plus
-current-session tool evidence when exporting for issue review.
+fenced code blocks. When a browser or mobile recording stops successfully, the
+Assistant shows the next `/codegen ...` command in its own fenced block.
+Unknown structured responses are formatted through the selected Assistant route
+when possible; if no formatter is available, the plugin falls back to a local
+Markdown-safe JSON/code rendering. Use the copy actions for rendered Markdown,
+raw support diagnostics, or the full transcript plus current-session tool
+evidence when exporting for issue review.
 
 ## Onboarding recording notes
 

--- a/docs/agentic/pilot.md
+++ b/docs/agentic/pilot.md
@@ -77,6 +77,17 @@ fields, credential-shaped values, private paths, and unsafe locator evidence
 are excluded or redacted. Replay succeeds only when the generated project
 compiles, passes, and produces populated Allure result JSON.
 
+During recording, SHAFT writes actions incrementally so a cross-domain
+navigation does not discard earlier steps. Text entry is consolidated into a
+single type action until it is committed or followed by a special key, while
+keys such as Enter and Tab remain separate actions. The recorder overlay lets
+you edit or delete captured steps, and deleting a typed step also removes its
+externalized test-data reference. Each action keeps sanitized page context and a
+DOM snapshot so code generation can rank semantic, stable locators and honor a
+pinned locator preference. Stopping the recording closes the managed browser,
+saves the session, and returns the next `/codegen` command as a fenced command
+block.
+
 ## Doctor example
 
 Analyze only explicitly allowed evidence with the Doctor command on


### PR DESCRIPTION
## Summary
- document recorder incremental persistence, cross-domain continuity, edit/delete behavior, DOM snapshots, pinned locator behavior, and stop/codegen handoff
- document IntelliJ Assistant command examples and post-stop codegen hints as fenced copyable command blocks

## Validation
- git diff --check