### PR TITLE
docs: add sikulix integration to sidebar (#792)

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -67,6 +67,7 @@ const sidebars = {
         'integrations/browserstack',
         'integrations/visual',
         'integrations/video',
+        'integrations/sikulix',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- docs/integrations/sikulix.md exists with real content and is cross-linked, but was missing from the Integrations sidebar category, making it unreachable via normal navigation. Added it.

## Test plan
- [x] `git diff` limited to one added array entry

Closes #792.