### PR TITLE
docs: fix SEO keyword to accurately position SHAFT as selenium-based (#789)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ const config = {
       tagName: 'meta',
       attributes: {
         name: 'keywords',
-        content: 'test automation framework, selenium alternative, java test automation, web testing, mobile testing, api testing, appium, rest assured, testng, junit, cucumber, page object model, SHAFT engine, open source testing',
+        content: 'test automation framework, selenium test framework, java test automation, web testing, mobile testing, api testing, appium, rest assured, testng, junit, cucumber, page object model, SHAFT engine, open source testing',
       },
     },
     {


### PR DESCRIPTION
## Summary
- SEO keywords listed "selenium alternative", contradicting every other product description in the repo (SHAFT is built on Selenium/Playwright/Appium/REST Assured, not a replacement for them). Swapped to "selenium test framework".

## Test plan
- [x] `git diff` limited to the single keyword phrase

Closes #789.