### PR TITLE
docs: remove fabricated star-prompt gating claim (#785)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,7 +59,7 @@ const audienceLanes = [
     points: [
       'One guide path helps new projects, migrations, and cross-surface expansion.',
       'Failures start with artifacts that explain what changed and where to look.',
-      'The star prompt only appears after a successful first run, so it never nags before evaluators see evidence.',
+      'Starring the repository stays a simple, always-visible action, never gated behind proving anything first.',
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- The homepage "For leaders" audience lane claimed the star CTA "only appears after a successful first run." No such gating exists anywhere in the codebase — every star CTA renders unconditionally. Rewrote the copy to describe only real, current behavior.

## Test plan
- [x] `git diff` limited to the single false-claim string
- [x] Re-read surrounding `audienceLanes` array to confirm syntax intact

Closes #785.