### PR TITLE
docs: make docs/maintainers/ fully public (#795)

### DIFF
--- a/netlify/functions/docs-loader.mjs
+++ b/netlify/functions/docs-loader.mjs
@@ -12,7 +12,7 @@ const snippets = JSON.parse(
   readFileSync(join(currentDir, '..', '..', 'src', 'data', 'snippets.json'), 'utf-8'),
 );
 const MCP_COMMAND_SYSTEMS = ['windows', 'macos', 'linux'];
-const EXCLUDED_DIRECTORIES = new Set(['archive', 'maintainers', 'superpowers']);
+const EXCLUDED_DIRECTORIES = new Set(['archive', 'superpowers']);
 
 let cachedIndex = null;
 

--- a/scripts/prune-search-index.mjs
+++ b/scripts/prune-search-index.mjs
@@ -4,7 +4,7 @@ import {fileURLToPath} from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const buildDirectory = path.join(root, 'build');
-const excludedPrefixes = ['/docs/archive/', '/docs/maintainers/', '/docs/superpowers/'];
+const excludedPrefixes = ['/docs/archive/', '/docs/superpowers/'];
 
 const files = (await readdir(buildDirectory))
   .filter((name) => name.startsWith('search-index-docs-') && name.endsWith('.json'));
@@ -54,4 +54,4 @@ for (const name of files) {
   await writeFile(file, JSON.stringify(payload));
 }
 
-console.log(`Removed ${removed} archive and maintainer sections from local search.`);
+console.log(`Removed ${removed} archive and superpowers sections from local search.`);

--- a/tests/docs-loader.test.js
+++ b/tests/docs-loader.test.js
@@ -23,8 +23,12 @@ assert(
   'Archive pages must be excluded.',
 );
 assert(
-  index.every((chunk) => !chunk.path.startsWith('maintainers/')),
-  'Maintainer pages must be excluded.',
+  index.every((chunk) => !chunk.path.startsWith('superpowers/')),
+  'Superpowers plan pages must be excluded.',
+);
+assert(
+  index.some((chunk) => chunk.path.startsWith('maintainers/')),
+  'Maintainer pages must be included.',
 );
 
 const cases = [


### PR DESCRIPTION
## Summary
- `docs/maintainers/` was hidden from the site's own search index and AutoBot while remaining fully indexable by external search engines and present in sidebars.js/sitemap — an inconsistent, unintentional half-exclusion.
- Per product decision, treat it as fully public: removed from `EXCLUDED_DIRECTORIES` (docs-loader.mjs) and `excludedPrefixes` (prune-search-index.mjs) so site search and AutoBot serve it like any other doc, matching what external search engines already do.
- Updated `tests/docs-loader.test.js` to assert maintainer pages are now included, and added a `superpowers/` exclusion assertion that was a coverage gap left over from #794.

## Test plan
- [x] `node tests/docs-loader.test.js`
- [x] `node tests/docs-quality.test.js`

Closes #795