### PR TITLE
docs: exclude docs/superpowers/ from search, AutoBot, and indexing (#794)

### DIFF
--- a/netlify/functions/docs-loader.mjs
+++ b/netlify/functions/docs-loader.mjs
@@ -12,7 +12,7 @@ const snippets = JSON.parse(
   readFileSync(join(currentDir, '..', '..', 'src', 'data', 'snippets.json'), 'utf-8'),
 );
 const MCP_COMMAND_SYSTEMS = ['windows', 'macos', 'linux'];
-const EXCLUDED_DIRECTORIES = new Set(['archive', 'maintainers']);
+const EXCLUDED_DIRECTORIES = new Set(['archive', 'maintainers', 'superpowers']);
 
 let cachedIndex = null;
 

--- a/scripts/prune-search-index.mjs
+++ b/scripts/prune-search-index.mjs
@@ -4,7 +4,7 @@ import {fileURLToPath} from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const buildDirectory = path.join(root, 'build');
-const excludedPrefixes = ['/docs/archive/', '/docs/maintainers/'];
+const excludedPrefixes = ['/docs/archive/', '/docs/maintainers/', '/docs/superpowers/'];
 
 const files = (await readdir(buildDirectory))
   .filter((name) => name.startsWith('search-index-docs-') && name.endsWith('.json'));

--- a/src/theme/DocItem/Metadata/index.tsx
+++ b/src/theme/DocItem/Metadata/index.tsx
@@ -5,7 +5,7 @@ import {PageMetadata} from '@docusaurus/theme-common';
 
 export default function DocItemMetadata(): ReactNode {
   const {metadata, frontMatter, assets} = useDoc();
-  const isArchive = metadata.permalink.includes('/docs/archive/');
+  const isInternalOnly = metadata.permalink.includes('/docs/archive/') || metadata.permalink.includes('/docs/superpowers/');
 
   return (
     <>
@@ -15,7 +15,7 @@ export default function DocItemMetadata(): ReactNode {
         keywords={frontMatter.keywords}
         image={assets.image ?? frontMatter.image}
       />
-      {isArchive ? (
+      {isInternalOnly ? (
         <Head>
           <meta name="robots" content="noindex, nofollow" />
         </Head>


### PR DESCRIPTION
## Summary
- `docs/superpowers/` (internal agent-framework planning artifacts) was absent from all three site content-exclusion mechanisms, unlike `archive/` and `maintainers/`.
- Adds it to `docs-loader.mjs`'s `EXCLUDED_DIRECTORIES` (AutoBot), `prune-search-index.mjs`'s `excludedPrefixes` (local search), and the `noindex, nofollow` condition in `DocItem/Metadata/index.tsx` (external search engines).
- `maintainers/` handling is untouched here — see #795 for that directory's own policy call.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node tests/docs-loader.test.js`

Closes #794