### PR TITLE
chore: adopt a11ymcp for user-guide accessibility checks (#739)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "a11ymcp": {
+      "command": "npx",
+      "args": ["-y", "a11y-mcp-server"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,8 @@
 
 - Substantive docs changes: `yarn test`, `yarn typecheck`, `yarn build`, `yarn test:playwright`.
 - Visual changes: inspect the built page in a browser.
+
+## Accessibility
+
+- UI/visual doc-page changes: run the `a11ymcp` MCP server (configured in `.mcp.json`, npm `a11y-mcp-server`, axe-core based) against the affected built pages, complementing the heuristic `accessibility-review` skill.
+- Treat axe-core violations as review evidence for the changed pages; the heuristic skill covers what automated rules cannot (focus order, meaningful labels, reduced-motion intent).


### PR DESCRIPTION
Closes #739.

Adopts `a11ymcp` in the user-guide repo so agents can run automated accessibility audits on built doc pages.

## Changes
- **`.mcp.json`** (new): registers the `a11ymcp` MCP server via `npx -y a11y-mcp-server` (the axe-core-based `ronantakizawa/a11ymcp` project, published to npm as `a11y-mcp-server`).
- **`AGENTS.md`**: new **Accessibility** section wiring a11ymcp into the docs review flow — run it against affected built pages for UI/visual changes, complementing the heuristic `accessibility-review` skill.

Retires the one-off `a11ymcp` note that previously lived in `SHAFT_ENGINE/AGENTS.md` (per the SHAFT_ENGINE Learning Loop policy the issue references).

Config-only + docs; no runtime/site changes, so no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)