### PR TITLE
Document persistent plugin MCP session and guided recorder assertion flow

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -112,9 +112,17 @@ missing locator candidates, positional or multi-match locators, missing
 post-navigation or post-submit assertions, redacted required inputs, and
 collector warnings. The chip reports issues only; it does not block recording.
 
-Use the assertion control to toggle assertion mode, then click an element and choose
-one of the deterministic verification types: visible, enabled, selected, text
-equals or contains, attribute equals, URL equals or contains, or title equals.
+Use the assertion control to open the guided assertion flow, which offers two
+deterministic branches. The **Element** branch asks you to click the target
+element, then shows the top scored locator candidates (with a manual XPath or
+CSS field as an alternative), then the fixed element catalog: exists, visible,
+enabled, and selected (each with an expected `true`/`false` choice), text equals
+or contains, attribute equals (with attribute name and expected value fields),
+and image matches. The **Browser** branch shows the fixed page-level catalog:
+URL equals or contains, title equals or contains, and page text contains, each
+with an editable expected value prefilled from the live page. Saved assertions
+appear in the panel step list and rehydrate across navigations like any other
+recorded step.
 The recorder stores these as `VerificationEvent` records. Expected text, URL,
 title, and attribute values are externalized through the same privacy classifier
 used for typed data, so generated assertions do not embed captured secrets.

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -100,9 +100,12 @@ organization MCP policy, and SHAFT IntelliJ plugin users should run the
 
 After the test succeeds, setup shows the verified runtime/workspace, **Ready**,
 and **Start chatting** action without showing the managed stdio command or
-probe logs. The plugin starts the configured stdio command when it invokes
-tools; it does not embed the SHAFT engine or manage provider model traffic
-itself.
+probe logs. The plugin starts the configured stdio command on the first tool
+invocation and keeps that MCP server process alive across tool calls, so
+session-based tools (a `/record-web` Capture recording, an initialized live
+driver) keep running between commands; the process is restarted transparently
+when it dies or the configured command changes. The plugin does not embed the
+SHAFT engine or manage provider model traffic itself.
 
 ## Tool window
 


### PR DESCRIPTION
Docs companion to ShaftHQ/SHAFT_ENGINE#3374 (fixes ShaftHQ/SHAFT_ENGINE#3365).

- **intellij.md**: the plugin now keeps one MCP server process alive across tool calls, so session-based tools (a `/record-web` Capture recording, an initialized live driver) keep running between commands; the process respawns transparently when it dies or the configured command changes.
- **capture.md**: replace the flat verification-type list with the guided assertion flow — the Element branch (click the target, pick from top scored locator candidates or enter a manual XPath/CSS locator, then choose from the fixed catalog including existence and true/false expected choices) and the Browser branch (URL/title/page-text checks with editable expected values prefilled from the live page) — and note that saved assertions rehydrate in the panel step list across navigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)