### PR TITLE
agent-tooling: point Windows always-on setup at the source-controlled installer

### DIFF
--- a/docs/maintainers/agent-tooling.md
+++ b/docs/maintainers/agent-tooling.md
@@ -95,21 +95,23 @@ gbrain sync --all --no-hard-deadline   # first full sync outlives the 1h watchdo
 
 Continuous operation: on macOS/Linux, `gbrain autopilot --install --repo
 <checkout>` registers the self-maintaining daemon. **`autopilot --install`
-has no Windows target** (launchd/systemd/cron only) — on Windows register
-user-level Scheduled Tasks running gbrain's cron-friendly one-shots:
+has no Windows target** (launchd/systemd/cron only) — on Windows run the
+source-controlled installer from the SHAFT_ENGINE checkout:
 
 ```powershell
-schtasks /Create /TN gbrain-autosync /TR "%USERPROFILE%\.gbrain\autopilot\gbrain-autosync.cmd" /SC MINUTE /MO 30 /F
-schtasks /Create /TN gbrain-dream   /TR "%USERPROFILE%\.gbrain\autopilot\gbrain-dream.cmd"   /SC DAILY /ST 05:00 /F
+powershell -ExecutionPolicy Bypass -File tools\agent-infra\install-agent-tasks.ps1
 ```
 
-`gbrain-autosync.cmd` runs `gbrain sync --all --no-pull --skip-failed
---no-hard-deadline` (`--no-pull` so the tasks never touch working-repo git
-state; `--skip-failed` so one unparseable file cannot wedge the sync
-bookmark) and `gbrain-dream.cmd` runs `gbrain dream` — the full maintenance
-cycle (sync, fact extraction, consolidation, take proposals, embeddings,
-orphan checks). `gbrain dream --dry-run` previews a cycle. Health and
-recommendations: `gbrain doctor`, `gbrain features`, `gbrain stats`.
+It registers two user-level Scheduled Tasks pointing at the repo's
+`tools/agent-infra/` scripts (source-controlled; logs stay machine-local in
+`~/.gbrain/autopilot/`): `gbrain-autosync` every 30 min runs `gbrain sync
+--all --no-pull --skip-failed --no-hard-deadline` (`--no-pull` never touches
+working-repo git state; `--skip-failed` so one unparseable file cannot wedge
+the sync bookmark), and `gbrain-dream` daily at 05:00 runs `gbrain dream` —
+the full maintenance cycle (sync, fact extraction, consolidation, take
+proposals, embeddings, orphan checks) — then rebuilds and re-clusters the
+graphify repository map. `gbrain dream --dry-run` previews a cycle. Health
+and recommendations: `gbrain doctor`, `gbrain features`, `gbrain stats`.
 Embed backlogs queued as jobs never drain on PGLite (no worker); cancel the
 job (`gbrain jobs cancel <id>`) and run `gbrain embed --stale`, or let the
 nightly dream absorb them.


### PR DESCRIPTION
Follow-up to #780: that PR merged without the final correction, so the published page still referenced user-level script paths that were replaced by SHAFT_ENGINE `tools/agent-infra/install-agent-tasks.ps1` (engine PR ShaftHQ/SHAFT_ENGINE#3617). Also notes the dream task now rebuilds the graphify map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)