### PR TITLE
docs: document IntelliJ Pick Locator, Heal action, and Visual Baselines panel

### DIFF
--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -200,7 +200,8 @@ recording must never belong to a one-shot local agent turn, whose MCP process
 Enabling **Settings | SHAFT | Enable advanced workflows and provider options**
 (Expert mode, also available as a checkbox on the setup view) reveals the
 **Workflow** selector with every specialist surface: **Guided**, **Recorder**,
-**Inspector**, **Triage**, **Evidence**, **Projects**, and **Advanced**. These
+**Inspector**, **Triage**, **Visual Baselines**, **Evidence**, **Projects**, and
+**Advanced**. These
 panels expose raw MCP requests and are aimed at users who already know the tool
 catalog; everything they do is reachable through plain Assistant requests. The
 Guided tab's **Try SHAFT on a sample page** button extracts a bundled local
@@ -573,6 +574,11 @@ The workflow selector exposes curated MCP requests for common automation jobs:
 - Inspector: browser and Playwright DOM snapshots, screenshots, mobile
   toolchain status, wrapped Appium Inspector recording, mobile screenshots, and
   accessibility trees.
+- Visual Baselines: scans the visual-baseline folder for pending `*_diff.png`
+  comparisons left by mismatched `matchesScreenshot()` runs, shows the
+  baseline and diff side by side, and lets you **Accept** (removes the stale
+  baseline so the next run records a fresh one) or **Reject** (clears the diff
+  marker, keeping the current baseline) each pending comparison.
 - Evidence: failed Allure analysis, trace discovery, trace analysis, trace
   summarization, report remediation, guarded reruns, and review-only locator
   proposals.
@@ -605,8 +611,9 @@ The workflow selector exposes curated MCP requests for common automation jobs:
   control-flow review output. Templates prefill MCP arguments only; apart from
   the chained mobile recorder start, they do not run tools or write source by
   themselves. When a test run fails and Allure evidence exists, the plugin
-  raises a "Diagnose with SHAFT Doctor" notification that prefills the
-  deterministic failed-Allure analysis in one click.
+  raises a notification with **Diagnose with SHAFT Doctor** and **Heal failed
+  test** actions, prefilling the deterministic failed-Allure analysis or a
+  `healer_run_failed_test` run (AI flags off by default) in one click.
 - Advanced Tools: WebDriver, Playwright, and mobile playback flows, scenario
   catalog prompts, generated-code guardrail checks, local Assistant client
   discovery, recorder evidence manifests, backend comparison, and official
@@ -615,6 +622,10 @@ The workflow selector exposes curated MCP requests for common automation jobs:
 Each category provides editable JSON arguments and calls the matching MCP tool.
 This keeps generated code and source edits reviewable in the IDE instead of
 hidden inside plugin code.
+
+A test-explorer tree, run-gutter icons, and watch-mode auto-run are not part
+of the plugin yet; that remaining scope is tracked in
+[ShaftHQ/SHAFT_ENGINE#3467](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3467).
 
 ![SHAFT IntelliJ Guided workflow templates](/img/agentic/intellij-plugin-guided.png)
 
@@ -635,6 +646,19 @@ The generated MCP response includes focused locator/action blocks plus a
 preview-only patch block; apply changes only after reviewing that preview and
 running the relevant verification command.
 This action is available only in IDE installations with Java support enabled.
+
+## Pick Locator at caret
+
+Use **Tools | SHAFT | Pick Locator from Live Session** (also on the editor
+popup menu, visible in SHAFT projects with a Java editor context) to call
+`capture_pick_locator` and insert the returned `SHAFT.GUI.Locator...` snippet
+at the caret — the same idea as Playwright's "Pick Locator". Start a SHAFT
+Capture session first and switch the recorder to inspect mode, then click the
+target element in the managed browser; the action warns instead of inserting
+anything when no pick is available yet. This v1 requires the recorder-side
+pick to already exist in the live session; full session pick-state plumbing is
+tracked in
+[ShaftHQ/SHAFT_ENGINE#3467](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3467).
 
 ## Coding partner plan
 
@@ -680,7 +704,8 @@ four sections:
 When you enable **Settings | SHAFT | Enable advanced workflows and provider
 options**, the Expert-mode toggle activates on the post-setup settings screen.
 Expert mode reveals the specialist workflow views (**Guided**, **Recorder**,
-**Inspector**, **Triage**, **Evidence**, **Projects**, **Advanced**) and the
+**Inspector**, **Triage**, **Visual Baselines**, **Evidence**, **Projects**,
+**Advanced**) and the
 ad-hoc provider/route controls in the Assistant composer. Regular users never
 need it: every workflow is reachable by describing the outcome in the
 Assistant.

--- a/docs/reference/actions/GUI/didYouKnow/Visual_Testing.md
+++ b/docs/reference/actions/GUI/didYouKnow/Visual_Testing.md
@@ -135,6 +135,8 @@ Baselines are stored per browser and platform, with a sanitized `_<browser>_<pla
 
 If no per-browser/OS baseline exists yet, SHAFT falls back to a legacy unsuffixed baseline when one is present, logging a one-line notice, so baselines captured before this change keep working. New baselines — and any run with `-Dshaft.updateSnapshots=true` — always write to the new per-browser/OS path.
 
+The IntelliJ plugin's **Visual Baselines** panel lists pending `*_diff.png` comparisons and lets you Accept or Reject each one without leaving the IDE — see the [IntelliJ IDEA plugin](/docs/agentic/intellij) guide.
+
 ## Related
 
 - [Did You Know](/docs/reference/actions/GUI/Did_You_Know)


### PR DESCRIPTION
## Summary
- Documents three IntelliJ plugin surfaces added by ShaftHQ/SHAFT_ENGINE#3468: **Pick Locator at caret** (`capture_pick_locator` editor action), the one-click **Heal failed test** notification action alongside the existing SHAFT Doctor action, and the new **Visual Baselines** tool-window panel for triaging `matchesScreenshot()` diffs.
- Adds a one-line pointer from the Visual Testing guide's baseline section to the new IDE panel.
- Notes that remaining test-explorer/gutter/watch scope is tracked in ShaftHQ/SHAFT_ENGINE#3467.

References ShaftHQ/SHAFT_ENGINE#3348, ShaftHQ/SHAFT_ENGINE#3453, ShaftHQ/SHAFT_ENGINE#3468.

## Test plan
- [x] `npm run build` completes successfully (only pre-existing blog-truncation warnings, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)