### PR TITLE
docs: differentiate duplicate reporting guide CTA labels (#786)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -118,7 +118,7 @@ const proofPoints = [
   {
     title: 'Failures start with evidence',
     description: 'Web, mobile, API, CLI, and DB actions attach evidence that Doctor and Heal can use for recovery.',
-    label: 'Reporting guide',
+    label: 'Reporting overview',
     to: '/docs/features/reporting',
   },
 ];
@@ -459,7 +459,7 @@ function AllureEvidenceSection(): JSX.Element {
           <Heading as="h2" id="allure-evidence-heading">Allure evidence people can inspect.</Heading>
           <p>SHAFT turns each checkout action into report evidence: steps, screenshots, logs, and diagnostics stay attached to the run instead of scattered across CI output.</p>
           <Link className={styles.inlineCta} to="/docs/reference/reporting">
-            Open reporting guide
+            Open reporting configuration reference
           </Link>
         </div>
         <figure className={styles.allureFrame}>


### PR DESCRIPTION
## Summary
- Fixes the real half of #786: two homepage CTAs both read "reporting guide" while pointing to different pages (features overview vs. reference/configuration). Relabels them so the destination is predictable before clicking.

## Note on scope
The issue also claimed `/docs/reference/reporting` 404s. That claim does not hold: `docs/reference/reporting/reporting.mdx` is named identically to its parent folder, which Docusaurus's documented `<folder>/<folder>.md` category-index convention (`node_modules/@docusaurus/plugin-content-docs/lib/slug.js`) maps directly to `/docs/reference/reporting` — verified against both the generated route table and a live fetch of https://shafthq.github.io/docs/reference/reporting (200, correct content). No routing change made; left a comment on the issue with this evidence.

## Test plan
- [x] Re-read both edit sites in full surrounding context to confirm JSX stayed syntactically intact
- [x] `git diff` limited to the two label/text strings, nothing else touched