### PR TITLE
docs: matchesScreenshot() options-object API (no perform())

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -214,7 +214,7 @@ Generated GUI assertions use SHAFT assertion builders such as
 replace checkpoint notes with raw TestNG or JUnit assertions. Aria snapshot
 matches and screenshot matches baseline render as
 `driver.element().assertThat(locator).matchesAriaSnapshot(...)` and
-`driver.element().assertThat(locator).matchesScreenshot().perform()`.
+`driver.element().assertThat(locator).matchesScreenshot()`.
 
 ![SHAFT Capture assertion mode](/img/capture-assertion-mode.png)
 

--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -146,11 +146,11 @@ The recorder overlay supports practical interactions:
 - **Step kind badges** — Each step row displays a badge indicating the action type: Click, Type, Select, Toggle, Upload, Keys, Navigate, Assert, or Pin. When a step carries a readiness warning, the badge is colored amber for visibility.
 - **Soft-delete with undo** — Deleting a step from the list is a soft delete with a 5-second undo window. A "Step deleted. Undo" notification appears; click Undo within the window to restore the step. The deletion is only persisted after the window elapses.
 - **Help sheet** — Click the "?" button in the overlay header to toggle a help sheet listing all recorder controls, including how to drag the overlay, press Esc to cancel assert or pick mode, and access undo.
-- **IntelliJ status alignment** — The IntelliJ Guided panel's live status mirror the overlay wording: "Recording · N steps · Ready · <url>. Stop here or in the browser overlay - both save the session." This makes it clear that stopping from either location (browser or IDE panel) saves the same recording.
+- **IntelliJ status alignment** — The IntelliJ Guided panel's live status mirror the overlay wording: "Recording · N steps · Ready · \<url\>. Stop here or in the browser overlay - both save the session." This makes it clear that stopping from either location (browser or IDE panel) saves the same recording.
 
 ### Stopping a recording
 
-Pressing stop from the panel opens a confirmation inside the overlay before the session stops. The confirmation displays "Session saved to: <path>" (sourced via loopback /session endpoint, best-effort) and prompts next actions — open the SHAFT Assistant in the IDE and use "Review code". Buttons: "Save & close" (stops the session and the browser closes) and "Keep recording" (dismisses the confirmation). Programmatic stops via MCP `capture_stop` are unchanged and close immediately without confirmation.
+Pressing stop from the panel opens a confirmation inside the overlay before the session stops. The confirmation displays "Session saved to: \<path\>" (sourced via loopback /session endpoint, best-effort) and prompts next actions — open the SHAFT Assistant in the IDE and use "Review code". Buttons: "Save & close" (stops the session and the browser closes) and "Keep recording" (dismisses the confirmation). Programmatic stops via MCP `capture_stop` are unchanged and close immediately without confirmation.
 
 Teams can pin recorder behavior for a whole repository by checking in
 `.shaft/recorder-policy.json` at the workspace root:

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -655,7 +655,7 @@ The workflow selector exposes curated MCP requests for common automation jobs:
   sessions and is also honored by the assistant web and mobile recording flows.
   The **Intent** field flows into `capture_start` as `sessionGoal`, so generated
   tests are named after the journey ("Log in as a valid user" yields
-  `logInAsAValidUser()`). A live **Status** strip shows "Recording · N steps · Ready · <url>",
+  `logInAsAValidUser()`). A live **Status** strip shows "Recording · N steps · Ready · \<url\>",
   allowing you to monitor session state, steps count (including pending debounced input),
   and current URL in the IDE panel; stopping from here or in the browser overlay
   saves the same recording session, so headless recordings stay observable and controllable

--- a/docs/reference/actions/GUI/didYouKnow/Visual_Testing.md
+++ b/docs/reference/actions/GUI/didYouKnow/Visual_Testing.md
@@ -119,15 +119,16 @@ Avoid running visual tests in headless mode if your baselines were captured in h
 
 ## matchesScreenshot()
 
-`matchesScreenshot()` is a lighter-weight, OpenCV-only pixel-diff assertion built into `shaft-engine` (no `shaft-visual` dependency required). It mirrors Playwright's `toHaveScreenshot()` options:
+`matchesScreenshot()` is a lighter-weight, OpenCV-only pixel-diff assertion built into `shaft-engine` (no `shaft-visual` dependency required). Like every other SHAFT assertion it runs immediately — no `perform()` is needed. Pass a `VisualComparisonOptions` object to tune the diff budget and masks, mirroring Playwright's `toHaveScreenshot()` options:
 
 ```java title="ScreenshotBaseline.java"
 driver.element().assertThat(By.id("logo"))
-      .matchesScreenshot()
-      .maxDiffPixelRatio(0.01)
-      .mask(By.id("timestamp"))
-      .perform();
+      .matchesScreenshot(VisualComparisonOptions.create()
+          .maxDiffPixelRatio(0.01)
+          .mask(By.id("timestamp")));
 ```
+
+For a straight comparison with default settings, call `matchesScreenshot()` with no arguments.
 
 ### Per-browser/OS baseline naming
 


### PR DESCRIPTION
Aligns the docs with ShaftHQ/SHAFT_ENGINE#3524, where `matchesScreenshot()` now executes immediately like every other assertion — no `perform()` required.

- **Visual Testing** example: pass `VisualComparisonOptions.create().maxDiffPixelRatio(0.01).mask(...)` instead of chaining trailing options + `.perform()`; note the bare no-arg form for default comparisons.
- **Capture** assertion-mode snippet: drop the stale `.perform()`.

Also clears the pre-existing `tests/docs-quality.test.js` failure (it forbids `.perform()` on assertion examples) — no test exemption needed, since the example is now correct SHAFT usage.

Verified: `node tests/docs-quality.test.js` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)