### PR TITLE
docs: replace fake coverage matrix with real surface cards (#784)

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -276,7 +276,6 @@
 .pathCard small,
 .codePanel figcaption,
 .handledPanel > span,
-.matrixHeader,
 .pathCard em,
 .allureFrame figcaption,
 .footerBadges strong,
@@ -628,8 +627,7 @@
 
 .pathCard:hover,
 .proofCard:hover,
-.loopStep:hover,
-.matrixRow:hover {
+.loopStep:hover {
   color: var(--ifm-font-color-base);
   text-decoration: none;
 }
@@ -660,69 +658,6 @@
   color: var(--site-color-primary);
   font-style: normal;
   font-weight: var(--site-font-weight-bold);
-}
-
-.surfaceMatrix {
-  display: grid;
-  margin-bottom: 1.35rem;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 8px;
-  overflow: hidden;
-  background: var(--ifm-background-surface-color);
-  box-shadow: 0 18px 48px rgba(var(--site-color-deep-alt-rgb), 0.07);
-}
-
-.matrixHeader,
-.matrixRow {
-  display: grid;
-  grid-template-columns: minmax(150px, 1.2fr) repeat(6, minmax(74px, 0.7fr));
-  align-items: stretch;
-}
-
-.matrixHeader {
-  background: rgba(var(--site-color-primary-rgb), 0.08);
-  color: var(--site-color-primary);
-  font-weight: var(--site-font-weight-bold);
-}
-
-.matrixHeader > *,
-.matrixRow > * {
-  min-width: 0;
-  padding: 0.82rem 0.9rem;
-  border-right: 1px solid var(--ifm-color-emphasis-200);
-}
-
-.matrixHeader > *:last-child,
-.matrixRow > *:last-child {
-  border-right: 0;
-}
-
-.matrixRow {
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-  color: var(--ifm-font-color-base);
-  text-decoration: none;
-}
-
-.matrixRow:hover {
-  background: rgba(var(--site-color-primary-rgb), 0.06);
-}
-
-.matrixRow > span {
-  position: relative;
-  color: transparent;
-}
-
-.matrixRow > span::before {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0.58rem;
-  height: 0.58rem;
-  border-radius: 999px;
-  background: var(--site-color-primary);
-  box-shadow: 0 0 0 5px rgba(var(--site-color-primary-rgb), 0.12);
-  transform: translate(-50%, -50%);
-  content: '';
 }
 
 .proofGrid {
@@ -954,7 +889,6 @@
 }
 
 :global(html[data-theme='light']) .pathGrid,
-:global(html[data-theme='light']) .surfaceMatrix,
 :global(html[data-theme='light']) .evidenceLoop,
 :global(html[data-theme='light']) .allureFrame {
   border-color: rgba(var(--site-color-primary-rgb), 0.16);
@@ -1050,23 +984,6 @@
   text-transform: uppercase;
 }
 
-.matrixHeader {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: var(--site-font-small);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.matrixStack {
-  display: block;
-  margin-top: 0.18rem;
-  color: var(--ifm-color-emphasis-700);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: var(--site-font-caption);
-  font-weight: var(--site-font-weight-regular);
-  letter-spacing: 0.05em;
-}
-
 .loopStep small {
   width: auto;
   min-width: 1.8rem;
@@ -1129,11 +1046,6 @@
   .pathCard::after {
     display: none;
   }
-
-  .matrixHeader,
-  .matrixRow {
-    grid-template-columns: minmax(140px, 1.1fr) repeat(6, minmax(64px, 0.7fr));
-  }
 }
 
 @media (max-width: 760px) {
@@ -1157,10 +1069,6 @@
 
   .codeCompare {
     grid-template-columns: 1fr;
-  }
-
-  .surfaceMatrix {
-    display: none;
   }
 
   .footerBadges {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -123,7 +123,6 @@ const proofPoints = [
   },
 ];
 
-const coverageColumns = ['Test', 'Validate', 'Data', 'State', 'Observe', 'Evidence'];
 const slackInviteUrl = 'https://join.slack.com/t/shaft-engine/shared_invite/zt-oii5i2gg-0ZGnih_Y34NjK7QqDn01Dw';
 
 const codeCompare = {
@@ -398,26 +397,16 @@ function SurfaceSection(): JSX.Element {
     <section className={`${styles.section} ${styles.surfaceSection} ${styles.reveal}`} data-testid="landing-surfaces" id="surface-section" data-reveal>
       <div className="container">
         <div className={styles.sectionHeading}>
-          <span className={styles.eyebrow}>Coverage matrix</span>
-          <Heading as="h2" id="testing-surfaces">One framework. Full surface coverage.</Heading>
+          <span className={styles.eyebrow}>Testing surfaces</span>
+          <Heading as="h2" id="testing-surfaces">One framework. Five testing surfaces.</Heading>
           <p>Start with the layer in front of you, then expand without changing the reporting and lifecycle model.</p>
         </div>
-        <div className={styles.surfaceMatrix} data-testid="landing-surface-matrix" aria-label="SHAFT surface coverage matrix">
-          <div className={styles.matrixHeader}>
-            <strong>Surface</strong>
-            {coverageColumns.map((column) => (
-              <span key={column}>{column}</span>
-            ))}
-          </div>
+        <div className={styles.proofGrid} data-testid="landing-surface-matrix" aria-label="SHAFT testing surfaces">
           {testSurfaces.map((surface) => (
-            <Link className={styles.matrixRow} to={surface.to} key={surface.title} data-hover-glow>
-              <strong>
-                {surface.title}
-                <small className={styles.matrixStack}>{surface.stack}</small>
-              </strong>
-              {coverageColumns.map((column) => (
-                <span key={column}>{column}</span>
-              ))}
+            <Link className={`${styles.proofCard} ${styles.reveal}`} to={surface.to} key={surface.title} data-reveal data-hover-glow>
+              <strong>{surface.title}</strong>
+              <span>{surface.description}</span>
+              <small>{surface.stack}</small>
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- The homepage "Coverage matrix" rendered the same 6 column-header labels in every cell of every row (Web GUI/Mobile GUI/API/Database/CLI) — no real per-surface data existed, so it looked structured but carried zero signal.
- Considered populating real per-surface capability data instead, but no canonical Test/Validate/Data/State/Observe/Evidence taxonomy exists anywhere else in the docs to verify per-cell claims against — inventing levels would risk fabricating unverifiable product claims (the exact failure mode #785 in this same audit already flagged). Went with the issue's other suggested fix instead.
- Replaced the fake matrix with the existing `.proofCard`/`.proofGrid` card pattern already used by `ProofSection` elsewhere on this page, driven by the real `testSurfaces` data (title/stack/description) that was already accurate. Removed the now-fully-dead matrix-specific CSS (94 lines).

## Test plan
- [x] `node tests/homepage-performance.test.js` — passes (kept required `landing-surface-matrix` testid and `surface-section` id)
- [x] `npm run typecheck` — clean
- [x] Read full diff for both files; confirmed no orphaned CSS selectors/braces

Closes #784.