### PR TITLE
docs: SHAFT.API head() and options() request methods

### DIFF
--- a/docs/reference/actions/API/Request_Builder.md
+++ b/docs/reference/actions/API/Request_Builder.md
@@ -53,6 +53,18 @@ api.patch("/posts/1");
 SHAFT.API api = new SHAFT.API("https://jsonplaceholder.typicode.com");
 api.delete("/posts/1");
 ```
+#### Head
+`HEAD` returns the same status and headers as `GET` without a response body, so it is handy for existence, cache, and header checks.
+```java
+SHAFT.API api = new SHAFT.API("https://jsonplaceholder.typicode.com");
+api.head("/posts/1");
+```
+#### Options
+`OPTIONS` is typically used to inspect the methods an endpoint allows (CORS/preflight), commonly asserted through the `Allow` response header.
+```java
+SHAFT.API api = new SHAFT.API("https://jsonplaceholder.typicode.com");
+api.options("/posts");
+```
 
 ### Set Authentication
 Set the authentication method that will be used by the API request that you're currently building. By default, this value is set to `AuthenticationType.NONE` but you can change it by calling this method. If you use this method, the authentication token will be saved automatically for all following requests using the same session.


### PR DESCRIPTION
Documents the new `SHAFT.API.head(...)` and `SHAFT.API.options(...)` request builders shipping in SHAFT_ENGINE #3567 (issue #3530 A3 — extra HTTP verbs).

Adds **Head** and **Options** subsections to `docs/reference/actions/API/Request_Builder.md`, alongside the existing Get/Post/Put/Patch/Delete verbs, each with a one-line note on typical use:
- HEAD — same status/headers as GET without a body; existence, cache, and header checks.
- OPTIONS — inspect an endpoint's allowed methods (CORS/preflight) via the `Allow` header.

Companion to SHAFT_ENGINE #3567.