### PR TITLE
Document storage-state reuse, SHAFT.Auth, HAR replay, and new MCP tools

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -50,10 +50,11 @@ geolocation, timezone, and service-worker bypass use browser protocol support;
 storage state uses SHAFT's browser storage-state JSON; and HAR output uses the
 same redacted observability entries as SHAFT failure traces. Unsupported
 drivers or unmapped device names produce deterministic warnings instead of raw
-protocol failures. `--save-har-glob` is accepted with a warning; Capture writes
-all observed network entries. Use `capture features` to list the current
-Playwright codegen feature map. `--session-goal` stores the recorder intent in
-session extensions so generated Java can include a safe review comment.
+protocol failures. `--save-har-glob` filters the saved HAR to URLs matching the
+glob and reports how many observed network entries were kept versus dropped.
+Use `capture features` to list the current Playwright codegen feature map.
+`--session-goal` stores the recorder intent in session extensions so generated
+Java can include a safe review comment.
 
 ```bash
 capture start \
@@ -70,7 +71,16 @@ capture start \
 The same lifecycle is exposed by the `capture_start`, `capture_start_codegen`,
 `capture_status`, and `capture_stop` MCP tools. Both start tools accept an
 optional `sessionGoal` describing the recorded journey; it names the generated
-test class and method. Generation is exposed by
+test class and method. Both start tools also accept an optional
+`saveHarContent` option: leaving it blank or `none` keeps today's truncated
+network-trace preview bodies, while `full` emits complete, redacted
+request/response bodies (headers redacted, binary content base64-encoded) for
+every transaction recorded during the session, sourced from the API-capture
+network events rather than the preview trace. `full` falls back to preview
+bodies with a warning when no such transactions were recorded, for example
+when `apiCapture` was not enabled for that session. This option is MCP-only;
+the local `capture start` CLI does not expose a `--save-har-content` flag.
+Generation is exposed by
 `capture_generate`; `capture_codegen_features` returns the feature map.
 `shaft_coding_partner_plan`, `capture_target_candidates`,
 `capture_backend_comparison`, and `capture_evidence_pack` cover repository-aware

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -290,10 +290,14 @@ builder calls such as `driver.assertThat().browser()...` or
 
 ### Delegate browser exploration to Playwright
 
-When a task needs token-efficient snapshots, storage state, network inspection,
-console output, tracing, video, PDF, or official Playwright Test Agent planning,
-let the local agent use official Playwright CLI or Playwright MCP as a sidecar.
-The final Java change still returns through SHAFT planning and guardrails.
+When a task needs token-efficient snapshots, console output, tracing, video,
+PDF, or official Playwright Test Agent planning, let the local agent use
+official Playwright CLI or Playwright MCP as a sidecar. The final Java change
+still returns through SHAFT planning and guardrails. Storage-state save/load
+and observed-network inspection no longer need a sidecar for the common case:
+use `browser_storage_state_save`/`browser_storage_state_load` (or the
+`playwright_*` equivalents) and `browser_network_requests`/
+`browser_network_request` directly.
 
 ```mermaid
 flowchart LR

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -237,8 +237,9 @@ flowchart LR
 |---|---|
 | MCP accessibility snapshots and browser actions | `browser_get_page_dom`, `browser_open_intent`, `browser_aria_snapshot` (whole-page or single-element YAML aria snapshot), `browser_accessibility_audit` (non-asserting axe-core WCAG audit), `playwright_browser_get_page_dom`, `element_*`, `playwright_element_*`, and semantic click/type tools. |
 | Screenshots, navigation, tabs, uploads, drag, hover, and form input | WebDriver and Playwright MCP tool families plus Capture action recording and replay. |
-| Codegen options for test id, viewport, device, color scheme, geolocation, language, timezone, storage state, proxy, HAR, user agent, and user data directory | `capture_start_codegen`, `capture_codegen_features`, `capture_code_blocks`, and `capture generate --backend playwright`. |
-| Playwright CLI network, storage, console, trace, video, PDF, and named-session commands | Use official `playwright-cli` as delegated evidence gathering; attach paths or summaries to `shaft_coding_partner_plan`, Doctor, Capture, or the final PR evidence. |
+| Codegen options for test id, viewport, device, color scheme, geolocation, language, timezone, storage state, proxy, HAR, user agent, and user data directory | `capture_start_codegen`, `capture_codegen_features`, `capture_code_blocks`, and `capture generate --backend playwright`. `capture_start`/`capture_start_codegen` also accept `saveHarGlob` (URL glob filter) and `saveHarContent=full` (complete redacted request/response bodies instead of truncated previews). |
+| Storage-state save/load, network request inspection, and mock routes | `browser_storage_state_save`/`browser_storage_state_load` and `playwright_browser_storage_state_save`/`playwright_browser_storage_state_load` (interchangeable JSON between backends); `browser_network_requests`/`browser_network_request` for observed traffic; `browser_route`/`browser_unroute` for mock responses. |
+| Playwright CLI console, trace, video, PDF, and named-session commands | Use official `playwright-cli` as delegated evidence gathering; attach paths or summaries to `shaft_coding_partner_plan`, Doctor, Capture, or the final PR evidence. |
 | Playwright Test Agents planner/generator/healer | Use `npx playwright init-agents --loop=codex` for Playwright Test projects; for SHAFT Java projects, map the planner output into `test_automation_scenarios`, Capture, Doctor, Heal, and reviewed Java source edits. |
 
 Do not paste Playwright TypeScript generated tests into a Java Maven project.
@@ -445,6 +446,15 @@ The packaged server supports:
 - explicit browser element actions through `element_click` and `element_type`,
   using locator strategy and locator value arguments, plus semantic
   WebDriver/Playwright click and type tools for human-readable element names;
+- storage-state save/load through `browser_storage_state_save`/
+  `browser_storage_state_load` and `playwright_browser_storage_state_save`/
+  `playwright_browser_storage_state_load`, writing and reading the same JSON
+  schema so a file saved from one backend loads on the other;
+- observed network transaction listing and detail through
+  `browser_network_requests` and `browser_network_request` (method, URL,
+  status, sizes, and a truncated redacted body preview; full bodies require a
+  Capture session with `saveHarContent=full`), plus mock network routes
+  through `browser_route` and `browser_unroute`;
 - official guide search through `shaft_guide_search`, so agents can retrieve
   cited SHAFT best practices, API/GUI/CLI examples, locators, Page Object Model
   guidance, and troubleshooting steps before writing code;

--- a/docs/reference/actions/GUI/Browser_Actions.md
+++ b/docs/reference/actions/GUI/Browser_Actions.md
@@ -218,7 +218,9 @@ driver.browser().deleteAllCookies();
 
 Use storage state when a test needs to reuse an authenticated browser session
 without repeating the login flow. SHAFT saves cookies, `localStorage`, and
-`sessionStorage` to a JSON file.
+`sessionStorage` to a JSON file. `saveStorageState()`/`loadStorageState()` are
+implemented identically on `SHAFT.GUI.WebDriver` and `SHAFT.GUI.Playwright`, so
+a file saved from one backend loads on the other.
 
 ```java title="SaveStorageState.java"
 driver.browser()
@@ -235,6 +237,25 @@ driver.browser()
         .and().loadStorageState("target/auth-state.json")
         .and().refreshCurrentPage();
 ```
+
+### Auto-load storage state on driver init
+
+Set `SHAFT.Properties.web.storageStatePath` (property key `storageStatePath`)
+to a storage-state JSON file and a freshly-initialized driver loads it
+automatically, without an explicit `loadStorageState()` call:
+
+```java title="AutoLoadStorageState.java"
+SHAFT.Properties.web.set().storageStatePath("target/auth-state.json");
+SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver();
+```
+
+SHAFT reads the `origin` recorded inside the storage-state file (falling back
+to `SHAFT.Properties.web.baseURL()` when the file has none) and navigates the
+fresh driver there first, since cookies cannot be added for an arbitrary
+domain before any page has loaded. This is fail-soft: a missing file, unreadable
+origin, or any other load failure is logged as a warning and never fails driver
+initialization. See [Authentication and session reuse](/docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests)
+for the cached-login helper built on top of this property.
 
 ## Screenshots and Snapshots
 
@@ -437,4 +458,6 @@ SHAFT provides automatic reporting for every browser action. Check the **Reporti
 
 - [Element Actions](/docs/reference/actions/GUI/Element_Actions)
 - [Element Identification](/docs/reference/actions/GUI/Element_Identification)
+- [Using Cookies / authentication and session reuse](/docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests)
+- [Network Mocking and HAR replay](/docs/reference/actions/GUI/didYouKnow/Network_Mocking)
 - [Web](/docs/testing/web)

--- a/docs/reference/actions/GUI/Playwright_Backend.md
+++ b/docs/reference/actions/GUI/Playwright_Backend.md
@@ -48,6 +48,7 @@ Common browser settings continue to use the existing web properties:
 - `baseURL`
 - `browserWindowWidth`
 - `browserWindowHeight`
+- `storageStatePath` — auto-loads a storage-state JSON file on driver init (see [Auto-load storage state on driver init](/docs/reference/actions/GUI/Browser_Actions#auto-load-storage-state-on-driver-init)); the file format is shared with the WebDriver backend
 - mobile emulation viewport and user-agent settings
 
 Playwright-specific properties use the `playwright.` prefix:
@@ -205,11 +206,13 @@ Legend:
 | `getWindowSize()` / `getWindowWidth()` / `getWindowHeight()` | Supported from viewport |
 | `addCookie()` / `getCookie()` / `getAllCookies()` / cookie getters | Supported through `BrowserContext.cookies()` |
 | `deleteCookie()` / `deleteAllCookies()` | Supported |
+| `saveStorageState(path)` / `loadStorageState(path)` | Supported; same JSON schema as WebDriver, files are interchangeable between backends |
 | `captureScreenshot()` / `captureScreenshot(type)` | Supported; attached to SHAFT report |
 | `capturePageSnapshot()` / `captureSnapshot()` | Supported as HTML attachment |
 | `waitForLazyLoading()` | Supported through Playwright load state |
 | `getContext()` / `setContext()` / `getContextHandles()` | Supported for the Playwright page context |
 | `mock()` / `intercept()` / `interceptRequest()` / `clearNetworkInterceptors()` / contract recording and replay | Supported through Playwright `BrowserContext` routing while preserving SHAFT's Selenium HTTP request/response contract |
+| `routeFromHar(harPath)` | Supported; same HAR 1.2 replay behavior as WebDriver |
 | `generateLightHouseReport()` | WebDriver-only |
 | `accessibility()` | Supported through bundled axe-core injection into the active Playwright page |
 

--- a/docs/reference/actions/GUI/didYouKnow/Network_Mocking.md
+++ b/docs/reference/actions/GUI/didYouKnow/Network_Mocking.md
@@ -94,6 +94,25 @@ first mismatch. See [UI and API contract replay](/docs/testing/contracts).
 
 ---
 
+## Replay a Recorded HAR
+
+Use `routeFromHar()` to replay a previously captured HAR 1.2 file as mocked
+responses, instead of building matchers by hand. It works the same way on both
+`SHAFT.GUI.WebDriver` and `SHAFT.GUI.Playwright`. Matching is exact on method
+and URL; when the HAR contains duplicate entries for the same method/URL, they
+are replayed in the order they were recorded.
+
+```java title="RouteFromHar.java"
+driver.browser().routeFromHar("src/test/resources/har/checkout.har");
+driver.browser().navigateToURL("https://shop.example/checkout");
+```
+
+A compatible HAR file can come from a [Capture](/docs/agentic/capture) session
+started with `--save-har` (local CLI) or `saveHarPath` (`capture_start`/
+`capture_start_codegen` MCP tools), or from any HAR 1.2 export.
+
+---
+
 ## Request Matchers
 
 Use the built-in matchers for common request fields:

--- a/docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md
+++ b/docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md
@@ -2,8 +2,8 @@
 id: Using_Cookies_In_Your_Tests
 title: Using Cookies in Your Tests
 sidebar_label: Using Cookies
-description: "Manage browser cookies in SHAFT tests — add, read, delete cookies and use them for authentication and session management."
-keywords: [SHAFT, cookies, browser cookies, session management, authentication cookies, cookie manipulation]
+description: "Manage browser cookies in SHAFT tests — add, read, delete cookies, reuse storage state across browser and API sessions, and cache logins with SHAFT.Auth."
+keywords: [SHAFT, cookies, browser cookies, session management, authentication cookies, cookie manipulation, storage state, SHAFT.Auth]
 tags: [web, cookies, authentication]
 ---
 
@@ -36,6 +36,32 @@ SHAFT.API api = new SHAFT.API("https://api.example.com");
 api.importCookiesFrom(driver.browser());
 api.get("/account");
 ```
+
+#### API session seeded from a saved storage-state file
+
+`SHAFT.API` also accepts a storage-state JSON path directly in its constructor — the same file produced by `driver.browser().saveStorageState(path)` on either `SHAFT.GUI.WebDriver` or `SHAFT.GUI.Playwright`:
+
+```java
+SHAFT.API api = new SHAFT.API("https://api.example.com", "target/auth-state.json");
+api.get("/account");
+```
+
+#### API session cookies back into the browser
+
+Use `exportCookiesTo(...)` to mirror `importCookiesFrom(...)` in the other direction, copying cookies from an `SHAFT.API` session into a browser session:
+
+```java
+SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver();
+driver.browser().navigateToURL("https://app.example.com");
+
+SHAFT.API api = new SHAFT.API("https://api.example.com");
+api.post("/auth/login").setRequestBody(credentials).setContentType(ContentType.JSON);
+api.exportCookiesTo(driver.browser());
+
+driver.browser().refreshCurrentPage();
+```
+
+Like `importCookiesFrom`, `exportCookiesTo(browserActions, domainFilter, pathFilter)` accepts optional exact domain and path filters to export only matching cookies.
 
 #### Manual cookie reuse
 ```java
@@ -72,6 +98,32 @@ public class CookieExample {
     }
 }
 ```
+
+## Cached Authentication with SHAFT.Auth
+
+`SHAFT.Auth.setup(name, flow)` is a Playwright-style cached-authentication helper: it runs a login `flow` once per `name` and caches the resulting browser storage state to disk, so later calls — including from other tests, classes, or threads — reuse the cached session instead of repeating the UI login.
+
+```java title="AuthSetup.java"
+import com.shaft.driver.SHAFT;
+import org.openqa.selenium.By;
+
+// Once per suite, e.g. in a @BeforeSuite:
+SHAFT.Auth.setup("standardUser", driver -> {
+    driver.browser().navigateToURL("https://example.com/login");
+    driver.element().type(By.id("username"), "standard_user");
+    driver.element().type(By.id("password"), "secret_sauce");
+    driver.element().click(By.id("login-button"));
+});
+
+// In every test, reuse the cached session instead of logging in again:
+SHAFT.Properties.web.set().storageStatePath(SHAFT.Auth.stateFile("standardUser"));
+SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver();
+```
+
+- The cache file is written in the same JSON schema as `saveStorageState(path)`, stored under `SHAFT.Properties.paths.authCache()` (default `target/auth-cache/`), one file per `name`.
+- **Staleness policy** is deliberately simple: the cache is valid as long as the file exists, with no TTL/max-age check. Call `SHAFT.Auth.stateFile(name)` to get the cache path and delete that file to force a re-login on the next `setup()` call.
+- **Thread-safety:** concurrent `setup()` calls for the *same* `name` are serialized on a per-name lock — only the first caller runs `flow`; every other concurrent caller blocks until it finishes, then reuses the now-cached file. Calls for different names never block each other.
+- Feed `SHAFT.Auth.stateFile(name)` to `SHAFT.Properties.web.set().storageStatePath(...)` (auto-loaded on the next driver init — see [Auto-load storage state on driver init](/docs/reference/actions/GUI/Browser_Actions#auto-load-storage-state-on-driver-init)) or directly to `driver.browser().loadStorageState(...)`.
 
 ## Related
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -115,6 +115,7 @@ You can use these tab groups to navigate and get information about how to manage
   String baseURL = SHAFT.Properties.web.baseURL();
   int browserWindowWidth = SHAFT.Properties.web.browserWindowWidth();
   int browserWindowHeight = SHAFT.Properties.web.browserWindowHeight();
+  String storageStatePath = SHAFT.Properties.web.storageStatePath();
 
   /** set **/
   SHAFT.Properties.web.set().targetBrowserName(Browser.CHROME.browserName())
@@ -130,7 +131,8 @@ You can use these tab groups to navigate and get information about how to manage
     .mobileEmulationUserAgent("")
     .baseURL("")
     .browserWindowWidth(1920)
-    .browserWindowHeight(1080);
+    .browserWindowHeight(1080)
+    .storageStatePath("");
 
   ```
 
@@ -161,6 +163,7 @@ You can use these tab groups to navigate and get information about how to manage
   browserWindowHeight=1080
   pageLoadStrategy=none
   readinessState=none
+  storageStatePath=
   ```
   
   </TabItem>
@@ -184,6 +187,7 @@ You can use these tab groups to navigate and get information about how to manage
 | browserWindowHeight            | `1080`        |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | • Won't work if autoMaximizeBrowserWindow is enabled.
 | pageLoadStrategy               | `none`        | `none`, `eager`, `normal`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | • Controls when Selenium considers the page loaded.
 | readinessState                 | `none`        | `interactive`, `none`, `complete`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | • Controls the document readiness state to wait for.
+| storageStatePath               | ` `           | example: `target/auth-state.json`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | • Path to a storage-state JSON file automatically loaded into a freshly-initialized driver.<br/>• SHAFT navigates to the file's recorded origin (falling back to `baseURL`) first; a load failure is logged as a warning and never fails driver init.<br/>• Blank (default) disables the feature.
 
   </TabItem>
 </Tabs>
@@ -1065,6 +1069,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | PerformanceReportFolderPath      | `performanceReport/`                          |                 | Path to the performance (Lighthouse) report output folder.               |
 | video.folder                     | `allure-results/videos`                       |                 | Path to the folder where recorded videos and generated animated GIF files are saved. |
 | servicesFolderPath               | `src/test/resources/META-INF/services/`       |                 | Path to the META-INF services folder for custom service implementations. |
+| authCacheFolderPath              | `target/auth-cache/`                          |                 | Folder that holds `SHAFT.Auth.setup(name, flow)` storage-state cache files (one JSON file per name). |
 | aiAgentWorkspaceRoot             | ``                                            |                 | Workspace root for SHAFT agent tooling.                                |
 | applitoolsApiKey                 | ``                                            |                 | Applitools API key for visual AI testing integration.                    |
 


### PR DESCRIPTION
## Summary

Closes the documentation gap left by ShaftHQ/SHAFT_ENGINE#3350, which shipped four user-facing features across PRs ShaftHQ/SHAFT_ENGINE#3458, ShaftHQ/SHAFT_ENGINE#3459, ShaftHQ/SHAFT_ENGINE#3461, and ShaftHQ/SHAFT_ENGINE#3462:

- **Storage-state reuse**: `driver.browser().saveStorageState(path)`/`loadStorageState(path)` now work identically on both `SHAFT.GUI.WebDriver` and `SHAFT.GUI.Playwright` (interchangeable JSON); the new `web.storageStatePath` property auto-loads a storage-state file on driver init (navigates to the file's recorded origin, falling back to `baseURL`, fail-soft on error); `SHAFT.API` interop gained a `new SHAFT.API(serviceURI, storageStatePath)` constructor and `API.exportCookiesTo(browserActions[, domainFilter, pathFilter])` mirroring the existing `importCookiesFrom`.
- **`SHAFT.Auth.setup(name, flow)`**: a Playwright-style cached-authentication helper that runs a login flow once per name, caches the storage state under `SHAFT.Properties.paths.authCache()` (default `target/auth-cache/`), and reuses it on later calls; `SHAFT.Auth.stateFile(name)` returns the cache path, and per-name locking keeps it thread-safe.
- **HAR record/replay**: Capture's `saveHarGlob` URL filtering is now implemented (previously stubbed with a warning); the new `saveHarContent=full` MCP option opts into complete redacted request/response bodies; `driver.browser().routeFromHar(harPath)` replays a HAR's responses as mocks on both backends.
- **New MCP tools**: `browser_storage_state_save`/`load`, `playwright_browser_storage_state_save`/`load`, `browser_network_requests`, `browser_network_request`, `browser_route`, `browser_unroute`, plus `capture_start`/`capture_start_codegen` accepting `saveHarContent`.

## Pages changed

- `docs/reference/actions/GUI/Browser_Actions.md` — storage-state cross-backend note + new "Auto-load storage state on driver init" subsection for `web.storageStatePath`.
- `docs/reference/actions/GUI/Playwright_Backend.md` — mapping-tree rows for `saveStorageState`/`loadStorageState`/`routeFromHar`, plus `storageStatePath` in the configuration list.
- `docs/reference/actions/GUI/didYouKnow/Using_Cookies_In_Your_Tests.md` — `SHAFT.API(serviceURI, storageStatePath)` constructor, `exportCookiesTo(...)`, and a new "Cached Authentication with SHAFT.Auth" section.
- `docs/reference/actions/GUI/didYouKnow/Network_Mocking.md` — new "Replay a Recorded HAR" section for `routeFromHar()`.
- `docs/reference/properties/PropertiesList.mdx` — `web.storageStatePath` (code/CLI/file/defaults) and `authCacheFolderPath` (Paths defaults).
- `docs/agentic/capture.md` — `--save-har-glob` now documented as real filtering (not a stub warning); `saveHarContent` MCP-only option documented.
- `docs/agentic/mcp.mdx` — Playwright coverage table updated with the storage/network/route tools and `saveHarContent`; new tools added to the transport capability bullet list.
- `docs/agentic/intellij.md` — "Delegate browser exploration to Playwright" note updated: storage-state and network inspection no longer need a Playwright sidecar for the common case.

No new page was needed — everything extended cleanly into existing docs.

## Test plan

- [x] `npm run build` completes successfully (pre-existing blog-truncation warnings only, unrelated to this change).
- [x] Spot-checked new cross-reference links (`Browser_Actions#auto-load-storage-state-on-driver-init`, `Using_Cookies_In_Your_Tests`, `Network_Mocking`) resolve during the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)