### PR TITLE
docs: Assistant failure headline + intent-routing status (SHAFT_ENGINE#3513)

### DIFF
--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -203,6 +203,12 @@ the command list.
 - "Upgrade this project to the latest SHAFT" has the agent preview, apply, and
   verify the upgrade (with Agent mode and source edits approved).
 
+As the Assistant routes a request to a tool, the running status names it in
+plain language — "Running: `capture_start` …" — so it is always clear which
+tool was chosen. When a tool fails, the result leads with a short headline
+("`<tool>` couldn't finish"), the humanized error, and exactly one next action,
+so a failure is easy to scan and act on rather than a wall of exception text.
+
 An empty chat keeps the surface uncluttered. The Assistant offers three chips
 that pre-fill the composer (Record a sample flow / Ask how to assert / Diagnose
 my last failure) plus a dismissible first-run coach: "Check setup → Record a


### PR DESCRIPTION
Companion docs for SHAFT_ENGINE PR #3537 (issue #3513). Notes the plain-language 'Running: <tool> …' routing status and the short-headline + one-next-action failure result pattern. One paragraph added to the IntelliJ Assistant section.