### PR TITLE
docs: remove nonexistent capture_generate MCP tool reference (#791)

### DIFF
--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -459,9 +459,9 @@ The packaged server supports:
   request/response events, with automatic secret-reference handling, size limiting,
   first-party/asset filtering, and privacy enforcement; Chrome/Edge browsers with
   DevTools Protocol support only;
-- deterministic WebDriver TestNG generation through `capture_generate`,
-  `capture_generate_replay`, `capture_code_blocks`, and
-  `capture_record_at_target_code_blocks`, with compile, optional replay, local
+- deterministic WebDriver TestNG generation through `capture_generate_replay`,
+  `capture_code_blocks`, and `capture_record_at_target_code_blocks`, with
+  compile, optional replay, local
   deterministic code-review warnings, existing-suite target candidates, focused
   source-anchor insertion snippets, preview-only patch blocks,
   setup/assertion/control-flow review blocks, locator-confidence queues,
@@ -545,7 +545,9 @@ The HTTP port defaults to `8081` and can be overridden with `PORT` or
 ## MCP command reference
 
 The same main class also provides local SHAFT Capture and Doctor CLIs. Use `;`
-instead of `:` in `MCP_CP` on Windows:
+instead of `:` in `MCP_CP` on Windows. The `capture generate` subcommand shown
+below is a separate, local-only CLI command, distinct from the MCP tool
+`capture_generate_replay` described above:
 
 ```bash
 MCP_CP="shaft-mcp/target/shaft-mcp-<version>.jar:shaft-mcp/target/dependency/*"


### PR DESCRIPTION
## Summary
- docs/agentic/mcp.mdx listed `capture_generate` as an MCP tool; no such tool exists (verified against the full shaft-mcp Java source and the live MCP tool registry — only `capture_generate_replay` is real). Removed the false entry and added a clarifying note distinguishing the CLI `capture generate` subcommand from the MCP tool `capture_generate_replay`.

## Test plan
- [x] `git diff` limited to the two intended locations
- [x] Re-read both edited sections in full context to confirm prose/markdown stayed intact

Closes #791.