### PR TITLE
docs: document recorder codegen handoff tools

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -192,6 +192,25 @@ SHAFT validates that the requested anchor is present when possible, but it never
 edits the source file until the calling agent performs a separately approved
 repository change.
 
+## Recorder/codegen enhancement plan
+
+The next recorder/codegen work is ordered around the moments where users still
+make manual decisions after recording. The goal is to turn each decision into a
+reviewable artifact before any source file is edited.
+
+| Rank | Enhancement | User-facing result |
+| --- | --- | --- |
+| 1 | Patch preview for record-at-target | `capture_record_at_target_code_blocks` and mobile record-at-target flows show the exact Java diff before an agent applies it. |
+| 2 | Existing-suite target scanner | The MCP server suggests likely Page Objects, test classes, package names, driver variables, and insertion anchors from the current repository. |
+| 3 | Assertion gap checklist | Generated results list missing post-login, post-submit, navigation, and error-state assertions. |
+| 4 | Locator confidence queue | Weak XPath, multi-match, and coordinate fallback steps are grouped into a fix-first review list. |
+| 5 | Fixture and secret handoff | Required environment variables, test data, and upload fixtures are summarized without exposing secret values. |
+| 6 | Flow grouping assistant | Explicit `FLOW_START` and `FLOW_END` checkpoints become helper-method proposals; repeated groups stay advisory until approved. |
+| 7 | Replay failure back-links | Compile or replay failures point back to recording step ids and generated code blocks. |
+| 8 | Backend comparison blocks | Users can compare WebDriver, Playwright, and mobile generation results when a recording can map to more than one backend. |
+| 9 | PR evidence pack | Screenshots, workbench HTML, generated source paths, and validation commands are collected for review. |
+| 10 | Guided IDE action copy | IntelliJ labels follow the real flow: record, review code, preview patch, apply, and verify. |
+
 All process arguments and filesystem paths are built with Java APIs
 (`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
 separator is assumed; restrictive POSIX permissions are applied when supported

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -69,11 +69,13 @@ capture start \
 
 The same lifecycle is exposed by the `capture_start`, `capture_start_codegen`,
 `capture_status`, and `capture_stop` MCP tools. Generation is exposed by
-`capture_generate`; `capture_codegen_features` returns the feature map. Status
-contains safe metadata, counts, readiness, and warnings, never typed values.
-Readiness is `READY`, `RISKY`, or `BLOCKED`; risky steps keep recording, while
-blocked readiness means generated replay will need user action such as a stable
-locator or required secret input.
+`capture_generate`; `capture_codegen_features` returns the feature map.
+`capture_target_candidates`, `capture_backend_comparison`, and
+`capture_evidence_pack` cover existing-suite targeting, backend comparison, and
+review evidence manifests. Status contains safe metadata, counts, readiness,
+and warnings, never typed values. Readiness is `READY`, `RISKY`, or `BLOCKED`;
+risky steps keep recording, while blocked readiness means generated replay will
+need user action such as a stable locator or required secret input.
 
 WebDriver code generation remains the default through `capture_generate`,
 `capture_generate_replay`, and `capture_code_blocks`. Use
@@ -144,16 +146,17 @@ The returned code blocks include deterministic Page Object insertion guidance
 for WebDriver and Playwright captures, including SHAFT locator inventory, action
 sequence, setup prerequisites for required data and fixtures, assertion
 suggestions for missing post-navigation or post-submit checks, control-flow
-review commands, and a `capture-page-object-draft` block with locator fields
-and flow methods when extractable candidates exist. Locator inventory blocks
-show the selected SHAFT locator expression and ranked alternatives from the
-generation report.
+review commands, locator confidence queues, validation back-links, and a
+`capture-page-object-draft` block with locator fields and flow methods when
+extractable candidates exist. Locator inventory blocks show the selected SHAFT
+locator expression and ranked alternatives from the generation report.
 
 For native mobile journeys, use the mobile MCP tools instead of browser
 Capture: `mobile_recording_code_blocks` returns the replay method, ranked
 mobile locator inventory, action sequence, and `mobile-page-object-draft`.
 `mobile_record_at_target_code_blocks` adds locator fields and an action snippet
-for an existing mobile Page Object anchor.
+for an existing mobile Page Object anchor, plus a preview-only patch block and a
+locator confidence queue when fallback actions need review.
 
 Use `FLOW_START` and `FLOW_END` checkpoints to mark an explicit reusable flow
 inside a recording. The checkpoint description becomes the generated helper
@@ -185,31 +188,30 @@ For a record-at-target flow, provide the existing Java source and insertion
 anchor when generating snippets. The CLI accepts
 `--target-source src/test/java/.../CheckoutTest.java --insert-after replayCheckout`
 and returns the normal generation result plus a focused insertion plan. MCP
-agents can call `capture_record_at_target_code_blocks` to receive separate
-blocks for SHAFT locator inventory/imports, action lines, and a no-edit
-insertion guide.
+agents can call `capture_target_candidates` first, then
+`capture_record_at_target_code_blocks` to receive separate blocks for SHAFT
+locator inventory/imports, action lines, and a preview-only patch block.
 SHAFT validates that the requested anchor is present when possible, but it never
 edits the source file until the calling agent performs a separately approved
 repository change.
 
-## Recorder/codegen enhancement plan
+## Recorder/codegen implementation
 
-The next recorder/codegen work is ordered around the moments where users still
-make manual decisions after recording. The goal is to turn each decision into a
-reviewable artifact before any source file is edited.
+Recorder/codegen now turns the main post-recording decisions into reviewable
+artifacts before any source file is edited.
 
 | Rank | Enhancement | User-facing result |
 | --- | --- | --- |
-| 1 | Patch preview for record-at-target | `capture_record_at_target_code_blocks` and mobile record-at-target flows show the exact Java diff before an agent applies it. |
-| 2 | Existing-suite target scanner | The MCP server suggests likely Page Objects, test classes, package names, driver variables, and insertion anchors from the current repository. |
-| 3 | Assertion gap checklist | Generated results list missing post-login, post-submit, navigation, and error-state assertions. |
+| 1 | Patch preview for record-at-target | `capture_record_at_target_code_blocks` and mobile record-at-target flows return preview-only diff blocks before an agent applies source edits. |
+| 2 | Existing-suite target scanner | `capture_target_candidates` suggests likely Page Objects, test classes, package names, driver variables, and insertion anchors from the current repository. |
+| 3 | Assertion gap checklist | Generated review blocks list missing post-login, post-submit, navigation, and error-state assertions. |
 | 4 | Locator confidence queue | Weak XPath, multi-match, and coordinate fallback steps are grouped into a fix-first review list. |
-| 5 | Fixture and secret handoff | Required environment variables, test data, and upload fixtures are summarized without exposing secret values. |
+| 5 | Fixture and secret handoff | Required environment variables, test data, and upload fixtures remain summarized without exposing secret values. |
 | 6 | Flow grouping assistant | Explicit `FLOW_START` and `FLOW_END` checkpoints become helper-method proposals; repeated groups stay advisory until approved. |
-| 7 | Replay failure back-links | Compile or replay failures point back to recording step ids and generated code blocks. |
-| 8 | Backend comparison blocks | Users can compare WebDriver, Playwright, and mobile generation results when a recording can map to more than one backend. |
-| 9 | PR evidence pack | Screenshots, workbench HTML, generated source paths, and validation commands are collected for review. |
-| 10 | Guided IDE action copy | IntelliJ labels follow the real flow: record, review code, preview patch, apply, and verify. |
+| 7 | Replay failure back-links | Validation review blocks point compile or replay failures back to recording step ids and generated code blocks. |
+| 8 | Backend comparison blocks | `capture_backend_comparison` returns WebDriver and Playwright code-block summaries for the same Capture session. |
+| 9 | PR evidence pack | `capture_evidence_pack` returns local screenshots, workbench HTML/review paths, generated source paths, and validation commands for review. |
+| 10 | Guided IDE action copy | IntelliJ Recorder templates follow the real flow: record, review code, preview patch, apply, and verify. |
 
 All process arguments and filesystem paths are built with Java APIs
 (`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
@@ -326,7 +328,10 @@ commands, checking blockers and required inputs, reviewing assertion gaps,
 locator decisions, a Page Object draft, copyable CLI/MCP command starters, the
 generated code-block summary, deterministic control-flow suggestions, generated
 source through the browser file picker or download fallback, and the Playwright
-codegen feature map beside the generated code.
+codegen feature map beside the generated code. Use
+`capture_backend_comparison` when reviewers need WebDriver and Playwright block
+summaries side by side, and `capture_evidence_pack` to return the local source,
+report, review, screenshot, and validation-command manifest for a PR.
 
 Add `--enable-fallback-locators` when generating WebDriver replay code to make
 the generated test try ranked captured alternatives before failing a target

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -181,7 +181,7 @@ The visible palette includes `/codegen`, `/record-web`, `/record-mobile`,
 | Command help | `/commands` | `/help`, `/mcp-help`, `/shaft-help` | Local help |
 | Assistant routing | `/assistant` | `/agent`, `/ask`, `/plan`, `/clients` | `autobot_local_agent_run`, `autobot_provider_chat`, `autobot_local_agent_clients` |
 | Browser control | `/browser` | `/web`, `/browse`, `/page`, `/inspect`, `/locator` | `driver_initialize`, `browser_open_intent`, `browser_get_page_dom`, `browser_take_screenshot`, `playwright_initialize`, `playwright_browser_navigate` |
-| Browser recording and codegen | `/record` | `/rec`, `/capture`, `/codegen`, `/generate`, `/gen`, `/generateTest` | `capture_start`, `capture_stop`, `capture_code_blocks`, `playwright_record_start`, `playwright_recording_code_blocks` |
+| Browser recording and codegen | `/record` | `/rec`, `/capture`, `/codegen`, `/generate`, `/gen`, `/generateTest` | `capture_start`, `capture_stop`, `capture_code_blocks`, `capture_target_candidates`, `capture_record_at_target_code_blocks`, `capture_backend_comparison`, `capture_evidence_pack`, `playwright_record_start`, `playwright_recording_code_blocks` |
 | Mobile control and inspection | `/mobile` | `/appium`, `/device`, `/phone`, `/emulator` | `mobile_toolchain_status`, `mobile_initialize_native`, `mobile_initialize_web_emulation`, `mobile_get_accessibility_tree`, `mobile_take_screenshot` |
 | Mobile recording and codegen | `/mobile-record` | `/app-record`, `/inspector-record`, `/mobile-codegen`, `/app-codegen`, `/mobile-replay` | `mobile_record_start`, `mobile_record_stop`, `mobile_recording_code_blocks`, `mobile_record_at_target_code_blocks`, `mobile_replay_recording`, `mobile_inspector_record_prepare` |
 | Failure analysis | `/doctor` | `/allure`, `/triage`, `/fixTestFailure`, `/failure`, `/fix` | `doctor_analyze_failed_allure`, `playwright_doctor_analyze_failed_allure`, `doctor_suggest_fix`, `doctor_analyze_trace` |
@@ -260,8 +260,8 @@ explicitly required for that environment.
 The workflow selector exposes curated MCP requests for common automation jobs:
 
 - Recorder: Capture start, status, checkpoints, stop, reviewed code blocks,
-  record-at-target snippets, Playwright recording controls, and replay code
-  generation.
+  target discovery, record-at-target patch previews, backend comparison,
+  evidence packs, Playwright recording controls, and replay code generation.
 - Inspector: browser and Playwright DOM snapshots, screenshots, mobile
   toolchain status, wrapped Appium Inspector recording, mobile screenshots, and
   accessibility trees.
@@ -279,7 +279,8 @@ The workflow selector exposes curated MCP requests for common automation jobs:
   only; they do not run tools or write source by themselves.
 - Advanced Tools: WebDriver, Playwright, and mobile playback flows, scenario
   catalog prompts, generated-code guardrail checks, local Assistant client
-  discovery, and official SHAFT guide search.
+  discovery, recorder evidence manifests, backend comparison, and official
+  SHAFT guide search.
 
 Each category provides editable JSON arguments and calls the matching MCP tool.
 This keeps generated code and source edits reviewable in the IDE instead of
@@ -300,6 +301,9 @@ method, and source path. The action defaults the session path to
 recording path. Change it only when you recorded to a different file. After
 review approval, keep the same capture session path so generation preserves the
 reviewed browser journey instead of rerunning capture.
+The generated MCP response includes focused locator/action blocks plus a
+preview-only patch block; apply changes only after reviewing that preview and
+running the relevant verification command.
 This action is available only in IDE installations with Java support enabled.
 
 Use **Settings | SHAFT** later to paste or edit the stdio command, retest the

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -232,11 +232,14 @@ The packaged server supports:
 - deterministic WebDriver TestNG generation through `capture_generate`,
   `capture_generate_replay`, `capture_code_blocks`, and
   `capture_record_at_target_code_blocks`, with compile, optional replay, local
-  deterministic code-review warnings, focused source-anchor insertion snippets,
-  setup/assertion/control-flow review blocks, selected and alternative locator
-  expressions, intent-derived default names, generated review headers,
-  compact fallback locator helpers, the `capture-page-object-draft` block, and
-  review-only AI enrichment phases;
+  deterministic code-review warnings, existing-suite target candidates, focused
+  source-anchor insertion snippets, preview-only patch blocks,
+  setup/assertion/control-flow review blocks, locator-confidence queues,
+  validation back-links, selected and alternative locator expressions,
+  intent-derived default names, generated review headers, compact fallback
+  locator helpers, the `capture-page-object-draft` block, backend comparison
+  summaries through `capture_backend_comparison`, local review manifests through
+  `capture_evidence_pack`, and review-only AI enrichment phases;
 - deterministic Playwright TestNG generation through
   `playwright_capture_generate_replay` and `playwright_capture_code_blocks`
   when the target repository uses `SHAFT.GUI.Playwright`;


### PR DESCRIPTION
## Summary
- Update the Capture guide from roadmap language to implemented recorder/codegen handoff behavior.
- Document `capture_target_candidates`, `capture_backend_comparison`, `capture_evidence_pack`, patch preview blocks, locator confidence queues, and validation back-links.
- Update the IntelliJ and MCP guide pages so the public command/tool references match the core implementation.

## Companion Core PR
- Core implementation PR: https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3281

## Validation
- `npm run test:docs`
- `npm run build`
- `git diff --check`

## Screenshots
![Recorder templates](https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/codex/recorder-codegen-top10/.github/pr-evidence/recorder-codegen-top10/intellij-plugin-recorder.png)

![Capture workbench](https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/codex/recorder-codegen-top10/.github/pr-evidence/recorder-codegen-top10/capture-workbench.png)

![Mobile recorder](https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/codex/recorder-codegen-top10/.github/pr-evidence/recorder-codegen-top10/mobile-recorder.png)