### PR TITLE
docs: SHAFT Overview per-type breakdown + fail-only filter (SHAFT_ENGINE#3523)

### DIFF
--- a/docs/reference/reporting/reporting.mdx
+++ b/docs/reference/reporting/reporting.mdx
@@ -124,19 +124,25 @@ SHAFT attaches a branded **SHAFT Overview** suite summary to the Allure report.
 The overview displays:
 
 - **Checkpoint totals** — count of total, passed, and failed checkpoints across the run
+- **By-type breakdown** — a per-type table splitting **Assertion** (hard) vs **Verification** (soft), each with its own passed / failed / total
 - **Pass ratio donut** — visual pass-rate indicator
 - **Traces captured** — count of SHAFT traces under `target/shaft-traces/` (retry-aware: counts each failed attempt when retries are configured)
+- **Fail-only filter** — a "Show failures only" toggle on the checkpoint details table that hides passing rows
 
 The overview provides a quick snapshot of test outcomes and captured diagnostics alongside Allure's native statistics.
 
 Alongside the HTML overview, SHAFT attaches a machine-readable **`Checkpoints`**
 JSON artifact (`application/json`) so tooling — SHAFT Doctor, the MCP server, and
 the IntelliJ plugin widgets — can consume structured checkpoint fields instead of
-scraping the HTML. Its shape is:
+scraping the HTML. It carries the same by-type breakdown the overview shows:
 
 ```json
 {
   "total": 4, "passed": 1, "failed": 3,
+  "byType": {
+    "assertion":    { "passed": 1, "failed": 0 },
+    "verification": { "passed": 0, "failed": 3 }
+  },
   "checkpoints": [
     { "id": 1, "type": "ASSERTION", "message": "...", "status": "PASS" },
     { "id": 2, "type": "VERIFICATION", "message": "...", "status": "FAIL" }


### PR DESCRIPTION
Companion docs for SHAFT_ENGINE PR #3533 (issue #3523). Documents the per-type (Assertion vs Verification) breakdown table, the fail-only details filter, and the matching `byType` field in the Checkpoints JSON. Focused additions to the SHAFT Overview reporting reference.