### PR TITLE
Document the shaft-mcp tool catalog shipped with SHAFT skills

### DIFF
--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -56,6 +56,15 @@ skip them. Unattended installs, including the IntelliJ IDEA plugin target,
 install the skills by default. Use `--install-shaft-skills` to force skill
 installation or `--skip-shaft-skills` to disable it.
 
+Installing the skills also installs a generated
+[tool catalog](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/shaft-skills/references/shaft-mcp-tools.md)
+at `shaft-skills/references/shaft-mcp-tools.md`, listing every `shaft-mcp`
+tool name and a one-line description. Agents should read this cached catalog
+for exact tool names instead of listing tools at runtime, which cuts
+consumer-agent token usage. On clients that defer tool schemas until
+requested, such as Claude Code's `ToolSearch`, batch-load every tool a task
+needs in one lookup instead of one call per tool.
+
 The resulting local stdio process lets SHAFT launch the browser on your desktop
 so you can see and interact with the automation session. Do not use the Docker
 image for interactive local browser work: its browser runs inside the container


### PR DESCRIPTION
## Summary
- Installing `shaft-skills/` also installs a generated tool catalog (`shaft-skills/references/shaft-mcp-tools.md`, shipped in [ShaftHQ/SHAFT_ENGINE#3435](https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3435)); document it right next to the existing shaft-skills install paragraph in the shaft-mcp guide.
- Point agents at the cached catalog for exact tool names instead of listing tools at runtime, and call out batch-loading schemas on clients that defer them (e.g. Claude Code's `ToolSearch`).

Closes [ShaftHQ/SHAFT_ENGINE#3436](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3436).

## Test plan
- [x] `npm run test:docs` (docs-loader, docs-quality, duplicate-block checks) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)