### PR TITLE
Document test_plan_explore and shaft_project_init_agents

### DIFF
--- a/docs/agentic/cli.md
+++ b/docs/agentic/cli.md
@@ -98,6 +98,9 @@ shaft-cli call shaft_guide_search query='click element' maxResults=1
 
 shaft-cli guide search query='click element' --stdio-ok
 # [guide search works with no session]
+
+shaft-cli call test_plan_explore targetUrl=https://example.test goal='checkout happy path' maxDepth=2
+# [Markdown test plans written to specs/]
 ```
 
 ## Exit codes

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -177,6 +177,55 @@ Use `shaft_project_upgrade` on an existing Java/Maven project to run the
 modular SHAFT upgrader script. Start with `dryRun: true`; applying changes
 requires `dryRun: false` and `approve: true`.
 
+Use `shaft_project_init_agents` to scaffold SHAFT agent/skill bridges into an
+existing test repository for a coding-agent loop. Pass `loop: "claude"` to
+generate a `.claude/skills/<skill>/SKILL.md` bridge file for every bundled
+SHAFT skill plus a root `SHAFT-AGENTS.md` guidance file, or `loop: "codex"`
+for the same layout under `.codex/skills/`. Every bridge is generated at call
+time from the bundled `shaft-skills/<skill>/SKILL.md` sources shipped inside
+the `shaft-mcp` jar, so the generated set always tracks the shaft-mcp build
+instead of a hand-duplicated copy. Existing files are left untouched unless
+`overwrite: true`; a skipped file is reported as a warning instead of failing
+the call, since `targetDirectory` is expected to be an existing repository
+that may already carry its own agent configuration. `vscode` and `opencode`
+loops are tracked in
+[ShaftHQ/SHAFT_ENGINE#3463](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3463).
+
+```json
+{"tool": "shaft_project_init_agents", "arguments": {"loop": "claude", "targetDirectory": ".", "overwrite": false}}
+```
+
+## Planning test coverage
+
+Use `test_plan_explore` to discover testable flows before recording or
+writing test code. It breadth-first crawls same-origin pages from an active
+SHAFT browser session starting at `targetUrl` (`maxDepth` clamped to 1..3,
+`maxPages` clamped to 1..50, default 10), inspects forms, primary navigation
+actions, and links with no AI calls, then writes one deterministic Markdown
+test plan per discovered flow into `specs/` inside the MCP workspace. Each
+plan lists numbered steps, candidate SHAFT locators ranked by the same
+pipeline `browser_open_intent` uses, seed data, and a verify section. An
+optional `goal` only orders the written plans by relevance and is never sent
+to a model provider.
+
+```json
+{"tool": "test_plan_explore", "arguments": {"targetUrl": "https://example.test", "goal": "checkout happy path", "maxDepth": 2, "maxPages": 10}}
+```
+
+Or from the command line once a `shaft-cli` session is running:
+
+```bash
+shaft-cli call test_plan_explore targetUrl=https://example.test goal="checkout happy path" maxDepth=2
+```
+
+`test_plan_explore` needs an active session started with `driver_initialize`.
+Review the generated `specs/` files with the user before recording or
+generating code — the `planning-shaft-tests` skill documents the full
+explore, review, codegen, and verify chain (`capture_start_codegen` for UI
+flows, `capture_api_start`/`capture_api_generate` for API flows, or
+`shaft_coding_partner_plan`/`shaft_coding_partner_diff` to insert into an
+existing repository), finishing with a scoped `verify_run_focused` run.
+
 ## Test automation scenario catalog
 
 Use `test_automation_scenarios` when the user asks an agent to create,
@@ -461,6 +510,10 @@ The packaged server supports:
 - structured test automation playbooks through `test_automation_scenarios`,
   repository-aware coding partner plans through `shaft_coding_partner_plan`,
   plus generated-code guardrail checks through `test_code_guardrails_check`;
+- deterministic, no-AI-call test planning through `test_plan_explore`, which
+  crawls the active session and drafts Markdown flow plans into `specs/`, and
+  agent/skill scaffolding for existing test repositories through
+  `shaft_project_init_agents`;
 - mobile web emulation and native Android/iOS execution through
   `mobile_initialize_web_emulation` and `mobile_initialize_native`;
   web-emulation results include a `deviceProfile` object with resolved

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -31,6 +31,7 @@ flowchart TD
 |---|---|---|
 | IntelliJ plugin | IDE front door for Assistant, Coding Partner, Recorder, Doctor, Healer, Inspector, Projects, and Guide search | [IntelliJ IDEA plugin](/docs/agentic/intellij) |
 | MCP | Local stdio tools; no model credentials stored | [Connect MCP](/docs/agentic/mcp) |
+| Planning | Deterministic same-origin crawl drafts Markdown test plans into `specs/`; no AI calls | [Planning test coverage](/docs/agentic/mcp#planning-test-coverage) |
 | Capture | Record and generate deterministic test code | [Capture](/docs/agentic/capture) |
 | Doctor | Analyze allowlisted evidence offline | [Doctor](/docs/agentic/doctor) |
 | Heal | Recover eligible web locators with an explainable policy | [Heal](/docs/agentic/heal) |


### PR DESCRIPTION
## Summary
- Document the `test_plan_explore` MCP tool (deterministic, no-AI-call, same-origin crawl that drafts Markdown test plans into `specs/`) and `shaft_project_init_agents` (scaffolds SHAFT agent/skill bridges plus `SHAFT-AGENTS.md` into a user's test repo) in `docs/agentic/mcp.mdx`, alongside the existing MCP tool coverage.
- Add a `shaft-cli call test_plan_explore ...` example to `docs/agentic/cli.md`.
- Add a "Planning" row to the capability table in `docs/agentic/overview.mdx`, linking to the new `mcp.mdx#planning-test-coverage` section so the new tools and the `planning-shaft-tests` skill (whose `SKILL.md` links to the overview page) are discoverable from the agentic entry point.

Refs ShaftHQ/SHAFT_ENGINE#3351, ShaftHQ/SHAFT_ENGINE#3464

## Test plan
- [x] `npm run build` completes successfully (only pre-existing blog-truncation warnings, no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)