### PR TITLE
docs: mark leaked plan file unlisted (#793)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-user-guide-growth-conversion.md
+++ b/docs/superpowers/plans/2026-06-25-user-guide-growth-conversion.md
@@ -1,3 +1,8 @@
+---
+unlisted: true
+tags: [superpowers-plan]
+---
+
 # User Guide Growth Conversion Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.


### PR DESCRIPTION
## Summary
- `docs/superpowers/plans/2026-06-25-user-guide-growth-conversion.md` had no frontmatter, unlike its sibling plan files, so it was fully public, sitemap-indexed, Google-indexable, and AutoBot-ingested.
- Adds `unlisted: true` and `tags: [superpowers-plan]` to match the two sibling files in the same directory.

## Test plan
- [x] `node tests/docs-quality.test.js` passes

Closes #793