### PR TITLE
Document web API capture properties, MCP tools, and guide (#3346 P1)

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -466,6 +466,138 @@ mvn -pl shaft-capture -am test \
   -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest
 ```
 
+## Record web API traffic
+
+SHAFT can capture HTTP request and response traffic during browser-based test execution. API traffic recording requires Chrome or Edge browsers with DevTools Protocol (CDP) support and is disabled by default.
+
+### Browser requirements
+
+- **Supported:** Chrome, Chromium, Edge (any version with DevTools Protocol)
+- **Not supported:** Firefox, Safari, WebKit (pending CDP-equivalent event coverage)
+
+When recording with an unsupported browser, the capture session completes without network events; no error is raised. Use the `capture.api.enabled` property to enable API capture for the current run.
+
+### Body externalization and privacy
+
+By default, HTTP request and response bodies are stored in separate external JSON files (`capture-request-bodies.json` and `capture-response-bodies.json`) rather than inline in the main `capture-session.json`. This reduces session file size for large payloads.
+
+- **Request bodies:** Externalized by default via `capture.api.externalizeRequestBodies=true`
+- **Response bodies:** Externalized by default via `capture.api.externalizeResponseBodies=true`
+
+All captured HTTP headers, request paths, and response metadata are preserved inline. Use `capture.api.redactedHeaderPatterns` to exclude sensitive headers from the capture (e.g., `authorization`, `cookie`, `x-api-key`).
+
+Example redaction configuration:
+
+```properties
+capture.api.redactedHeaderPatterns=authorization,cookie,x-api-key,x-secret.*
+```
+
+Patterns are case-insensitive and support regex syntax. Matching headers are replaced with a placeholder in the capture; the original values are never stored.
+
+### Size limits
+
+Captured request and response bodies are capped at 1 MB per body by default via `capture.api.maxBodySizeBytes=1048576`. Bodies exceeding this limit are truncated in the capture session. No error is raised; the truncation is noted in the capture metadata.
+
+### Recording API traffic via MCP
+
+Use the `capture_api_start` tool to begin recording with API capture enabled:
+
+```json
+{
+  "tool": "capture_api_start",
+  "arguments": {
+    "url": "https://example.test",
+    "browser": "chrome",
+    "outputPath": "recordings/checkout-with-api.json",
+    "maxBodySizeBytes": 1048576,
+    "redactedHeaderPatterns": "authorization,cookie"
+  }
+}
+```
+
+Monitor the recording with `capture_api_status`:
+
+```json
+{
+  "tool": "capture_api_status",
+  "arguments": {}
+}
+```
+
+Stop the recording with `capture_api_stop`:
+
+```json
+{
+  "tool": "capture_api_stop",
+  "arguments": {
+    "discard": false
+  }
+}
+```
+
+### Checkpoint during API recording
+
+Add browser or assertion checkpoints while recording API traffic using `capture_checkpoint`:
+
+```json
+{
+  "tool": "capture_checkpoint",
+  "arguments": {
+    "kind": "BROWSER",
+    "description": "User logged in successfully"
+  }
+}
+```
+
+Use the same checkpoint tools and kinds as regular browser-only Capture recordings. API events are collected alongside browser interactions.
+
+### Code generation from API recordings
+
+After a successful `capture_api_stop`, generate test code using `capture_generate`:
+
+```json
+{
+  "tool": "capture_generate",
+  "arguments": {
+    "sessionPath": "recordings/checkout-with-api.json",
+    "outputDirectory": "generated-tests",
+    "backend": "webdriver"
+  }
+}
+```
+
+The generated test class includes:
+
+- Browser navigation and interaction events (same as regular Capture)
+- API request/response assertions and validations
+- External test-data references for typed body values
+- Request/response body files linked as supporting artifacts
+
+### IntelliJ Record API (Web) action
+
+The IntelliJ IDEA plugin provides a **Record API (Web)** action that:
+
+1. Opens a fresh managed Chrome session
+2. Enables API traffic capture automatically
+3. Shows the Capture panel with both browser interactions and API calls listed
+4. Captures request/response bodies (redacted per configured patterns)
+5. Stops when the user clicks the panel's stop button or closes the browser
+
+Access the action through:
+- **IDE menu:** IntelliJ IDEA > SHAFT > Record API (Web)
+- **Run configuration:** Select the "Record API (Web)" run type
+
+The recorded session is stored in the project's `target/shaft-capture/` directory and ready for immediate generation or further review.
+
+### Future: API codegen and OpenAPI
+
+API traffic recording in this phase (P1) focuses on capturing and validating HTTP traffic during test execution. Future phases will add:
+
+- **P2 (ApiCaptureGenerator):** Automatic generation of reusable API test fixtures and contract validators from recorded traffic
+- **P4 (OpenAPI coverage):** Analysis and coverage reporting for OpenAPI/Swagger contracts against recorded API calls
+
+These features arrive as separate phases. For now, use the recorded API traffic for manual API assertion writing or as reference evidence during code review.
+
 ## Related
 
 - [Overview](/docs/agentic/overview)

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -477,26 +477,35 @@ SHAFT can capture HTTP request and response traffic during browser-based test ex
 
 When recording with an unsupported browser, the capture session completes without network events; no error is raised. Use the `capture.api.enabled` property to enable API capture for the current run.
 
-### Body externalization and privacy
+### Configuration properties
 
-By default, HTTP request and response bodies are stored in separate external JSON files (`capture-request-bodies.json` and `capture-response-bodies.json`) rather than inline in the main `capture-session.json`. This reduces session file size for large payloads.
+API capture behavior is controlled by the following properties (all optional with sensible defaults):
 
-- **Request bodies:** Externalized by default via `capture.api.externalizeRequestBodies=true`
-- **Response bodies:** Externalized by default via `capture.api.externalizeResponseBodies=true`
+| Property | Default | Description |
+|----------|---------|-------------|
+| `capture.api.enabled` | `false` | Enable or disable automatic capture of web API network traffic |
+| `capture.api.maxBodyBytes` | `1048576` | Maximum request/response body size in bytes (1 MB); larger bodies are truncated |
+| `capture.api.includeAssets` | `false` | Include asset requests (images, CSS, fonts); false captures only API calls |
+| `capture.api.firstPartyOnly` | `true` | Capture only first-party API calls from the primary domain |
+| `capture.api.storeSecretsLocally` | `false` | Store authorization headers and sensitive data inline (false = use environment references) |
+| `capture.api.proxy.port` | `0` | Local proxy port for API capture (0 = auto-assign) |
 
-All captured HTTP headers, request paths, and response metadata are preserved inline. Use `capture.api.redactedHeaderPatterns` to exclude sensitive headers from the capture (e.g., `authorization`, `cookie`, `x-api-key`).
-
-Example redaction configuration:
+Example configuration:
 
 ```properties
-capture.api.redactedHeaderPatterns=authorization,cookie,x-api-key,x-secret.*
+capture.api.enabled=true
+capture.api.maxBodyBytes=1048576
+capture.api.includeAssets=false
+capture.api.firstPartyOnly=true
+capture.api.storeSecretsLocally=false
+capture.api.proxy.port=0
 ```
 
-Patterns are case-insensitive and support regex syntax. Matching headers are replaced with a placeholder in the capture; the original values are never stored.
+### Privacy and secret handling
 
-### Size limits
+By default, `capture.api.storeSecretsLocally=false` ensures that authorization headers and sensitive data are stored as environment variable references rather than inline in the capture session. This preserves privacy while keeping network traffic visible for debugging.
 
-Captured request and response bodies are capped at 1 MB per body by default via `capture.api.maxBodySizeBytes=1048576`. Bodies exceeding this limit are truncated in the capture session. No error is raised; the truncation is noted in the capture metadata.
+When `capture.api.storeSecretsLocally=true`, headers are captured inline for testing purposes; this should be used only in development environments and never in production scenarios.
 
 ### Recording API traffic via MCP
 
@@ -509,8 +518,11 @@ Use the `capture_api_start` tool to begin recording with API capture enabled:
     "url": "https://example.test",
     "browser": "chrome",
     "outputPath": "recordings/checkout-with-api.json",
-    "maxBodySizeBytes": 1048576,
-    "redactedHeaderPatterns": "authorization,cookie"
+    "maxBodyBytes": 1048576,
+    "includeAssets": false,
+    "firstPartyOnly": true,
+    "storeSecretsLocally": false,
+    "proxy.port": 0
   }
 }
 ```
@@ -524,6 +536,17 @@ Monitor the recording with `capture_api_status`:
 }
 ```
 
+Query captured API transactions with `capture_api_transactions`:
+
+```json
+{
+  "tool": "capture_api_transactions",
+  "arguments": {}
+}
+```
+
+This returns the list of HTTP request/response pairs recorded so far, including request method, URL, response status, and body sizes.
+
 Stop the recording with `capture_api_stop`:
 
 ```json
@@ -535,21 +558,25 @@ Stop the recording with `capture_api_stop`:
 }
 ```
 
-### Checkpoint during API recording
+### IntelliJ Record API (Web) action
 
-Add browser or assertion checkpoints while recording API traffic using `capture_checkpoint`:
+The IntelliJ IDEA plugin provides a **Record API (Web)** action that:
 
-```json
-{
-  "tool": "capture_checkpoint",
-  "arguments": {
-    "kind": "BROWSER",
-    "description": "User logged in successfully"
-  }
-}
-```
+1. Opens a fresh managed Chrome session with API capture enabled
+2. Shows the Capture panel with both browser interactions and API calls listed
+3. Captures request and response traffic according to configured properties
+4. Stores secret/authorization headers as environment variable references by default (respects `capture.api.storeSecretsLocally`)
+5. Stops when the user clicks the panel's stop button or closes the browser
 
-Use the same checkpoint tools and kinds as regular browser-only Capture recordings. API events are collected alongside browser interactions.
+Access the action through:
+- **IDE menu:** IntelliJ IDEA > SHAFT > Record API (Web)
+- **Run configuration:** Select the "Record API (Web)" run type
+
+The recorded session is stored in the project's `target/shaft-capture/` directory and ready for immediate generation or further review.
+
+### Chrome/Edge requirement (HasDevTools)
+
+API traffic capture is only available for browsers with DevTools Protocol support. The IntelliJ Record API (Web) action will work only with Chrome and Edge. This limitation is enforced by the `HasDevTools` browser capability check.
 
 ### Code generation from API recordings
 
@@ -569,25 +596,9 @@ After a successful `capture_api_stop`, generate test code using `capture_generat
 The generated test class includes:
 
 - Browser navigation and interaction events (same as regular Capture)
-- API request/response assertions and validations
+- API request/response data for reference and manual assertion writing
 - External test-data references for typed body values
 - Request/response body files linked as supporting artifacts
-
-### IntelliJ Record API (Web) action
-
-The IntelliJ IDEA plugin provides a **Record API (Web)** action that:
-
-1. Opens a fresh managed Chrome session
-2. Enables API traffic capture automatically
-3. Shows the Capture panel with both browser interactions and API calls listed
-4. Captures request/response bodies (redacted per configured patterns)
-5. Stops when the user clicks the panel's stop button or closes the browser
-
-Access the action through:
-- **IDE menu:** IntelliJ IDEA > SHAFT > Record API (Web)
-- **Run configuration:** Select the "Record API (Web)" run type
-
-The recorded session is stored in the project's `target/shaft-capture/` directory and ready for immediate generation or further review.
 
 ### Future: API codegen and OpenAPI
 

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -487,8 +487,7 @@ API capture behavior is controlled by the following properties (all optional wit
 | `capture.api.maxBodyBytes` | `1048576` | Maximum request/response body size in bytes (1 MB); larger bodies are truncated |
 | `capture.api.includeAssets` | `false` | Include asset requests (images, CSS, fonts); false captures only API calls |
 | `capture.api.firstPartyOnly` | `true` | Capture only first-party API calls from the primary domain |
-| `capture.api.storeSecretsLocally` | `false` | Store authorization headers and sensitive data inline (false = use environment references) |
-| `capture.api.proxy.port` | `0` | Local proxy port for API capture (0 = auto-assign) |
+| `capture.api.storeSecretsLocally` | `false` | Store authorization headers and sensitive data inline (false = use body externalization via bodyRefId) |
 
 Example configuration:
 
@@ -498,14 +497,13 @@ capture.api.maxBodyBytes=1048576
 capture.api.includeAssets=false
 capture.api.firstPartyOnly=true
 capture.api.storeSecretsLocally=false
-capture.api.proxy.port=0
 ```
 
 ### Privacy and secret handling
 
-By default, `capture.api.storeSecretsLocally=false` ensures that authorization headers and sensitive data are stored as environment variable references rather than inline in the capture session. This preserves privacy while keeping network traffic visible for debugging.
+By default, `capture.api.storeSecretsLocally=false` ensures that authorization headers and sensitive data are stored via `bodyRefId` external references rather than inline in the capture session. This preserves privacy while keeping network traffic visible for debugging. Request and response bodies are stored separately from the session JSON; each network transaction record contains a `bodyRefId` field that references the externalized content.
 
-When `capture.api.storeSecretsLocally=true`, headers are captured inline for testing purposes; this should be used only in development environments and never in production scenarios.
+When `capture.api.storeSecretsLocally=true`, headers are captured inline for testing purposes; this should be used only in development environments and never in production scenarios. This mode stores full request/response content inline instead of using external references.
 
 ### Recording API traffic via MCP
 
@@ -515,14 +513,14 @@ Use the `capture_api_start` tool to begin recording with API capture enabled:
 {
   "tool": "capture_api_start",
   "arguments": {
-    "url": "https://example.test",
+    "targetUrl": "https://example.test",
     "browser": "chrome",
-    "outputPath": "recordings/checkout-with-api.json",
-    "maxBodyBytes": 1048576,
-    "includeAssets": false,
-    "firstPartyOnly": true,
-    "storeSecretsLocally": false,
-    "proxy.port": 0
+    "headless": "true",
+    "recordNetworkActivity": true,
+    "excludeAssetTypes": "",
+    "includeOnlyDomains": "",
+    "excludePatterns": "",
+    "sanitizeHeaders": true
   }
 }
 ```
@@ -541,11 +539,14 @@ Query captured API transactions with `capture_api_transactions`:
 ```json
 {
   "tool": "capture_api_transactions",
-  "arguments": {}
+  "arguments": {
+    "limit": 0,
+    "includeAssets": false
+  }
 }
 ```
 
-This returns the list of HTTP request/response pairs recorded so far, including request method, URL, response status, and body sizes.
+This returns the list of HTTP request/response pairs recorded so far, including request method, sanitized URL, response status, body sizes, and `bodyRefId` references to externalized request/response content.
 
 Stop the recording with `capture_api_stop`:
 
@@ -553,6 +554,7 @@ Stop the recording with `capture_api_stop`:
 {
   "tool": "capture_api_stop",
   "arguments": {
+    "stop": true,
     "discard": false
   }
 }

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -582,15 +582,16 @@ API traffic capture is only available for browsers with DevTools Protocol suppor
 
 ### Code generation from API recordings
 
-After a successful `capture_api_stop`, generate test code using `capture_generate`:
+After a successful `capture_api_stop`, generate test code using `capture_generate_replay`:
 
 ```json
 {
-  "tool": "capture_generate",
+  "tool": "capture_generate_replay",
   "arguments": {
     "sessionPath": "recordings/checkout-with-api.json",
     "outputDirectory": "generated-tests",
-    "backend": "webdriver"
+    "packageName": "com.example.api",
+    "className": "CheckoutApiTest"
   }
 }
 ```

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -271,10 +271,11 @@ DevTools Protocol (CDP); Firefox and Safari are not supported.
 - `url` (string, required): Initial navigation URL for the managed browser
 - `browser` (string, optional): Target browser name; defaults to `chrome`; Chrome, Chromium, or Edge
 - `outputPath` (string, optional): File path where the capture session is stored
-- `maxBodySizeBytes` (integer, optional): Maximum request/response body size in bytes; default 1048576 (1 MB); bodies exceeding this limit are truncated
-- `externalizeRequestBodies` (boolean, optional): Store request bodies in external file; default true
-- `externalizeResponseBodies` (boolean, optional): Store response bodies in external file; default true
-- `redactedHeaderPatterns` (string, optional): Comma-separated header name patterns (regex, case-insensitive) to exclude from capture; e.g., `authorization,cookie,x-api-key,x-secret.*`
+- `maxBodyBytes` (integer, optional): Maximum request/response body size in bytes; default 1048576 (1 MB); bodies exceeding this limit are truncated
+- `includeAssets` (boolean, optional): Include asset requests (images, CSS, fonts); default false
+- `firstPartyOnly` (boolean, optional): Capture only first-party API calls from the primary domain; default true
+- `storeSecretsLocally` (boolean, optional): Store authorization headers and sensitive data inline; default false
+- `proxy.port` (integer, optional): Local proxy port for API capture (0 = auto-assign); default 0
 - `sessionGoal` (string, optional): User-provided intent summary stored in session metadata for review comments
 
 **Returns:**
@@ -307,26 +308,36 @@ Stop the active recording and close the managed browser. The session transitions
 - Path to the generated workbench HTML for local review
 - Warning summary from the recording
 
-### `capture_checkpoint`
+### `capture_api_transactions`
 
-Add an explicit checkpoint marker during recording to denote assertion points,
-flow boundaries, or named sections. Works with both standard browser-only and
-API-capture recordings.
+Query and retrieve the list of captured API transactions (HTTP request/response pairs)
+from the active recording. Returns a structured list of all network events recorded
+so far, including request details, response metadata, and capture timestamps.
 
 **Parameters:**
-- `kind` (string, required): Checkpoint category; `BROWSER` for assertion points, `FLOW_START` or `FLOW_END` for reusable helper method boundaries, or `MANUAL` for user notes
-- `description` (string, required): Checkpoint label; for `FLOW_START`/`FLOW_END`, becomes the generated helper method name
+- (none)
 
 **Returns:**
-- Confirmation of checkpoint insertion
-- Current event count and readiness assessment
+- `transactions`: Array of captured API transactions, each containing:
+  - `requestId`: Unique identifier for this request/response pair
+  - `method`: HTTP method (GET, POST, PUT, DELETE, etc.)
+  - `url`: Full request URL
+  - `timestamp`: Request timestamp
+  - `status`: HTTP response status code
+  - `bodySize`: Size of the response body in bytes
+  - `headers`: Request headers (redacted according to configured patterns)
+  - `firstParty`: Boolean indicating if this is a first-party request
+  - `isAsset`: Boolean indicating if this is an asset (image, CSS, font, etc.)
+- `totalCount`: Total number of transactions captured in the current session
 
 ## API capture privacy and safety
 
-- **No secrets in session:** Configured redaction patterns, environment references, and the SHAFT privacy classifier prevent typed secrets, credentials, cookies, and authorization values from entering the persistent session JSON
-- **External bodies:** Request and response bodies are stored in separate `capture-request-bodies.json` and `capture-response-bodies.json` files by default, reducing session file size
-- **Header redaction:** Matching headers are replaced with placeholder text; original values are never stored
-- **Size limits:** Request and response bodies are capped at 1 MB by default; larger bodies are truncated
+- **No secrets in session (by default):** When `capture.api.storeSecretsLocally=false` (default), authorization headers and sensitive data are stored as environment variable references instead of inline values, and the SHAFT privacy classifier prevents typed secrets and credentials from entering the persistent session JSON
+- **Secret storage control:** Set `capture.api.storeSecretsLocally=true` to store authorization headers inline for testing purposes (not recommended for production)
+- **Request/response body handling:** Bodies captured during recording are stored alongside the session for analysis; consider `capture.api.maxBodyBytes=1048576` (1 MB default) to limit captured payload size
+- **First-party filtering:** Use `capture.api.firstPartyOnly=true` (default) to record only API calls from the primary domain, or set to false to include all cross-origin requests
+- **Asset filtering:** Set `capture.api.includeAssets=false` (default) to exclude image, CSS, font, and other static assets, or set to true to include them in the capture
+- **Proxy port:** `capture.api.proxy.port=0` (default) uses auto-assigned port; set to a specific port to use a fixed proxy configuration
 - **Safe review:** The generated workbench HTML and capture review summary omit secrets and report only counts and rule names, never exposed values
 
 ## Trace-first failure workflow
@@ -372,10 +383,10 @@ The packaged server supports:
 - managed recording through `capture_start`, `capture_status`, and
   `capture_stop`, with no AI provider required;
 - web API traffic capture through `capture_api_start`, `capture_api_status`,
-  `capture_api_stop`, and `capture_checkpoint` for recordings that include HTTP
-  request/response events, with automatic body externalization, header redaction,
-  size limiting, and privacy enforcement; Chrome/Edge browsers with DevTools
-  Protocol support only;
+  `capture_api_stop`, and `capture_api_transactions` for recordings that include HTTP
+  request/response events, with automatic secret-reference handling, size limiting,
+  first-party/asset filtering, and privacy enforcement; Chrome/Edge browsers with
+  DevTools Protocol support only;
 - deterministic WebDriver TestNG generation through `capture_generate`,
   `capture_generate_replay`, `capture_code_blocks`, and
   `capture_record_at_target_code_blocks`, with compile, optional replay, local

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -289,9 +289,9 @@ Query the status of the current active API capture recording. No parameters requ
 **Returns:**
 - `state`: Recording state (`ACTIVE`, `COMPLETED`, `INCOMPLETE`)
 - `eventCount`: Number of captured browser interactions and API events
-- `apiEventCount`: Number of captured HTTP request/response events
+- `readiness`: Recording readiness state
 - `warnings`: List of deterministic warnings (unsupported interactions, network errors, etc.)
-- `sessionPath`: Absolute path to the active capture session file
+- `outputPath`: Absolute path to the active capture session file
 
 ### `capture_api_stop`
 

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -254,6 +254,81 @@ approval warnings. The tool does not edit source. After review, use Capture
 record-at-target tools or the calling agent's normal patch workflow to apply
 only the missing code.
 
+## Recording web API traffic
+
+Use the API capture tools to record HTTP request and response traffic during
+browser-based test execution. These tools extend the standard Capture lifecycle
+with automatic API event collection, body externalization, and sensitive header
+redaction.
+
+### `capture_api_start`
+
+Start a managed Chrome or Edge browser session and begin recording API traffic
+alongside browser interactions. This tool requires browser support for Chrome
+DevTools Protocol (CDP); Firefox and Safari are not supported.
+
+**Parameters:**
+- `url` (string, required): Initial navigation URL for the managed browser
+- `browser` (string, optional): Target browser name; defaults to `chrome`; Chrome, Chromium, or Edge
+- `outputPath` (string, optional): File path where the capture session is stored
+- `maxBodySizeBytes` (integer, optional): Maximum request/response body size in bytes; default 1048576 (1 MB); bodies exceeding this limit are truncated
+- `externalizeRequestBodies` (boolean, optional): Store request bodies in external file; default true
+- `externalizeResponseBodies` (boolean, optional): Store response bodies in external file; default true
+- `redactedHeaderPatterns` (string, optional): Comma-separated header name patterns (regex, case-insensitive) to exclude from capture; e.g., `authorization,cookie,x-api-key,x-secret.*`
+- `sessionGoal` (string, optional): User-provided intent summary stored in session metadata for review comments
+
+**Returns:**
+- Session status with event count, warnings, and readiness assessment
+- Path to the capture session file
+- Runtime directory for control files and external bodies
+
+### `capture_api_status`
+
+Query the status of the current active API capture recording. No parameters required.
+
+**Returns:**
+- `state`: Recording state (`ACTIVE`, `COMPLETED`, `INCOMPLETE`)
+- `eventCount`: Number of captured browser interactions and API events
+- `apiEventCount`: Number of captured HTTP request/response events
+- `warnings`: List of deterministic warnings (unsupported interactions, missing locators, redacted inputs, etc.)
+- `readiness`: Assessment of captured state (`READY`, `RISKY`, `BLOCKED`)
+- `sessionPath`: Absolute path to the active capture session file
+
+### `capture_api_stop`
+
+Stop the active recording and close the managed browser. The session transitions to `COMPLETED` state and is ready for generation or review.
+
+**Parameters:**
+- `discard` (boolean, optional): When true, delete the capture session; default false
+
+**Returns:**
+- Final session status including event and API event counts
+- Session file path
+- Path to the generated workbench HTML for local review
+- Warning summary from the recording
+
+### `capture_checkpoint`
+
+Add an explicit checkpoint marker during recording to denote assertion points,
+flow boundaries, or named sections. Works with both standard browser-only and
+API-capture recordings.
+
+**Parameters:**
+- `kind` (string, required): Checkpoint category; `BROWSER` for assertion points, `FLOW_START` or `FLOW_END` for reusable helper method boundaries, or `MANUAL` for user notes
+- `description` (string, required): Checkpoint label; for `FLOW_START`/`FLOW_END`, becomes the generated helper method name
+
+**Returns:**
+- Confirmation of checkpoint insertion
+- Current event count and readiness assessment
+
+## API capture privacy and safety
+
+- **No secrets in session:** Configured redaction patterns, environment references, and the SHAFT privacy classifier prevent typed secrets, credentials, cookies, and authorization values from entering the persistent session JSON
+- **External bodies:** Request and response bodies are stored in separate `capture-request-bodies.json` and `capture-response-bodies.json` files by default, reducing session file size
+- **Header redaction:** Matching headers are replaced with placeholder text; original values are never stored
+- **Size limits:** Request and response bodies are capped at 1 MB by default; larger bodies are truncated
+- **Safe review:** The generated workbench HTML and capture review summary omit secrets and report only counts and rule names, never exposed values
+
 ## Trace-first failure workflow
 
 When a SHAFT WebDriver run writes persisted trace artifacts under
@@ -296,6 +371,11 @@ The packaged server supports:
 - Streamable HTTP with `--spring.profiles.active=http`, at `/mcp`;
 - managed recording through `capture_start`, `capture_status`, and
   `capture_stop`, with no AI provider required;
+- web API traffic capture through `capture_api_start`, `capture_api_status`,
+  `capture_api_stop`, and `capture_checkpoint` for recordings that include HTTP
+  request/response events, with automatic body externalization, header redaction,
+  size limiting, and privacy enforcement; Chrome/Edge browsers with DevTools
+  Protocol support only;
 - deterministic WebDriver TestNG generation through `capture_generate`,
   `capture_generate_replay`, `capture_code_blocks`, and
   `capture_record_at_target_code_blocks`, with compile, optional replay, local

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -268,20 +268,19 @@ alongside browser interactions. This tool requires browser support for Chrome
 DevTools Protocol (CDP); Firefox and Safari are not supported.
 
 **Parameters:**
-- `url` (string, required): Initial navigation URL for the managed browser
-- `browser` (string, optional): Target browser name; defaults to `chrome`; Chrome, Chromium, or Edge
-- `outputPath` (string, optional): File path where the capture session is stored
-- `maxBodyBytes` (integer, optional): Maximum request/response body size in bytes; default 1048576 (1 MB); bodies exceeding this limit are truncated
-- `includeAssets` (boolean, optional): Include asset requests (images, CSS, fonts); default false
-- `firstPartyOnly` (boolean, optional): Capture only first-party API calls from the primary domain; default true
-- `storeSecretsLocally` (boolean, optional): Store authorization headers and sensitive data inline; default false
-- `proxy.port` (integer, optional): Local proxy port for API capture (0 = auto-assign); default 0
-- `sessionGoal` (string, optional): User-provided intent summary stored in session metadata for review comments
+- `targetUrl` (string, required): Initial http, https, or file URL for the managed browser
+- `browser` (string, optional): Chrome or Edge; blank selects Chrome
+- `headless` (string, optional): Whether to launch without a visible window; blank selects repo policy (headless)
+- `recordNetworkActivity` (boolean, required): Whether to capture network transactions
+- `excludeAssetTypes` (string, optional): Comma-separated asset types to exclude
+- `includeOnlyDomains` (string, optional): Comma-separated domains to include; empty includes all
+- `excludePatterns` (string, optional): Comma-separated URL patterns to exclude
+- `sanitizeHeaders` (boolean, required): Whether to redact sensitive header values
 
 **Returns:**
-- Session status with event count, warnings, and readiness assessment
-- Path to the capture session file
-- Runtime directory for control files and external bodies
+- Safe recorder status with network transaction count
+- Session state (`ACTIVE`, `COMPLETED`, `INCOMPLETE`)
+- Event count and network metrics
 
 ### `capture_api_status`
 
@@ -291,22 +290,20 @@ Query the status of the current active API capture recording. No parameters requ
 - `state`: Recording state (`ACTIVE`, `COMPLETED`, `INCOMPLETE`)
 - `eventCount`: Number of captured browser interactions and API events
 - `apiEventCount`: Number of captured HTTP request/response events
-- `warnings`: List of deterministic warnings (unsupported interactions, missing locators, redacted inputs, etc.)
-- `readiness`: Assessment of captured state (`READY`, `RISKY`, `BLOCKED`)
+- `warnings`: List of deterministic warnings (unsupported interactions, network errors, etc.)
 - `sessionPath`: Absolute path to the active capture session file
 
 ### `capture_api_stop`
 
-Stop the active recording and close the managed browser. The session transitions to `COMPLETED` state and is ready for generation or review.
+Stop the active API capture recording.
 
 **Parameters:**
-- `discard` (boolean, optional): When true, delete the capture session; default false
+- `stop` (boolean, required): Must be `true` for safety confirmation
+- `discard` (boolean, optional): Whether to delete capture artifacts after shutdown
 
 **Returns:**
-- Final session status including event and API event counts
+- Final recorder status with network transaction counts
 - Session file path
-- Path to the generated workbench HTML for local review
-- Warning summary from the recording
 
 ### `capture_api_transactions`
 
@@ -315,29 +312,33 @@ from the active recording. Returns a structured list of all network events recor
 so far, including request details, response metadata, and capture timestamps.
 
 **Parameters:**
-- (none)
+- `limit` (integer, required): Maximum transactions to return (0 = all)
+- `includeAssets` (boolean, required): Whether to include asset requests (images, fonts, stylesheets)
 
 **Returns:**
-- `transactions`: Array of captured API transactions, each containing:
-  - `requestId`: Unique identifier for this request/response pair
+- Ordered list of network transaction summaries, each containing:
+  - `transactionId`: Unique transaction identifier
   - `method`: HTTP method (GET, POST, PUT, DELETE, etc.)
-  - `url`: Full request URL
-  - `timestamp`: Request timestamp
-  - `status`: HTTP response status code
-  - `bodySize`: Size of the response body in bytes
-  - `headers`: Request headers (redacted according to configured patterns)
-  - `firstParty`: Boolean indicating if this is a first-party request
-  - `isAsset`: Boolean indicating if this is an asset (image, CSS, font, etc.)
-- `totalCount`: Total number of transactions captured in the current session
+  - `sanitizedUrl`: Redacted URL without credentials or sensitive query params
+  - `statusCode`: HTTP response status code (0 if failed/blocked)
+  - `resourceKind`: Inferred resource type (document, xhr, fetch, stylesheet, image, font, other)
+  - `durationMs`: Transaction duration in milliseconds
+  - `requestSizeBytes`: Request body size in bytes (0 if no body)
+  - `responseSizeBytes`: Response body size in bytes (0 if unavailable)
+  - `failureReason`: Network or security error reason (empty if successful)
+  - `responseHeaders`: Redacted response headers (excludes sensitive values)
+  - `correlatedUiSequence`: List of correlated UI event IDs if any
+  - `bodyRefId`: Safe reference to stored body content if present
+  - `timestamp`: When the transaction started
 
 ## API capture privacy and safety
 
-- **No secrets in session (by default):** When `capture.api.storeSecretsLocally=false` (default), authorization headers and sensitive data are stored as environment variable references instead of inline values, and the SHAFT privacy classifier prevents typed secrets and credentials from entering the persistent session JSON
+- **No secrets in session (by default):** When `capture.api.storeSecretsLocally=false` (default), authorization headers and sensitive data are stored via `bodyRefId` reference instead of inline values, and the SHAFT privacy classifier prevents typed secrets and credentials from entering the persistent session JSON
+- **Body externalization and reference handling:** Request/response bodies are stored via `bodyRefId` references in captured transactions for privacy preservation; the real body content is stored separately and referenced safely
 - **Secret storage control:** Set `capture.api.storeSecretsLocally=true` to store authorization headers inline for testing purposes (not recommended for production)
-- **Request/response body handling:** Bodies captured during recording are stored alongside the session for analysis; consider `capture.api.maxBodyBytes=1048576` (1 MB default) to limit captured payload size
+- **Request/response body handling:** Bodies captured during recording are limited by `capture.api.maxBodyBytes=1048576` (1 MB default); bodies exceeding this limit are truncated
 - **First-party filtering:** Use `capture.api.firstPartyOnly=true` (default) to record only API calls from the primary domain, or set to false to include all cross-origin requests
 - **Asset filtering:** Set `capture.api.includeAssets=false` (default) to exclude image, CSS, font, and other static assets, or set to true to include them in the capture
-- **Proxy port:** `capture.api.proxy.port=0` (default) uses auto-assigned port; set to a specific port to use a fixed proxy configuration
 - **Safe review:** The generated workbench HTML and capture review summary omit secrets and report only counts and rule names, never exposed values
 
 ## Trace-first failure workflow

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -446,18 +446,20 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 
   /** get **/
   boolean captureApiEnabled = SHAFT.Properties.capture.apiEnabled();
-  int captureApiMaxBodySizeBytes = SHAFT.Properties.capture.apiMaxBodySizeBytes();
-  boolean captureApiExternalizeRequestBodies = SHAFT.Properties.capture.externalizeRequestBodies();
-  boolean captureApiExternalizeResponseBodies = SHAFT.Properties.capture.externalizeResponseBodies();
-  String captureApiRedactedHeaderPatterns = SHAFT.Properties.capture.redactedHeaderPatterns();
+  int captureApiMaxBodyBytes = SHAFT.Properties.capture.apiMaxBodyBytes();
+  boolean captureApiIncludeAssets = SHAFT.Properties.capture.apiIncludeAssets();
+  boolean captureApiFirstPartyOnly = SHAFT.Properties.capture.apiFirstPartyOnly();
+  boolean captureApiStoreSecretsLocally = SHAFT.Properties.capture.apiStoreSecretsLocally();
+  int captureApiProxyPort = SHAFT.Properties.capture.apiProxyPort();
 
   /** set **/
   SHAFT.Properties.capture.set()
     .apiEnabled(true)
-    .apiMaxBodySizeBytes(1048576)
-    .externalizeRequestBodies(true)
-    .externalizeResponseBodies(true)
-    .redactedHeaderPatterns("authorization,cookie,x-api-key");
+    .apiMaxBodyBytes(1048576)
+    .apiIncludeAssets(false)
+    .apiFirstPartyOnly(true)
+    .apiStoreSecretsLocally(false)
+    .apiProxyPort(0);
   ```
   </TabItem>
 
@@ -466,10 +468,11 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   ```bash showLineNumbers
   mvn test \
     -Dcapture.api.enabled=true \
-    -Dcapture.api.maxBodySizeBytes=1048576 \
-    -Dcapture.api.externalizeRequestBodies=true \
-    -Dcapture.api.externalizeResponseBodies=true \
-    -Dcapture.api.redactedHeaderPatterns=authorization,cookie,x-api-key
+    -Dcapture.api.maxBodyBytes=1048576 \
+    -Dcapture.api.includeAssets=false \
+    -Dcapture.api.firstPartyOnly=true \
+    -Dcapture.api.storeSecretsLocally=false \
+    -Dcapture.api.proxy.port=0
   ```
   </TabItem>
 
@@ -477,22 +480,24 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 
   ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
   capture.api.enabled=true
-  capture.api.maxBodySizeBytes=1048576
-  capture.api.externalizeRequestBodies=true
-  capture.api.externalizeResponseBodies=true
-  capture.api.redactedHeaderPatterns=authorization,cookie,x-api-key
+  capture.api.maxBodyBytes=1048576
+  capture.api.includeAssets=false
+  capture.api.firstPartyOnly=true
+  capture.api.storeSecretsLocally=false
+  capture.api.proxy.port=0
   ```
   </TabItem>
 
   <TabItem value="defaults" label="Default Values">
 
-  | Property Name                         | Default Value | Possible Values | Description                                                                                                                                                         |
-  |--------------------------------------|----------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | `capture.api.enabled`               | `false`       | `true`, `false` | • Enable or disable automatic capture of web API network traffic during test execution.<br/>• Requires Chrome or Edge browser with DevTools Protocol support.         |
-  | `capture.api.maxBodySizeBytes`      | `1048576`     | bytes (integer) | • Maximum request/response body size to capture in bytes (default 1 MB).<br/>• Bodies exceeding this limit are truncated in the capture session.                    |
-  | `capture.api.externalizeRequestBodies` | `true`    | `true`, `false` | • Store request bodies in external `capture-request-bodies.json` file instead of inline in the capture session.<br/>• Reduces session JSON size for large payloads. |
-  | `capture.api.externalizeResponseBodies` | `true`   | `true`, `false` | • Store response bodies in external `capture-response-bodies.json` file instead of inline in the capture session.<br/>• Reduces session JSON size for large payloads. |
-  | `capture.api.redactedHeaderPatterns` | ` `         | comma-separated header names | • Comma-separated list of header name patterns (case-insensitive regex) to redact from captured traffic.<br/>• Examples: `authorization`, `cookie`, `x-api-key`, `x-secret.*` |
+  | Property Name                    | Default Value | Possible Values | Description                                                                                                                                                         |
+  |----------------------------------|----------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `capture.api.enabled`            | `false`       | `true`, `false` | • Enable or disable automatic capture of web API network traffic during test execution.<br/>• Requires Chrome or Edge browser with DevTools Protocol support.         |
+  | `capture.api.maxBodyBytes`       | `1048576`     | bytes (integer) | • Maximum request/response body size to capture in bytes (1 MB).<br/>• Bodies exceeding this limit are truncated in the capture session.                           |
+  | `capture.api.includeAssets`      | `false`       | `true`, `false` | • Include asset requests (images, CSS, fonts, etc.) in API capture.<br/>• When false, only data/API calls are recorded.                                            |
+  | `capture.api.firstPartyOnly`     | `true`        | `true`, `false` | • Capture only first-party API calls from the primary domain.<br/>• When false, all cross-origin requests are included.                                           |
+  | `capture.api.storeSecretsLocally` | `false`      | `true`, `false` | • Store authorization headers and sensitive data in the capture session.<br/>• When false (default), secrets are referenced by environment variable instead.       |
+  | `capture.api.proxy.port`         | `0`           | port (integer)  | • Port for the local API capture proxy (0 = auto-assign).<br/>• Requires DevTools Protocol and Chrome/Edge support.                                              |
 
   </TabItem>
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -445,21 +445,19 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   import com.shaft.driver.SHAFT;
 
   /** get **/
-  boolean captureApiEnabled = SHAFT.Properties.capture.apiEnabled();
-  int captureApiMaxBodyBytes = SHAFT.Properties.capture.apiMaxBodyBytes();
-  boolean captureApiIncludeAssets = SHAFT.Properties.capture.apiIncludeAssets();
-  boolean captureApiFirstPartyOnly = SHAFT.Properties.capture.apiFirstPartyOnly();
-  boolean captureApiStoreSecretsLocally = SHAFT.Properties.capture.apiStoreSecretsLocally();
-  int captureApiProxyPort = SHAFT.Properties.capture.apiProxyPort();
+  boolean captureApiEnabled = SHAFT.Properties.capture.isEnabled();
+  int captureApiMaxBodyBytes = SHAFT.Properties.capture.maxBodyBytes();
+  boolean captureApiIncludeAssets = SHAFT.Properties.capture.includeAssets();
+  boolean captureApiFirstPartyOnly = SHAFT.Properties.capture.firstPartyOnly();
+  boolean captureApiStoreSecretsLocally = SHAFT.Properties.capture.storeSecretsLocally();
 
   /** set **/
   SHAFT.Properties.capture.set()
-    .apiEnabled(true)
-    .apiMaxBodyBytes(1048576)
-    .apiIncludeAssets(false)
-    .apiFirstPartyOnly(true)
-    .apiStoreSecretsLocally(false)
-    .apiProxyPort(0);
+    .enabled(true)
+    .maxBodyBytes(1048576)
+    .includeAssets(false)
+    .firstPartyOnly(true)
+    .storeSecretsLocally(false);
   ```
   </TabItem>
 
@@ -471,8 +469,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
     -Dcapture.api.maxBodyBytes=1048576 \
     -Dcapture.api.includeAssets=false \
     -Dcapture.api.firstPartyOnly=true \
-    -Dcapture.api.storeSecretsLocally=false \
-    -Dcapture.api.proxy.port=0
+    -Dcapture.api.storeSecretsLocally=false
   ```
   </TabItem>
 
@@ -484,7 +481,6 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   capture.api.includeAssets=false
   capture.api.firstPartyOnly=true
   capture.api.storeSecretsLocally=false
-  capture.api.proxy.port=0
   ```
   </TabItem>
 
@@ -496,8 +492,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   | `capture.api.maxBodyBytes`       | `1048576`     | bytes (integer) | • Maximum request/response body size to capture in bytes (1 MB).<br/>• Bodies exceeding this limit are truncated in the capture session.                           |
   | `capture.api.includeAssets`      | `false`       | `true`, `false` | • Include asset requests (images, CSS, fonts, etc.) in API capture.<br/>• When false, only data/API calls are recorded.                                            |
   | `capture.api.firstPartyOnly`     | `true`        | `true`, `false` | • Capture only first-party API calls from the primary domain.<br/>• When false, all cross-origin requests are included.                                           |
-  | `capture.api.storeSecretsLocally` | `false`      | `true`, `false` | • Store authorization headers and sensitive data in the capture session.<br/>• When false (default), secrets are referenced by environment variable instead.       |
-  | `capture.api.proxy.port`         | `0`           | port (integer)  | • Port for the local API capture proxy (0 = auto-assign).<br/>• Requires DevTools Protocol and Chrome/Edge support.                                              |
+  | `capture.api.storeSecretsLocally` | `false`      | `true`, `false` | • Store authorization headers and sensitive data in the capture session.<br/>• When false (default), secrets are referenced via bodyRefId instead.                 |
 
   </TabItem>
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -434,6 +434,70 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 
 </Tabs>
 
+### Capture
+
+- These properties control web API request/response recording and capture settings, including network event filtering, request/response body externalization, and sensitive data redaction for API traffic capture during test execution.
+
+<Tabs groupId="PropertyTypes" queryString="Capture">
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  import com.shaft.driver.SHAFT;
+
+  /** get **/
+  boolean captureApiEnabled = SHAFT.Properties.capture.apiEnabled();
+  int captureApiMaxBodySizeBytes = SHAFT.Properties.capture.apiMaxBodySizeBytes();
+  boolean captureApiExternalizeRequestBodies = SHAFT.Properties.capture.externalizeRequestBodies();
+  boolean captureApiExternalizeResponseBodies = SHAFT.Properties.capture.externalizeResponseBodies();
+  String captureApiRedactedHeaderPatterns = SHAFT.Properties.capture.redactedHeaderPatterns();
+
+  /** set **/
+  SHAFT.Properties.capture.set()
+    .apiEnabled(true)
+    .apiMaxBodySizeBytes(1048576)
+    .externalizeRequestBodies(true)
+    .externalizeResponseBodies(true)
+    .redactedHeaderPatterns("authorization,cookie,x-api-key");
+  ```
+  </TabItem>
+
+  <TabItem value="cli-based" label="CLI-based">
+
+  ```bash showLineNumbers
+  mvn test \
+    -Dcapture.api.enabled=true \
+    -Dcapture.api.maxBodySizeBytes=1048576 \
+    -Dcapture.api.externalizeRequestBodies=true \
+    -Dcapture.api.externalizeResponseBodies=true \
+    -Dcapture.api.redactedHeaderPatterns=authorization,cookie,x-api-key
+  ```
+  </TabItem>
+
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  capture.api.enabled=true
+  capture.api.maxBodySizeBytes=1048576
+  capture.api.externalizeRequestBodies=true
+  capture.api.externalizeResponseBodies=true
+  capture.api.redactedHeaderPatterns=authorization,cookie,x-api-key
+  ```
+  </TabItem>
+
+  <TabItem value="defaults" label="Default Values">
+
+  | Property Name                         | Default Value | Possible Values | Description                                                                                                                                                         |
+  |--------------------------------------|----------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `capture.api.enabled`               | `false`       | `true`, `false` | • Enable or disable automatic capture of web API network traffic during test execution.<br/>• Requires Chrome or Edge browser with DevTools Protocol support.         |
+  | `capture.api.maxBodySizeBytes`      | `1048576`     | bytes (integer) | • Maximum request/response body size to capture in bytes (default 1 MB).<br/>• Bodies exceeding this limit are truncated in the capture session.                    |
+  | `capture.api.externalizeRequestBodies` | `true`    | `true`, `false` | • Store request bodies in external `capture-request-bodies.json` file instead of inline in the capture session.<br/>• Reduces session JSON size for large payloads. |
+  | `capture.api.externalizeResponseBodies` | `true`   | `true`, `false` | • Store response bodies in external `capture-response-bodies.json` file instead of inline in the capture session.<br/>• Reduces session JSON size for large payloads. |
+  | `capture.api.redactedHeaderPatterns` | ` `         | comma-separated header names | • Comma-separated list of header name patterns (case-insensitive regex) to redact from captured traffic.<br/>• Examples: `authorization`, `cookie`, `x-api-key`, `x-secret.*` |
+
+  </TabItem>
+
+</Tabs>
+
 ### Flags
 
 - These properties control generic platform flags, like the number of test retry attempts, auto-maximization of web browser window, and any other built-in checks or workarounds that aim to stabilize your test execution.


### PR DESCRIPTION
## Summary

Document the web API traffic capture feature for SHAFT Capture:

- Five new `capture.api.*` properties in the properties reference (`capture.api.enabled`, `capture.api.maxBodyBytes`, `capture.api.includeAssets`, `capture.api.firstPartyOnly`, `capture.api.storeSecretsLocally`), with defaults matching the code
- Four MCP tools documented in the MCP tools reference: `capture_api_start`, `capture_api_status`, `capture_api_stop`, `capture_api_transactions` (parameters, returns, and safety notes: bodies externalized via `bodyRefId`, secret/authorization headers referenced rather than inlined by default, no secrets in session JSON)
- New "Record web API traffic" guide section covering browser support (Chrome/Edge-only via `HasDevTools`/DevTools Protocol), the body-externalization/secret-ref model, the 1 MB body cap, the IntelliJ **Record API (Web)** action, and the P1 boundary (codegen from recordings arrives in a later phase)

## References

- Addresses ShaftHQ/SHAFT_ENGINE#3346 P1 (NetworkEvent model + schema migration + CaptureNetworkRecorder + MCP tools + IntelliJ action)
- No code changes in SHAFT_ENGINE; docs-only PR in shafthq.github.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)