### PR TITLE
docs: fix navbar GitHub link org casing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -313,7 +313,7 @@ const config = {
           //   value: '<a class="navbar__item navbar__link" href="https://shafthq.github.io/SHAFT_ENGINE/" target="_blank"><b>JavaDocs</b></a>',
           // },
           {
-            href: 'https://github.com/shafthq/SHAFT_ENGINE',
+            href: 'https://github.com/ShaftHQ/SHAFT_ENGINE',
             position: 'right',
             className: 'header-github-link',
             target: '_blank',


### PR DESCRIPTION
The navbar's GitHub icon linked to `github.com/shafthq/SHAFT_ENGINE`
(lowercase org). Match the canonical `ShaftHQ` casing used everywhere
else on the site.

Closes #788