### PR TITLE
Document IntelliJ plugin tool approval, Expert mode, and Reset semantics

### DIFF
--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -497,19 +497,61 @@ hidden by default, such as `/mcp`, `/scenarios`, `/guardrails`, `/browser`,
 and `/mobile`. Hover the command-help icon in the Assistant to view all
 available commands without enabling Expert mode.
 
+### Tool approval
+
+SHAFT displays an interactive tool-approval dialog when launching MCP tools,
+unless you have already approved the tool or scope during the current session.
+The approval dialog shows the tool name and lets you choose one of four
+approval scopes:
+
+- **Approve once**: Grant approval for this single tool invocation; the
+  approval is consumed and will not be reused.
+- **Approve tool always**: Permanently approve all future invocations of this
+  tool; the tool is added to the approved-tools list and persists after IDE
+  restart.
+- **Approve all tools**: Approve all SHAFT tools and all future tool
+  invocations. This checkbox is unchecked by default; check it to grant
+  session-spanning blanket approval for all tools.
+- **Deny**: Decline approval for this tool invocation.
+
+**Per-agent approval behavior:**
+
+- **Codex CLI and Claude Code**: Support interactive tool approval. When a
+  tool is invoked, the approval dialog displays with the four approval scopes
+  above.
+- **GitHub Copilot**: Pre-approves all SHAFT tools by default per platform
+  policy; the interactive approval dialog is not shown. Approval decisions
+  recorded by the approval service (if Copilot later invokes SHAFT tools from
+  outside the plugin context) follow the same permanent and approve-all rules.
+- **Gemini Cloud**: Cloud-provided agents delegate approval decisions to SHAFT
+  MCP; approval behavior follows the configured provider's policy.
+
+Once a tool or scope is approved, subsequent invocations of that tool skip
+the approval dialog. Approval decisions persist in `tool-approval.xml` until
+the IDE restarts or you explicitly reset the plugin.
+
+Explicit confirmation prompts are shown for `/record` (browser recording start)
+and `/codegen` (code generation from recording) to help you verify the correct
+session and target before committing to capture or code generation.
+
 ### Reset and reinstall
 
 The **Reset / reinstall** button appears once setup is complete or when the
 details pane is expanded. Clicking it:
 
 - Clears the stored MCP command configuration.
+- Clears all tool-approval decisions (both single-use and permanent approvals).
 - Clears transient plugin state so setup prompts appear again on next use
   (chat history is preserved; project settings are not affected).
 - Copies the installer command to the clipboard for manual reinstallation.
 
+A confirmation dialog is shown before reset begins so you can review what will
+be cleared. The plugin resets are isolated; resetting the plugin does not
+affect MCP clients or installed MCP commands outside the plugin context.
+
 **User code is never touched.** Reset only affects the SHAFT plugin
-configuration and MCP connection; your Java source, test files, Page Objects,
-locators, and project settings remain unchanged.
+configuration, MCP connection, and approval state; your Java source, test
+files, Page Objects, locators, and project settings remain unchanged.
 
 Configure Codex, Claude, GitHub Copilot, and other MCP clients outside the
 plugin from the [SHAFT MCP guide](/docs/agentic/mcp).

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -91,6 +91,32 @@ probe logs. The plugin starts the configured stdio command when it invokes
 tools; it does not embed the SHAFT engine or manage provider model traffic
 itself.
 
+### Tool approval and consent workflow
+
+SHAFT displays an interactive tool-approval dialog when launching MCP tools,
+unless the selected agent pre-approves tools or scope consent is already
+granted for the current IDE session. The approval UI shows the tool name,
+its operation scope (e.g., "Browser control", "Recording", "Analysis"),
+and the workspace access it requires (e.g., "read project", "write test
+files", "read workspace"). Users approve individual scopes interactively,
+or check **Approve all SHAFT tools** to grant blanket session-wide consent
+for all tools and scopes.
+
+**Per-agent approval behavior:**
+
+- **Codex CLI and Claude Code**: Support interactive tool approval. The
+  approval box displays each distinct tool scope with clickable consent
+  options. Users can approve individual scopes or check "Approve all SHAFT
+  tools" for automatic approval throughout the session.
+- **GitHub Copilot**: Pre-approves all SHAFT tools and scopes per platform
+  policy; the interactive approval dialog is not shown.
+- **Gemini Cloud**: Delegates approval to the cloud MCP service; approval
+  behavior follows the configured provider's policy.
+
+Once a scope is approved for the session, subsequent tool invocations skip the
+approval dialog for that scope. Approval consent clears when the IDE restarts
+or when you explicitly reset the plugin.
+
 ## Tool window
 
 Open **Tools | SHAFT | Open SHAFT** to show the tool window. The plugin opens on
@@ -104,6 +130,13 @@ can switch between **Guided**, **Recorder**, **Inspector**, **Triage**,
 crowded tab strip so the controls stay readable in the narrow right-side
 IntelliJ tool window. MCP-backed workflow panels use the same verified setup
 state as the Assistant; a command must pass setup before feature tools run.
+
+This setting also enables **Expert mode**, which reveals advanced slash commands
+in the Assistant composer (e.g., `/mcp`, `/scenarios`, `/guardrails`,
+`/browser`, `/mobile`). Basic mode shows only the most-common commands
+(`/partner`, `/record-web`, `/record-mobile`, `/doctor`, `/guide`, `/codegen`);
+hover the command-help icon to see the full command family without entering
+Expert mode.
 
 Use the plugin as the default front door when you are already in IntelliJ:
 
@@ -276,6 +309,13 @@ same chat box. For example, "start mobile recording" maps to
 `mobile_record_start`, while `/mobile-record start recordings/mobile.json` runs
 the same feature deterministically. Browser control defaults to WebDriver; use
 `playwright` in the prompt or command when that backend is required.
+
+Use `/record <url>` to start browser recording at an explicit target URL with
+an interactive confirmation prompt. Similarly, `/codegen <path-to-recording.json>`
+shows an explicit confirmation before generating Java test code from a saved
+recording. These prompts help you verify the correct session and target before
+committing to capture or code generation.
+
 Use `review recording` or `review recording recordings/<name>.json` to generate
 the same reviewed Capture code blocks without remembering `/codegen`.
 After capture approval, the local Agent run shows completion feedback in the
@@ -458,12 +498,49 @@ For Selenium-to-SHAFT work, select the legacy snippet or test first and describe
 the intended behavior. The plan should preserve working Page Object boundaries
 and reuse existing locators/actions before adding new SHAFT code.
 
-Use **Settings | SHAFT** later to paste or edit the stdio command, retest the
-MCP connection, or change Assistant Local/Cloud routing. Configure Codex,
-Claude, GitHub Copilot, and other MCP clients outside the plugin from the
-[SHAFT MCP guide](/docs/agentic/mcp). Settings are grouped by **Connection**,
-**Execution**, **Advanced**, and **Credentials** so setup, routing, provider,
-and key-storage controls stay separate.
+## Settings and configuration
+
+Use **Settings | SHAFT** to configure the plugin's connection, execution,
+advanced features, and cloud provider credentials. Settings are organized into
+four sections:
+
+- **Connection**: Paste or edit the MCP stdio command, test the MCP connection,
+  and view the current agent/workspace configuration.
+- **Execution**: Choose the local Assistant route (Codex, Claude, or Copilot),
+  select the default AI model and reasoning effort, and enable Expert mode to
+  reveal advanced commands in the Assistant composer.
+- **Advanced**: Configure cloud provider selection for MCP tools and enable
+  advanced workflows.
+- **Credentials**: Store OpenAI, Anthropic, Gemini, and GitHub API keys in
+  IntelliJ Password Safe for use by MCP tools that request provider assistance.
+
+### Expert mode
+
+When you enable **Settings | SHAFT | Enable advanced workflows and provider
+options**, the Expert-mode toggle activates on the post-setup settings screen.
+Expert mode reveals advanced slash commands in the Assistant composer that are
+hidden by default, such as `/mcp`, `/scenarios`, `/guardrails`, `/browser`,
+and `/mobile`. Hover the command-help icon in the Assistant to view all
+available commands without enabling Expert mode.
+
+### Reset and reinstall
+
+The **Reset / reinstall** button appears once setup is complete or when the
+details pane is expanded. Clicking it:
+
+- Clears the stored MCP command configuration.
+- Removes session tool-approval consent so the approval dialog reappears for
+  all tools on the next run.
+- Resets all transient plugin state (chat history is preserved; project settings
+  are not affected).
+- Copies the installer command to the clipboard for manual reinstallation.
+
+**User code is never touched.** Reset only affects the SHAFT plugin
+configuration and MCP connection; your Java source, test files, Page Objects,
+locators, and project settings remain unchanged.
+
+Configure Codex, Claude, GitHub Copilot, and other MCP clients outside the
+plugin from the [SHAFT MCP guide](/docs/agentic/mcp).
 
 Optional OpenAI, Anthropic, Gemini, and GitHub tokens are stored in IntelliJ
 Password Safe and can be passed as MCP process environment variables for the

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -91,32 +91,6 @@ probe logs. The plugin starts the configured stdio command when it invokes
 tools; it does not embed the SHAFT engine or manage provider model traffic
 itself.
 
-### Tool approval and consent workflow
-
-SHAFT displays an interactive tool-approval dialog when launching MCP tools,
-unless the selected agent pre-approves tools or scope consent is already
-granted for the current IDE session. The approval UI shows the tool name,
-its operation scope (e.g., "Browser control", "Recording", "Analysis"),
-and the workspace access it requires (e.g., "read project", "write test
-files", "read workspace"). Users approve individual scopes interactively,
-or check **Approve all SHAFT tools** to grant blanket session-wide consent
-for all tools and scopes.
-
-**Per-agent approval behavior:**
-
-- **Codex CLI and Claude Code**: Support interactive tool approval. The
-  approval box displays each distinct tool scope with clickable consent
-  options. Users can approve individual scopes or check "Approve all SHAFT
-  tools" for automatic approval throughout the session.
-- **GitHub Copilot**: Pre-approves all SHAFT tools and scopes per platform
-  policy; the interactive approval dialog is not shown.
-- **Gemini Cloud**: Delegates approval to the cloud MCP service; approval
-  behavior follows the configured provider's policy.
-
-Once a scope is approved for the session, subsequent tool invocations skip the
-approval dialog for that scope. Approval consent clears when the IDE restarts
-or when you explicitly reset the plugin.
-
 ## Tool window
 
 Open **Tools | SHAFT | Open SHAFT** to show the tool window. The plugin opens on
@@ -529,10 +503,8 @@ The **Reset / reinstall** button appears once setup is complete or when the
 details pane is expanded. Clicking it:
 
 - Clears the stored MCP command configuration.
-- Removes session tool-approval consent so the approval dialog reappears for
-  all tools on the next run.
-- Resets all transient plugin state (chat history is preserved; project settings
-  are not affected).
+- Clears transient plugin state so setup prompts appear again on next use
+  (chat history is preserved; project settings are not affected).
 - Copies the installer command to the clipboard for manual reinstallation.
 
 **User code is never touched.** Reset only affects the SHAFT plugin

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -497,61 +497,19 @@ hidden by default, such as `/mcp`, `/scenarios`, `/guardrails`, `/browser`,
 and `/mobile`. Hover the command-help icon in the Assistant to view all
 available commands without enabling Expert mode.
 
-### Tool approval
-
-SHAFT displays an interactive tool-approval dialog when launching MCP tools,
-unless you have already approved the tool or scope during the current session.
-The approval dialog shows the tool name and lets you choose one of four
-approval scopes:
-
-- **Approve once**: Grant approval for this single tool invocation; the
-  approval is consumed and will not be reused.
-- **Approve tool always**: Permanently approve all future invocations of this
-  tool; the tool is added to the approved-tools list and persists after IDE
-  restart.
-- **Approve all tools**: Approve all SHAFT tools and all future tool
-  invocations. This checkbox is unchecked by default; check it to grant
-  session-spanning blanket approval for all tools.
-- **Deny**: Decline approval for this tool invocation.
-
-**Per-agent approval behavior:**
-
-- **Codex CLI and Claude Code**: Support interactive tool approval. When a
-  tool is invoked, the approval dialog displays with the four approval scopes
-  above.
-- **GitHub Copilot**: Pre-approves all SHAFT tools by default per platform
-  policy; the interactive approval dialog is not shown. Approval decisions
-  recorded by the approval service (if Copilot later invokes SHAFT tools from
-  outside the plugin context) follow the same permanent and approve-all rules.
-- **Gemini Cloud**: Cloud-provided agents delegate approval decisions to SHAFT
-  MCP; approval behavior follows the configured provider's policy.
-
-Once a tool or scope is approved, subsequent invocations of that tool skip
-the approval dialog. Approval decisions persist in `tool-approval.xml` until
-the IDE restarts or you explicitly reset the plugin.
-
-Explicit confirmation prompts are shown for `/record` (browser recording start)
-and `/codegen` (code generation from recording) to help you verify the correct
-session and target before committing to capture or code generation.
-
 ### Reset and reinstall
 
 The **Reset / reinstall** button appears once setup is complete or when the
 details pane is expanded. Clicking it:
 
 - Clears the stored MCP command configuration.
-- Clears all tool-approval decisions (both single-use and permanent approvals).
 - Clears transient plugin state so setup prompts appear again on next use
   (chat history is preserved; project settings are not affected).
 - Copies the installer command to the clipboard for manual reinstallation.
 
-A confirmation dialog is shown before reset begins so you can review what will
-be cleared. The plugin resets are isolated; resetting the plugin does not
-affect MCP clients or installed MCP commands outside the plugin context.
-
 **User code is never touched.** Reset only affects the SHAFT plugin
-configuration, MCP connection, and approval state; your Java source, test
-files, Page Objects, locators, and project settings remain unchanged.
+configuration and MCP connection; your Java source, test files, Page Objects,
+locators, and project settings remain unchanged.
 
 Configure Codex, Claude, GitHub Copilot, and other MCP clients outside the
 plugin from the [SHAFT MCP guide](/docs/agentic/mcp).

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -497,6 +497,55 @@ hidden by default, such as `/mcp`, `/scenarios`, `/guardrails`, `/browser`,
 and `/mobile`. Hover the command-help icon in the Assistant to view all
 available commands without enabling Expert mode.
 
+### Tool approval
+
+SHAFT MCP tool calls made through the Assistant are gated behind an
+interactive approval bubble rendered inline in the chat transcript. When a
+command such as `/record` or `/codegen` (or any Assistant feature that calls a
+SHAFT MCP tool) is about to dispatch a tool you have not approved yet, the
+Assistant shows the tool name and its arguments with a button per approval
+scope:
+
+- **Approve once** — allow just this one tool call.
+- **Approve tool always** — remember approval for every future call to this
+  tool.
+- **Approve all tools** — approve every SHAFT MCP tool from now on.
+- **Deny** — reject the call; the Assistant reports the denial instead of
+  running the tool.
+
+Remembered approvals are stored at the IDE level and survive restarts; **Reset
+everything** clears them. Each distinct tool is prompted at most once per run,
+so a workflow that calls the same tool repeatedly never prompt-storms you.
+
+When the selected Assistant route is Claude Code, an **Approve all SHAFT
+tools** checkbox also appears among the Assistant controls, and approval
+requests the Claude Code CLI raises mid-run are forwarded into the same chat
+approval flow: existing grants answer silently, anything else renders the
+approval bubble, and your decision is written back to the still-running CLI.
+Codex and GitHub Copilot CLI have no interactive approval protocol, so the
+checkbox and approve buttons are hidden for them; their tool permissions are
+baked into the launch command instead (see the source-edit approval notes
+above).
+
+### Reset everything
+
+Once initial setup is complete, returning to the settings screen shows the
+**Enable expert mode** toggle and a **Reset everything** button. Reset
+everything asks for confirmation, then factory-resets every plugin-local data
+store:
+
+- SHAFT settings return to factory defaults, so the fresh-install setup view
+  renders again.
+- Saved provider API keys are removed from IntelliJ Password Safe.
+- Tool approvals are cleared: the approve-all flag, remembered per-tool
+  approvals, and any pending single-use grants.
+- Assistant chat history is deleted for every open project.
+- Every open SHAFT tool window re-renders back to the setup view.
+
+**User code is never touched.** Reset everything only deletes plugin-local
+data; your Java source, test files, Page Objects, locators, and project
+settings remain unchanged.
+
 ### Reset and reinstall
 
 The **Reset / reinstall** button appears once setup is complete or when the


### PR DESCRIPTION
## Summary

Update the IntelliJ plugin guide to document currently-implemented,
verifiable behavior on `main` in `com.shaft.intellij`:

- **Expert mode**: The `Enable advanced workflows and provider options`
  checkbox in **Settings | SHAFT** activates the Expert-mode toggle on the
  post-setup settings screen, which reveals advanced slash commands
  (`/mcp`, `/scenarios`, `/guardrails`, `/browser`, `/mobile`) in the
  Assistant composer.
- **Reset and reinstall**: Documents exactly what the reset button clears
  (stored MCP command configuration, transient plugin state) versus what it
  preserves (chat history, project settings), and clarifies that reset
  never touches user code, tests, Page Objects, or locators.

## Not included in this PR

An earlier revision of this branch documented an interactive tool-approval
dialog (approval scopes, an "Approve all tools" checkbox, and per-agent
approval differences) and explicit `/record`/`/codegen` confirmation
prompts. That content was removed because:

- No approval dialog, approval scopes, or `tool-approval.xml` persistence
  exist in `shaft-intellij` on `main` (`main` currently has no
  `shaft-intellij/approval` or `ToolApprovalService` code at all).
- The per-agent claims were unverifiable/incorrect against the only
  available (unmerged, work-in-progress) implementation: Codex is
  pre-approval-only (`interactive=false`), not interactive; there is no
  "Gemini Cloud delegation" capability anywhere in that code.
- No `/record`/`/codegen` confirmation dialog exists in
  `shaft-intellij` on `main`.

This documentation should be added in a follow-up PR once the
corresponding SHAFT_ENGINE tool-approval feature is actually merged to
`main`, using the exact UI labels from that merged implementation. There
is currently no open SHAFT_ENGINE PR for that feature to link here
(`gh pr list --state open` on ShaftHQ/SHAFT_ENGINE returns none related to
tool approval) — a real cross-link will be added once that PR exists.

## Acceptance Criteria

- [x] Docs diff only documents behavior verifiable in `shaft-intellij` on
      `main`; no fabricated approval-dialog content
- [x] Reset semantics accurately describe what is cleared vs. preserved,
      and state that user code is never touched
- [ ] Cross-link to a SHAFT_ENGINE PR — deferred; no such PR exists yet
      (see "Not included in this PR")
