### PR TITLE
docs: IntelliJ plugin trustworthy first contact (SHAFT_ENGINE#3426)

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -116,6 +116,34 @@ missing locator candidates, positional or multi-match locators, missing
 post-navigation or post-submit assertions, redacted required inputs, and
 collector warnings. The chip reports issues only; it does not block recording.
 
+Teams can pin recorder behavior for a whole repository by checking in
+`.shaft/recorder-policy.json` at the workspace root:
+
+```json
+{
+  "headless": false,
+  "outputDirectory": "recordings",
+  "browser": "Chrome"
+}
+```
+
+All fields are optional. When the file exists, SHAFT MCP's `capture_start`
+applies it to every recording started against that workspace — whichever
+client asked (IntelliJ plugin, agent CLI, raw MCP call): `headless` locks the
+browser visibility, `outputDirectory` re-roots every recording into the team
+directory (the requested file name is kept), and `browser` fills the default
+when a request names none. The IntelliJ Guided panel mirrors the policy
+visibly: the Headless toggle is applied and locked with a "locked by team
+policy" tooltip, and the default session path moves into the team directory.
+A malformed policy file never blocks recording; it just falls back to
+defaults.
+
+For the maintenance loop, the Guided panel's **Weekly flaky triage** template
+prefills a batch Doctor analysis with historical bundles
+(`target/shaft-doctor/history`) so repeat offenders surface as trends; follow
+up with `healer_run_failed_test` per flaky test, and pair the template with a
+weekly scheduled agent that sends `/doctor` and consolidates the report.
+
 The recorder only keeps actions a user actually performed. Browser-synthesized
 noise is suppressed on both the in-page recorder and the server pipeline:
 pressing Enter in a form no longer records a phantom click on the form's

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -116,9 +116,22 @@ missing locator candidates, positional or multi-match locators, missing
 post-navigation or post-submit assertions, redacted required inputs, and
 collector warnings. The chip reports issues only; it does not block recording.
 
+The recorder only keeps actions a user actually performed. Browser-synthesized
+noise is suppressed on both the in-page recorder and the server pipeline:
+pressing Enter in a form no longer records a phantom click on the form's
+invisible default submit button, the duplicate `change` re-announcement of an
+already-recorded typed value no longer appends a second type step, clicks on
+the bare page background (`body`/`html`) are ignored, and page clicks made
+while the assertion wizard is open are treated as wizard interaction rather
+than recorded steps.
+
 Use the assertion control to open the guided assertion flow, which offers two
 deterministic branches. The **Element** branch asks you to click the target
-element, then shows the top scored locator candidates (with a manual XPath or
+element: a prominent top-of-page banner ("Assertion: click the element you
+want to verify... Press Esc to cancel"), a crosshair cursor, and the hover
+highlight make the waiting-for-your-click state unmissable, and that pick
+click is never recorded as a step. It then shows the top scored locator
+candidates (with a manual XPath or
 CSS field as an alternative), then the fixed element catalog: exists, visible,
 enabled, and selected (each with an expected `true`/`false` choice), text equals
 or contains, attribute equals (with attribute name and expected value fields),

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -70,6 +70,21 @@ support is available. First run shows a six-step setup inside the tool window:
    **Copy restart command** button copies a terminal command that stops stale
    CLI processes and re-verifies access. Success reveals **Start chatting**.
 
+Setup readiness has two lanes. The recorder, codegen, Doctor, and Healer only
+need the verified SHAFT MCP — no agent at all — so when the MCP check passes
+but the selected agent is missing or unreachable, setup still completes with a
+**Start without an agent** button and honest copy ("Recorder, codegen, and
+doctor are ready now — connecting an agent adds chat and is optional"), while
+the agent diagnostics and restart recovery stay visible for the optional
+second lane. The wizard is also project-aware: the Upgrade step distinguishes
+"already on the latest SHAFT" (green), "SHAFT upgrade available", "Maven
+project without SHAFT" (adopt via the upgrade command), and "no `pom.xml` at
+all" (scaffold a project first), so an empty folder is never told to upgrade.
+
+After setup, the main view header keeps a persistent **MCP health chip**
+("MCP: verified / failed / not checked") with a one-click **Recheck** that
+runs a live connection probe, so a broken MCP never fails silently mid-session.
+
 The Marketplace plugin does not download or execute installer scripts at
 runtime. It only helps you choose the agent, copy the terminal installer
 command, find the installed `shaft-mcp.args` automatically, then stores and
@@ -155,13 +170,26 @@ Open **Tools | SHAFT | Open SHAFT** to show the tool window. The plugin opens on
 the **Assistant** workflow. By default, use Assistant slash commands such as
 `/partner`, `/record-web`, `/record-mobile`, `/doctor`, and `/guide`.
 
+Workflow tabs disclose progressively: the default **Workflow** selector shows
+**Assistant** and **Guided**, and the specialist tabs appear only when their
+artifacts make them relevant — **Recorder** once a `recordings/` directory
+exists, **Triage** and **Evidence** once `target/allure-results` or
+`target/shaft-traces` exist, and **Advanced** on demand the first time a
+workflow prepares a raw MCP request.
+
 If you enable **Settings | SHAFT | Enable advanced workflows and provider
-options**, the **Workflow** selector appears at the top of the tool window and
-can switch between **Guided**, **Recorder**, **Inspector**, **Triage**,
-**Evidence**, **Projects**, and **Advanced**. The selector is used instead of a
+options**, the selector always shows every workflow: **Guided**, **Recorder**,
+**Inspector**, **Triage**, **Evidence**, **Projects**, and **Advanced**. The
+selector is used instead of a
 crowded tab strip so the controls stay readable in the narrow right-side
 IntelliJ tool window. MCP-backed workflow panels use the same verified setup
 state as the Assistant; a command must pass setup before feature tools run.
+
+The fastest first contact is the Guided tab's **Try SHAFT on a sample page**
+button: it extracts a bundled local bookstore page (nothing leaves your
+machine), opens a visible recording on it, and walks you through search → add
+to cart → assertion → Stop → **Review code** — a complete record-review-insert
+loop in about 90 seconds, no target site required.
 
 This setting also enables **Expert mode**, which reveals advanced slash commands
 in the Assistant composer (e.g., `/mcp`, `/scenarios`, `/guardrails`,
@@ -428,15 +456,36 @@ ends with a factual **Local agent activity** footer whenever the run created
 or edited files or lost tool calls to permission denials, listing the touched
 paths and the denied tools with per-tool counts.
 
-An empty transcript stays focused on the larger composer instead of adding
-starter text below the chat. The run timeline and action controls stay hidden
+An empty chat teaches instead of staring back: four **starter cards** (record
+a web flow, generate a test from a recording, diagnose failed tests, upgrade
+the project) prefill the matching command with one click and disappear as
+soon as the chat has content. The run timeline and action controls stay hidden
 until the current prompt, selected tool, running, approval, completion,
 cancellation, or failure state makes them useful. Type `/` for commands, `@`
 for workflow starters, and `#` for the current file or known project
 artifacts; the dropdown filters live as you keep typing (for example `/co`
-narrows to `/codegen`), shows each command's summary, and inserts the clean
-command ready for its argument. The former "+" context button was removed in
-favor of these typed triggers.
+narrows to `/codegen`), shows each command's summary **and an example
+argument** (e.g. `/codegen recordings/intellij-capture.json`), and inserts
+the clean command ready for its argument. The former "+" context button was
+removed in favor of these typed triggers.
+
+Pasting raw Selenium/Appium Java into the composer proactively offers a
+one-click **"Selenium detected — convert to SHAFT + guardrails"** action that
+wraps the code in a convert-to-SHAFT request and runs the guardrail check on
+the converted result.
+
+After a recording stops and its review is generated, the review bar offers the
+whole Record → Review → Insert loop in one place: **Create test class** writes
+the reviewed class into `src/test/java` (never overwriting) and opens it,
+**Insert into open class** regenerates the steps anchored to the file open in
+the editor (`capture_record_at_target_code_blocks`), **Open review file**
+jumps to the generated review artifact, **Evidence pack** returns a shareable
+manifest of source/report/review artifacts with validation commands, and
+**Compare backends** generates the same recording as both WebDriver and
+Playwright SHAFT code side by side. The generation report's readiness
+findings (flaky steps, unsupported events, required inputs, fallback
+locators) also surface as file-level IDE annotations directly on the
+generated class.
 
 A single JetBrains-style command-help icon appears in the composer. Hover it to
 view the tested command families without filling the chat with command

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -40,17 +40,26 @@ support is available. First run shows a six-step setup inside the tool window:
    meta-version. Java and Maven are
    advisory: the SHAFT MCP installer bootstraps its own Java when none is
    found.
-1. **Upgrade project** is optional and independent of the steps below: copy
-   the command that upgrades the open project to the latest modular SHAFT
-   release, then use the **Open terminal** button that appears next to it to
-   run it. See the [Upgrade guide](/docs/start/upgrade) for what that command
-   does; a brand-new project has nothing to upgrade and can skip this step.
+1. **Upgrade project** runs a real check: the plugin reads the open project's
+   `pom.xml`, finds its SHAFT version, and compares it against the latest
+   released engine version. A project already on the latest release — or on a
+   newer local development build — shows **Done** immediately with nothing to
+   do. Otherwise the step explains exactly what it found (current vs. latest
+   version, or that the project has no SHAFT dependency yet), **Copy command**
+   copies the upgrade command *and opens an IntelliJ terminal with it
+   pre-typed* so you only press Enter, and **Check** re-runs the comparison
+   after the upgrade finishes. See the [Upgrade guide](/docs/start/upgrade)
+   for what that command does.
 2. **Pick agent** defaults to Codex CLI. Local Codex, Claude, and GitHub
    Copilot families are joined by **Gemini**, a cloud route configured with a
-   Google AI Studio API key instead of a local runtime.
+   Google AI Studio API key instead of a local runtime. The step shows
+   **Done** only when the selected agent is actually detected on this machine
+   (or, for Gemini, when a key is stored).
 3. **Install SHAFT MCP** copies the right installer command for the selected
-   agent and shows a short clipboard toast; an **Open terminal** button
-   appears next to it once copied, so both actions stay visible together.
+   agent and opens an IntelliJ terminal with the command pre-typed — press
+   Enter there to run it. The step shows **Done** only when an installed
+   `shaft-mcp` is really found on disk, never just because a button was
+   clicked.
 4. **Check setup** finds the installed SHAFT MCP command automatically,
    verifies the selected local agent and workspace, and additionally asks the
    selected agent CLI itself whether it can access `shaft-mcp` (for example
@@ -78,6 +87,10 @@ Setup opens with a **Connect SHAFT Assistant** summary and a simple vertical
 stepper with visible state chips, only showing the buttons relevant to the
 current step, so the path reads as
 **Prerequisites -> Upgrade project -> Pick agent -> Install SHAFT MCP -> Check setup -> Start chatting**.
+Every state chip reflects a real verification of what is on the machine or in
+the project — never a "you clicked the button" heuristic — and a check that
+ran and did not pass shows an explicit red **Failed** chip with recovery
+guidance instead of silently staying neutral.
 The whole setup flow scrolls vertically when it outgrows the tool window (the
 scrollbar appears only when needed, and content re-wraps instead of scrolling
 sideways), so the bottom of the page always stays reachable.
@@ -328,14 +341,18 @@ While a prompt runs, the submit icon becomes an animated spinner;
 hovering it changes the same square control into cancel. If you cancel, the
 request ends with a dedicated final transcript entry and no capture-generated
 output is finalized.
-A **Verbose** checkbox, shown for local CLI routes, streams the agent's
-progress into the chat as it happens instead of only showing the final
-result: extended-thinking/reasoning blocks, each tool call (with a short
+A **Verbose** checkbox, available on every route, forwards the unfiltered
+picture into the chat as it happens instead of only showing the final result.
+For local agent CLI runs that means the agent's own stream:
+extended-thinking/reasoning blocks, each tool call (with a short
 summary of its input when one is available), and each tool call's result or
-failure once it completes. Toggling Verbose mid-run is safe in either
-direction -- the transcript never ends up showing a stale in-progress bubble
-or losing an unrelated message. With Verbose off, a brief "running" bubble
-still appears while the agent works and is replaced by the final answer.
+failure once it completes. For direct SHAFT MCP tool runs (slash commands
+such as `/codegen`), Verbose echoes the exact tool request being sent and the
+raw tool response alongside the formatted answer. Toggling Verbose mid-run is
+safe in either direction -- the transcript never ends up showing a stale
+in-progress bubble or losing an unrelated message. With Verbose off, a brief
+"running" bubble still appears while the agent works and is replaced by the
+final answer.
 Local Agent mode is blocked from
 source mutation until the user explicitly approves it for that request. For
 browser-only tasks, leave `Allow source edits` off; enable it when the request
@@ -365,14 +382,31 @@ recording. These prompts help you verify the correct session and target before
 committing to capture or code generation.
 
 `/codegen` against a Capture recording generates the SHAFT test, compiles it,
-and **re-executes the recording headless** (`capture_generate_replay`), so the
+and **re-executes the recording** (`capture_generate_replay`), so the
 returned code blocks are verified against the live flow rather than only
-statically generated. When only the replay step fails, the generated and
-compiling code blocks are still returned together with the replay diagnostics,
-so a replay hiccup never turns into an empty "no code" response. Re-running
-`/codegen` regenerates the deterministic `RecordedFlowTest` output in place
-instead of failing because the class already exists. Playwright
-and mobile recordings keep their generate-only code-block tools.
+statically generated. Before the run starts, the Assistant explains the three
+phases (generate, compile, replay) and warns that a browser window may open
+for the replay (it starts on `about:blank` before the test navigates). The
+result is a step-by-step story — which file was generated where, whether it
+compiled, whether the replay passed with per-step failure diagnostics when it
+did not, the report/review artifact paths, and the generated code with
+next-step guidance — never a bare confirmation. When only the replay step
+fails, the generated and compiling code blocks are still returned together
+with the replay diagnostics, so a replay hiccup never turns into an empty "no
+code" response. Re-running `/codegen` regenerates the deterministic
+`RecordedFlowTest` output in place instead of failing because the class
+already exists. Playwright and mobile recordings keep their generate-only
+code-block tools.
+
+`/upgrade` in **Agent** mode with **Allow source edits** enabled performs the
+project upgrade itself: the agent states the project's current SHAFT setup,
+previews the change with the `shaft_project_upgrade` dry run, runs the
+official upgrader non-interactively, verifies the project still compiles
+(repairing upgrade-induced breakage with SHAFT syntax when needed), and
+reports the old and new versions plus every file it touched and why. Outside
+Agent mode — or on cloud/non-CLI routes that cannot edit local files — the
+command explains exactly how to authorize the agent-run upgrade and still
+offers the manual copy-paste command.
 
 Use `review recording` or `review recording recordings/<name>.json` to generate
 the same reviewed Capture code blocks without remembering `/codegen`.

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -36,6 +36,31 @@ flowchart TD
 | Heal | Recover eligible web locators with an explainable policy | [Heal](/docs/agentic/heal) |
 | Pilot providers | Disabled until explicitly configured and approved | [Provider controls](/docs/agentic/providers) |
 
+## Why SHAFT?
+
+Compared with plain recorder/codegen tools and raw agent-written Selenium,
+SHAFT's agentic loop differs on four load-bearing points:
+
+- **Privacy-safe recording.** Typed values are externalized to test-data
+  files, secrets are redacted at capture time, and a checked-in team policy
+  (`.shaft/recorder-policy.json`) pins recording behavior for the whole
+  repository — recordings are safe to commit and share.
+- **Compile-validated codegen.** Generated tests are compiled against SHAFT
+  and optionally replayed end-to-end before you ever see them; a replay
+  failure returns the code *plus* the failing step's diagnostics, never a
+  silent broken file.
+- **Repo-aware generation.** The Coding Partner plans against your existing
+  page objects, locator fields, and action methods before proposing new code,
+  so generation extends your suite instead of forking it.
+- **A maintenance loop, not just a generator.** Doctor triages failed runs
+  from Allure evidence and Heal recovers eligible locators with an
+  explainable policy — the same tools that created the test keep it alive.
+
+The same workflows run on every agent — Codex, Claude Code, GitHub Copilot,
+and Gemini — because they are MCP tools, not agent-specific plugins; and the
+No-AI lane (Recorder, codegen, Doctor, Healer) works with no agent or model
+credentials at all.
+
 Use the [MCP command reference](/docs/agentic/mcp#mcp-command-reference) for
 Capture and Doctor CLI examples.
 


### PR DESCRIPTION
Documents the behavior changes shipped for ShaftHQ/SHAFT_ENGINE#3426:

- Setup steps earn their badges from real checks (pom-vs-latest version comparison, agent detection, on-disk shaft-mcp detection, probe verdicts with an explicit Failed chip).
- Copy command now opens an IntelliJ terminal with the command pre-typed; the separate Open terminal buttons are gone.
- Verbose applies to every route and echoes exact MCP tool requests/responses as-is.
- /codegen narrates its generate → compile → replay phases and reports a full step-by-step story instead of bare code blocks.
- /upgrade is performed by the local agent under source-edit approval, with preview, verification, and a full change report.
- Recorder suppresses browser-synthesized phantom steps and adds an unmissable assertion-target banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)