### PR TITLE
docs: rename opaque config page ids to self-describing slugs (#796)

### DIFF
--- a/docs/reference/configuration/apiConfig.md
+++ b/docs/reference/configuration/apiConfig.md
@@ -1,5 +1,5 @@
 ---
-id: basicConfig3
+id: apiConfig
 title: Basic Configuration for API
 sidebar_label: API
 description: "Configure SHAFT Engine properties for REST API testing — proxy, timeouts, retry settings, and Swagger/OpenAPI schema validation."

--- a/docs/reference/configuration/mobileConfig.md
+++ b/docs/reference/configuration/mobileConfig.md
@@ -1,5 +1,5 @@
 ---
-id: basicConfig2
+id: mobileConfig
 title: Basic Configuration for Mobile GUI
 sidebar_label: Mobile GUI
 description: "Configure SHAFT Engine properties for mobile app automation with Appium — Android, iOS, native and web execution settings."
@@ -100,7 +100,7 @@ If both `browserStack.appUrl` and `mobile_app` point to remote app values, `brow
 
 ## Mobile Web (Browser on Device)
 
-For mobile browser testing, configure the same properties as [Web GUI](./basicConfig) and add the mobile target:
+For mobile browser testing, configure the same properties as [Web GUI](./webConfig) and add the mobile target:
 
 ```properties title="src/main/resources/properties/custom.properties"
 executionAddress=localhost:4723

--- a/docs/reference/configuration/webConfig.md
+++ b/docs/reference/configuration/webConfig.md
@@ -1,5 +1,5 @@
 ---
-id: basicConfig
+id: webConfig
 title: Basic Configuration for Web GUI
 sidebar_label: Web GUI
 description: "Configure SHAFT Engine properties for web browser automation — browser type, headless mode, timeouts, proxy, and visual reporting."

--- a/docs/testing/api.mdx
+++ b/docs/testing/api.mdx
@@ -64,7 +64,7 @@ assertion is appropriate for the scenario.
 | Reuse tokens or basic auth | [API Authentication](/docs/reference/actions/API/API_Authentication) |
 | Validate JSON fields or schemas | [Response Validations](/docs/reference/actions/API/Response_Validations) |
 | Record and replay UI/API traffic | [UI and API contract replay](/docs/testing/contracts) |
-| Track OpenAPI coverage | [API configuration](/docs/reference/configuration/basicConfig3) |
+| Track OpenAPI coverage | [API configuration](/docs/reference/configuration/apiConfig) |
 
 ## Related
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,21 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/reference/configuration/basicConfig"
+  to = "/docs/reference/configuration/webConfig"
+  status = 301
+
+[[redirects]]
+  from = "/docs/reference/configuration/basicConfig2"
+  to = "/docs/reference/configuration/mobileConfig"
+  status = 301
+
+[[redirects]]
+  from = "/docs/reference/configuration/basicConfig3"
+  to = "/docs/reference/configuration/apiConfig"
+  status = 301
+
+[[redirects]]
   from = "/docs/Best_Practices/*"
   to = "/docs/reference/guides/:splat"
   status = 301


### PR DESCRIPTION
## Summary
- Renamed `basicConfig`/`basicConfig2`/`basicConfig3` (and their ids) to `webConfig`/`mobileConfig`/`apiConfig`, so the URL itself signals which surface it configures — matters for bookmarks, shared links, and agents reasoning over a sitemap/URL list without fetching every page.
- Added 301 redirects for all three old paths in `netlify.toml`, reusing this repo's existing redirect mechanism (no new Docusaurus plugin needed).
- Updated the two real internal cross-references (`mobileConfig.md`'s link to `webConfig`, and `docs/testing/api.mdx`'s link to `apiConfig`).

## Test plan
- [x] `npm run build` (has `onBrokenLinks: 'throw'` / `onBrokenMarkdownLinks: 'throw'`) — succeeds, confirming the id-only rename resolves correctly and nothing else references the old ids
- [x] Confirmed `build/docs/reference/configuration/{webConfig,mobileConfig,apiConfig}.html` are generated
- [x] `grep -rn "basicConfig" docs/ src/ sidebars.js` — zero remaining references (one pre-existing, unrelated, already-broken/unused reference-style link left untouched, out of scope)

Closes #796.