### PR TITLE
docs: Capture overlay P1 ergonomics — drag, step badges, undo delete, help sheet

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -138,6 +138,16 @@ The status line shows a pill stack at the top of the overlay:
 
 Below the pills, readiness warnings appear on their own line when present. When a navigation occurs within ~10 seconds after a recorded step, it is treated as a consequence of that step and not recorded separately; a brief "Ignored: navigation caused by your last step, kept as part of that step." note appears instead.
 
+### Overlay ergonomics
+
+The recorder overlay supports practical interactions:
+
+- **Dragging and position memory** — Drag the overlay by its header to reposition it on the page. The position is clamped to the viewport boundaries and remembered for the duration of the page session. The default position is bottom-right.
+- **Step kind badges** — Each step row displays a badge indicating the action type: Click, Type, Select, Toggle, Upload, Keys, Navigate, Assert, or Pin. When a step carries a readiness warning, the badge is colored amber for visibility.
+- **Soft-delete with undo** — Deleting a step from the list is a soft delete with a 5-second undo window. A "Step deleted. Undo" notification appears; click Undo within the window to restore the step. The deletion is only persisted after the window elapses.
+- **Help sheet** — Click the "?" button in the overlay header to toggle a help sheet listing all recorder controls, including how to drag the overlay, press Esc to cancel assert or pick mode, and access undo.
+- **IntelliJ status alignment** — The IntelliJ Guided panel's live status mirror the overlay wording: "Recording · N steps · Ready · <url>. Stop here or in the browser overlay - both save the session." This makes it clear that stopping from either location (browser or IDE panel) saves the same recording.
+
 ### Stopping a recording
 
 Pressing stop from the panel opens a confirmation inside the overlay before the session stops. The confirmation displays "Session saved to: <path>" (sourced via loopback /session endpoint, best-effort) and prompts next actions — open the SHAFT Assistant in the IDE and use "Review code". Buttons: "Save & close" (stops the session and the browser closes) and "Keep recording" (dismisses the confirmation). Programmatic stops via MCP `capture_stop` are unchanged and close immediately without confirmation.

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -639,10 +639,11 @@ The workflow selector exposes curated MCP requests for common automation jobs:
   also honored by the assistant web and mobile recording flows. The
   **Intent** field flows into `capture_start` as `sessionGoal`, so generated
   tests are named after the journey ("Log in as a valid user" yields
-  `logInAsAValidUser()`). A live **Status** strip polls the recorder after
-  Start recording and shows the session state, steps count (including
-  pending debounced input), and current URL, so headless recordings stay
-  observable in-panel. On the Mobile backend, Start recording chains
+  `logInAsAValidUser()`). A live **Status** strip shows "Recording · N steps · Ready · <url>",
+  allowing you to monitor session state, steps count (including pending debounced input),
+  and current URL in the IDE panel; stopping from here or in the browser overlay
+  saves the same recording session, so headless recordings stay observable and controllable
+  in-panel. On the Mobile backend, Start recording chains
   `mobile_initialize_web_emulation` and `mobile_record_start` as one action,
   gating the recorder start on the emulated session succeeding. The guided
   recorder action says **Review code** because it prepares reviewed SHAFT code


### PR DESCRIPTION
Documents the Capture overlay P1 ergonomics shipped in ShaftHQ/SHAFT_ENGINE#3509 (issue ShaftHQ/SHAFT_ENGINE#3496): draggable panel with remembered position, step kind badges, 5-second undo for deleted steps, the header help sheet, and the Guided panel live-status parity wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)