### PR TITLE
docs: correct pilot.ai.gemini.model's default value

### DIFF
--- a/docs/agentic/providers.md
+++ b/docs/agentic/providers.md
@@ -41,7 +41,8 @@ pilot.ai.enabled=false
 pilot.ai.provider=none
 ```
 
-Provider models default to blank, remote and local consent default to `false`,
+Provider models default to blank except `pilot.ai.gemini.model`, which
+defaults to `gemini-3.5-flash`; remote and local consent default to `false`,
 and no evidence category is approved by default. Disabled or unavailable AI
 returns the request's `deterministicFallback` and makes no network call.
 

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -2659,7 +2659,7 @@
     "section": "Pilot",
     "key": "pilot.ai.gemini.model",
     "targetFile": "custom.properties",
-    "defaultValue": "",
+    "defaultValue": "gemini-3.5-flash",
     "possibleValues": "",
     "description": "configured Gemini model"
   },


### PR DESCRIPTION
## Summary

- `pilot.ai.gemini.model` now defaults to `gemini-3.5-flash` in shipped code (`shaft-engine`'s `Pilot.java`), not blank like the other provider models — these docs still described it as blank.
- Cross-checked directly against shipped code (`Pilot.java`'s `@DefaultValue` annotations for every provider's model property, and `ShaftSettingsState.java`), not carried over from an earlier discarded draft.
- Scoped strictly to this one already-shipped default. The companion SHAFT_ENGINE PR (ShaftHQ/SHAFT_ENGINE#3290) also ships 9 internal IntelliJ plugin UI/UX polish ideas, but those have no externally documented behavior, so nothing else needed changing here — `docs/agentic/intellij.md` and the example `.properties` files were checked and found already accurate (no default-provider claims needed updating).

## Changes

- `docs/agentic/providers.md`: qualify "Provider models default to blank" with the Gemini exception
- `src/data/properties-catalog.json`: `pilot.ai.gemini.model`'s `defaultValue` corrected from `""` to `"gemini-3.5-flash"`

## Test plan

- [x] Cross-checked every claim in the touched paragraph against `shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java` (`@DefaultValue` for `provider`, `enabled`, `geminiModel`, `openaiModel`, `anthropicModel`, `githubModel`, `ollamaModel`)
- [x] Confirmed `static/examples/shaft-pilot/providers/gemini.properties` already follows the same `<model>` placeholder convention as every other provider example — no change needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>