### PR TITLE
docs: fix JSON-LD license URL branch reference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,7 @@ const config = {
         operatingSystem: 'Windows, macOS, Linux',
         description: 'Unified test automation engine for Web, Mobile, API, CLI, and Database testing. Built on Selenium, Appium, and REST Assured.',
         url: siteUrl,
-        license: 'https://github.com/ShaftHQ/SHAFT_ENGINE/blob/master/LICENSE',
+        license: 'https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/LICENSE',
         author: {
           '@type': 'Organization',
           name: 'ShaftHQ',


### PR DESCRIPTION
The homepage's SoftwareApplication JSON-LD `license` field pointed at
`blob/master/LICENSE` on SHAFT_ENGINE, but that repo's default branch is
`main` — the link 404s. The homepage's own License link elsewhere already
uses `blob/main/LICENSE`; this makes the JSON-LD field match.

Closes #787