### PR TITLE
Landing page: two-voice evidence design pass + TS7 typecheck fix

### DIFF
--- a/scripts/landing-shots.mjs
+++ b/scripts/landing-shots.mjs
@@ -1,0 +1,27 @@
+import {chromium} from '@playwright/test';
+
+const outDir = process.argv[2] ?? 'test-screenshots';
+const base = 'http://127.0.0.1:3000';
+
+const shots = [
+  {name: 'landing-desktop-light', width: 1440, height: 900, scheme: 'light', full: true},
+  {name: 'landing-desktop-dark', width: 1440, height: 900, scheme: 'dark', full: true},
+  {name: 'landing-mobile-light', width: 375, height: 844, scheme: 'light', full: true},
+];
+
+const browser = await chromium.launch();
+for (const shot of shots) {
+  const context = await browser.newContext({
+    viewport: {width: shot.width, height: shot.height},
+    colorScheme: shot.scheme,
+    reducedMotion: 'reduce',
+  });
+  const page = await context.newPage();
+  await page.addInitScript((theme) => window.localStorage.setItem('theme', theme), shot.scheme);
+  await page.goto(base, {waitUntil: 'networkidle'});
+  await page.waitForTimeout(600);
+  await page.screenshot({path: `${outDir}/${shot.name}.png`, fullPage: shot.full});
+  await context.close();
+  console.log(`captured ${shot.name}`);
+}
+await browser.close();

--- a/scripts/landing-zoom.mjs
+++ b/scripts/landing-zoom.mjs
@@ -1,0 +1,30 @@
+import {chromium} from '@playwright/test';
+
+const outDir = process.argv[2] ?? 'test-screenshots';
+const base = 'http://127.0.0.1:3000';
+
+const targets = [
+  ['[data-testid="landing-hero"]', 'zoom-hero'],
+  ['[data-testid="landing-code-proof"]', 'zoom-code-proof'],
+  ['[data-testid="landing-evidence-loop"]', 'zoom-evidence-loop'],
+  ['[data-testid="landing-surface-matrix"]', 'zoom-matrix'],
+  ['[data-testid="landing-allure-evidence"]', 'zoom-allure'],
+];
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: {width: 1440, height: 900},
+  colorScheme: 'light',
+  reducedMotion: 'reduce',
+});
+const page = await context.newPage();
+await page.goto(base, {waitUntil: 'networkidle'});
+await page.waitForTimeout(600);
+for (const [selector, name] of targets) {
+  await page.locator(selector).scrollIntoViewIfNeeded();
+  await page.waitForTimeout(250);
+  await page.locator(selector).screenshot({path: `${outDir}/${name}.png`});
+  console.log(`captured ${name}`);
+}
+await context.close();
+await browser.close();

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -71,6 +71,54 @@
   text-decoration: none;
 }
 
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.3rem 0.9rem;
+  max-width: 720px;
+  margin: 0 auto 1.15rem;
+  color: rgba(var(--site-color-muted-rgb), 0.82);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-small);
+  font-weight: var(--site-font-weight-regular);
+  letter-spacing: 0.08em;
+}
+
+.heroMeta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.heroMeta span + span::before {
+  width: 0.32rem;
+  height: 0.32rem;
+  background: rgba(var(--site-color-primary-rgb), 0.75);
+  content: '';
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.9rem;
+  color: var(--site-color-primary);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-small);
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.eyebrow::before {
+  width: 0.5rem;
+  height: 0.5rem;
+  background: var(--site-color-primary);
+  box-shadow: 0 0 0 4px rgba(var(--site-color-primary-rgb), 0.14);
+  content: '';
+}
+
 .heroCopy h1 {
   max-width: 980px;
   margin: 0 auto 1.25rem;
@@ -279,7 +327,65 @@
 
 .codePanel figcaption,
 .handledPanel > span {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 1.7rem;
   margin-bottom: 0.48rem;
+  font-family: var(--ifm-font-family-monospace);
+  letter-spacing: 0.06em;
+}
+
+.chromeDots {
+  display: inline-flex;
+  gap: 0.34rem;
+}
+
+.chromeDots i {
+  width: 0.52rem;
+  height: 0.52rem;
+  border: 1px solid rgba(var(--site-color-muted-rgb), 0.55);
+  border-radius: 999px;
+}
+
+.chromeDots i:first-child {
+  border-color: var(--site-color-primary);
+  background: rgba(var(--site-color-primary-rgb), 0.55);
+}
+
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  padding: 0.1rem 0.55rem;
+  border: 1px solid rgba(var(--site-color-primary-rgb), 0.45);
+  border-radius: 999px;
+  background: rgba(var(--site-color-primary-rgb), 0.1);
+  color: var(--site-color-primary);
+  font-size: var(--site-font-caption);
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.codePanel,
+.allureFrame {
+  position: relative;
+}
+
+.codePanel::after,
+.allureFrame::after {
+  position: absolute;
+  inset: 5px;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(var(--site-color-primary-rgb), 0.55), rgba(var(--site-color-primary-rgb), 0.55)) 0 0 / 14px 1px no-repeat,
+    linear-gradient(0deg, rgba(var(--site-color-primary-rgb), 0.55), rgba(var(--site-color-primary-rgb), 0.55)) 0 0 / 1px 14px no-repeat,
+    linear-gradient(90deg, rgba(var(--site-color-primary-rgb), 0.55), rgba(var(--site-color-primary-rgb), 0.55)) 100% 100% / 14px 1px no-repeat,
+    linear-gradient(0deg, rgba(var(--site-color-primary-rgb), 0.55), rgba(var(--site-color-primary-rgb), 0.55)) 100% 100% / 1px 14px no-repeat;
+  content: '';
 }
 
 .codeCompare pre {
@@ -354,6 +460,27 @@
   background: var(--site-color-primary);
   transform: translateY(-50%);
   content: '';
+}
+
+.handledPanel ul {
+  font-family: var(--ifm-font-family-monospace);
+  line-height: 1.5;
+}
+
+.handledPanel li {
+  padding-left: 1.2rem;
+}
+
+.handledPanel li::before {
+  top: 0;
+  width: auto;
+  height: auto;
+  border-radius: 0;
+  background: transparent;
+  color: var(--site-color-primary);
+  font-weight: var(--site-font-weight-bold);
+  transform: none;
+  content: '+';
 }
 
 .audienceSection {
@@ -580,12 +707,12 @@
   background: rgba(var(--site-color-primary-rgb), 0.06);
 }
 
-.matrixRow span {
+.matrixRow > span {
   position: relative;
   color: transparent;
 }
 
-.matrixRow span::before {
+.matrixRow > span::before {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -914,6 +1041,53 @@
 
 :global(html[data-reveal-ready='true']) .reveal[data-reveal-state='rolled-back'] {
   transform: translate3d(0, calc(var(--reveal-distance) * 0.85), 0) scale(0.975);
+}
+
+.pathCard small {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-small);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.matrixHeader {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-small);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.matrixStack {
+  display: block;
+  margin-top: 0.18rem;
+  color: var(--ifm-color-emphasis-700);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-caption);
+  font-weight: var(--site-font-weight-regular);
+  letter-spacing: 0.05em;
+}
+
+.loopStep small {
+  width: auto;
+  min-width: 1.8rem;
+  justify-self: start;
+  padding: 0 0.4rem;
+  border-radius: 6px;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-small);
+  letter-spacing: 0.08em;
+}
+
+.footerBadges strong {
+  font-family: var(--ifm-font-family-monospace);
+  letter-spacing: 0.06em;
+}
+
+.finalKicker {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--site-font-label);
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: 0.14em;
 }
 
 @media (max-width: 1180px) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,13 +128,14 @@ const slackInviteUrl = 'https://join.slack.com/t/shaft-engine/shared_invite/zt-o
 
 const codeCompare = {
   handled: [
-    'SHAFT handles the repeatable work:',
     'driver lifecycle, waits, retries, and sync',
     'screenshots, logs, steps, and attachments',
     'configuration and data isolation',
     'Allure evidence that Doctor and Heal can read',
   ],
 };
+
+const heroMeta = ['io.github.shafthq : shaft-engine', 'Java 25', 'MIT', 'Allure native'];
 
 const evidenceLoop = [
   {
@@ -269,11 +270,18 @@ function CodeCompare(): JSX.Element {
   return (
     <div className={styles.codeCompare} data-testid="landing-code-proof" aria-label="SHAFT test code proof">
       <figure className={styles.codePanel}>
-        <figcaption>SHAFT test</figcaption>
+        <figcaption>
+          <span className={styles.chromeDots} aria-hidden="true"><i /><i /><i /></span>
+          CheckoutTest.java
+          <span className={styles.statusChip}>Pass</span>
+        </figcaption>
         <JavaCodeExample />
       </figure>
       <div className={styles.handledPanel}>
-        <span>SHAFT handles</span>
+        <span>
+          SHAFT handles
+          <span className={styles.statusChip}>evidence attached</span>
+        </span>
         <ul>
           {codeCompare.handled.map((item) => (
             <li key={item}>{item}</li>
@@ -301,6 +309,11 @@ function Hero(): JSX.Element {
       <div className={`container ${styles.heroGrid}`}>
         <div className={styles.heroCopy}>
           <Link className={styles.heroBrand} to="/" aria-label="SHAFT home">SHAFT</Link>
+          <p className={styles.heroMeta} aria-label="Project coordinates">
+            {heroMeta.map((fact) => (
+              <span key={fact}>{fact}</span>
+            ))}
+          </p>
           <h1>Ship automation evidence, not boilerplate code.</h1>
           <p>
             <strong>One Java test suite for web, mobile, API, DB, and CLI.</strong>
@@ -341,13 +354,14 @@ function GuidePathSection(): JSX.Element {
     <section className={`${styles.section} ${styles.pathSection} ${styles.reveal}`} data-testid="landing-pathfinder" id="guide-paths" data-reveal>
       <div className="container">
         <div className={`${styles.sectionHeading} ${styles.centerHeading}`}>
+          <span className={styles.eyebrow}>Guided paths</span>
           <Heading as="h2" id="guide-paths-heading">Get started in minutes.</Heading>
           <p>Install, configure, write a readable test, run it headlessly, and review the evidence before starring the repository.</p>
         </div>
         <div className={styles.pathGrid} aria-labelledby="guide-paths-heading">
           {guidePaths.map((path, index) => (
             <Link className={`${styles.pathCard} ${styles.reveal}`} to={path.to} key={path.title} data-reveal data-hover-glow>
-              <small>{index + 1}. {path.audience}</small>
+              <small>{String(index + 1).padStart(2, '0')} · {path.audience}</small>
               <strong>{path.title}</strong>
               <span>{path.description}</span>
               <em>{path.label}</em>
@@ -384,6 +398,7 @@ function SurfaceSection(): JSX.Element {
     <section className={`${styles.section} ${styles.surfaceSection} ${styles.reveal}`} data-testid="landing-surfaces" id="surface-section" data-reveal>
       <div className="container">
         <div className={styles.sectionHeading}>
+          <span className={styles.eyebrow}>Coverage matrix</span>
           <Heading as="h2" id="testing-surfaces">One framework. Full surface coverage.</Heading>
           <p>Start with the layer in front of you, then expand without changing the reporting and lifecycle model.</p>
         </div>
@@ -396,7 +411,10 @@ function SurfaceSection(): JSX.Element {
           </div>
           {testSurfaces.map((surface) => (
             <Link className={styles.matrixRow} to={surface.to} key={surface.title} data-hover-glow>
-              <strong>{surface.title}</strong>
+              <strong>
+                {surface.title}
+                <small className={styles.matrixStack}>{surface.stack}</small>
+              </strong>
               {coverageColumns.map((column) => (
                 <span key={column}>{column}</span>
               ))}
@@ -413,6 +431,7 @@ function ProofSection(): JSX.Element {
     <section className={`${styles.section} ${styles.reveal}`} data-testid="landing-proof" id="proof-section" data-reveal>
       <div className="container">
         <div className={styles.sectionHeading}>
+          <span className={styles.eyebrow}>Code proof</span>
           <Heading as="h2" id="why-shaft">Boilerplate code removed from tests.</Heading>
           <p>Clean tests that read like documentation. Let SHAFT own the repeatable mechanics that make evidence reliable.</p>
         </div>
@@ -436,6 +455,7 @@ function AllureEvidenceSection(): JSX.Element {
     <section className={`${styles.section} ${styles.allureSection} ${styles.reveal}`} data-testid="landing-allure-evidence" id="allure-evidence" data-reveal>
       <div className={`container ${styles.allureGrid}`}>
         <div className={styles.sectionHeading}>
+          <span className={styles.eyebrow}>Run evidence</span>
           <Heading as="h2" id="allure-evidence-heading">Allure evidence people can inspect.</Heading>
           <p>SHAFT turns each checkout action into report evidence: steps, screenshots, logs, and diagnostics stay attached to the run instead of scattered across CI output.</p>
           <Link className={styles.inlineCta} to="/docs/reference/reporting">
@@ -464,13 +484,14 @@ function AgentSection(): JSX.Element {
     <section className={`${styles.section} ${styles.agentBand} ${styles.reveal}`} data-testid="landing-agent" id="connect-ai-agent" data-reveal>
       <div className={`container ${styles.agentSection}`}>
         <div className={styles.sectionHeading}>
+          <span className={styles.eyebrow}>Diagnostic loop</span>
           <Heading as="h2">The evidence loop makes failures explainable.</Heading>
           <p>Run the suite, collect the artifacts, diagnose the path, and improve the checks with the same evidence trail.</p>
         </div>
         <div className={styles.evidenceLoop} data-testid="landing-evidence-loop" aria-label="SHAFT evidence loop">
           {evidenceLoop.map((step, index) => (
             <div className={styles.loopStep} key={step.title} data-hover-glow>
-              <small>{index + 1}</small>
+              <small>{String(index + 1).padStart(2, '0')}</small>
               <strong>{step.title}</strong>
               <span>{step.description}</span>
             </div>
@@ -501,7 +522,7 @@ function FinalCta(): JSX.Element {
         )}
       </BrowserOnly>
       <div className={`container ${styles.finalCtaInner}`}>
-        <p className={styles.finalKicker}>You shipped evidence. We captured it.</p>
+        <p className={styles.finalKicker}>run complete · evidence attached · exit 0</p>
         <h2>Star SHAFT on GitHub.</h2>
         <p>Start with the quick path. After the sample test produces evidence, star the repository so releases stay visible.</p>
         <div className={styles.actions}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,17 @@
 {
-  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
-    "noEmit": true
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## What

Design/UX pass on the user guide landing page aimed at technical evaluators and sharper market positioning, plus an inline fix for the `yarn typecheck` breakage introduced by the TypeScript 7 bump.

### Design system: claims in sans, evidence in mono
SHAFT's product is *evidence*, so the page now uses a two-voice type system: persuasive claims stay in the human sans voice; every verifiable fact switches to a machine mono voice styled like an instrument panel — strictly on the approved blue token palette (`DESIGN_LANGUAGE.md`), in both themes.

- **Hero**: mono project-coordinates line (`io.github.shafthq : shaft-engine · Java 25 · MIT · Allure native`) above the headline.
- **Section eyebrows**: consistent mono-caps labels (Coverage matrix, Code proof, Run evidence, Diagnostic loop, Guided paths) improve scannability.
- **Code proof as a passing run**: editor-tab chrome (dots + `CheckoutTest.java` + `Pass` chip); the SHAFT-handles panel reads as an attached-artifacts log (`+` log lines, `evidence attached` chip); viewfinder corner ticks on the two captured-evidence visuals.
- **Coverage matrix**: previously-unused engine stack facts (Selenium + Playwright, Appium, REST Assured, JDBC, Local/Docker/SSH) surfaced as mono sublabels per row.
- **Evidence loop / guided paths**: zero-padded mono step indices (`01`–`05`).
- **Final CTA kicker** closes the page like a run log: `run complete · evidence attached · exit 0`.

### Build fix (pre-existing, hit while validating)
TypeScript 7.0.2 (#724) removed `baseUrl`, and the extended `@docusaurus/tsconfig` still sets it, so `yarn typecheck` failed on every fresh install. Inlined the Docusaurus compiler options without `baseUrl`, keeping the `@site/*` alias.

### Tooling
`scripts/landing-shots.mjs` + `scripts/landing-zoom.mjs` capture reproducible landing screenshots (light/dark/mobile + per-section zooms) against the served build.

## Not changed
All stable test hooks, CTAs, quick-start anchors, canonical MCP links, particle backgrounds, reduced-motion and mobile behavior, and the pinned hero/product messaging are preserved.

## Validation
- `yarn test` (docs, homepage content/evidence/a11y, history, release template) ✅
- `yarn typecheck` ✅ (was failing on master with a fresh install)
- `yarn build` ✅
- `yarn test:playwright` — 3/3 homepage e2e ✅
- Visual inspection of the built page: desktop light + dark, mobile 375px (screenshots attached in PR thread)

Note: graphify refresh was not run from this scratchpad worktree; graph deltas are limited to the two edited landing files and two new standalone scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)