### PR TITLE
docs: mobile recorder adopts the web Capture glossary (SHAFT_ENGINE#3497)

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -276,6 +276,15 @@ replays it through `mobile_replay_recording` against the active mobile session
 before returning the generated code -- the same live-validation guarantee
 WebDriver and Playwright recordings get.
 
+The mobile recording status speaks the **same vocabulary as the web recorder**
+rather than a parallel one: recorded interactions are **steps**, readiness is
+`READY` / `RISKY` / `BLOCKED` (coordinate-only or redacted-value steps are
+`RISKY`; a stop with no steps is `BLOCKED`), and stopping surfaces the saved
+session path with a **Review code** next-step. Actions performed while
+recording is inactive are reported with the same `Ignored: <reason>`
+transparency note used by the web overlay. The IntelliJ Guided panel's live
+status mirrors this wording automatically.
+
 Use `FLOW_START` and `FLOW_END` checkpoints to mark an explicit reusable flow
 inside a recording. The checkpoint description becomes the generated helper
 method name, so a segment marked as `login as admin` generates a


### PR DESCRIPTION
Companion docs for SHAFT_ENGINE PR #3525 (issue #3497 M0). Documents that the mobile recording status now shares the web recorder vocabulary — **steps**, Ready/Risky/Blocked readiness, saved session path + **Review code** CTA, and the `Ignored: <reason>` transparency note. One paragraph added to the Capture recorder guide (`docs/agentic/capture.md`).