### PR TITLE
Document deterministic SHAFT skills install command

### DIFF
--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -6,9 +6,9 @@
   "githubRepository": "https://github.com/ShaftHQ/SHAFT_ENGINE",
   "mcpInstaller": {
     "commandTemplates": {
-      "windows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.ps1 | iex; Install-ShaftMcp -Client {client}\"",
-      "macos": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag}",
-      "linux": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag}"
+      "windows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.ps1 | iex; Install-ShaftMcp -Client {client} --install-shaft-skills\"",
+      "macos": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag} --install-shaft-skills",
+      "linux": "curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- {agentFlag} --install-shaft-skills"
     },
     "applications": [
       {


### PR DESCRIPTION
## Summary
- Add `--install-shaft-skills` to the reusable SHAFT MCP installer snippets for Windows, macOS, and Linux.
- Keep public snippets aligned with the IntelliJ setup flow and existing MCP guide text.

## Validation
- `npm run test:docs`

Related to ShaftHQ/SHAFT_ENGINE#3285.