### PR TITLE
docs: describe the SHAFT Tests tab, gutter icons, and watch mode correlation

### DIFF
--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -692,9 +692,15 @@ Each category provides editable JSON arguments and calls the matching MCP tool.
 This keeps generated code and source edits reviewable in the IDE instead of
 hidden inside plugin code.
 
-A test-explorer tree, run-gutter icons, and watch-mode auto-run are not part
-of the plugin yet; that remaining scope is tracked in
-[ShaftHQ/SHAFT_ENGINE#3467](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3467).
+Gutter run/debug icons appear next to any TestNG or JUnit `@Test` method in a
+SHAFT project. The **SHAFT Tests** tab lists recent test runs (pass/fail,
+class name, timestamp); double-click a row to rerun that test, or
+Ctrl+double-click to navigate to its source. **Settings | Tools | SHAFT**'s
+"Enable watch mode" checkbox reruns the last test automatically on every
+source save under `src/test/`; watch mode checks the saved file's class
+against the last run's target class first, and on a mismatch offers a
+"Run `<Class>`" notification action instead of silently replaying a stale
+result ([ShaftHQ/SHAFT_ENGINE#3467](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3467)).
 
 ![SHAFT IntelliJ Guided workflow templates](/img/agentic/intellij-plugin-guided.png)
 


### PR DESCRIPTION
## Summary
`docs/agentic/intellij.md` still described the SHAFT Tests tab, gutter run
icons, and watch-mode auto-run as "not part of the plugin yet" (tracked in
[ShaftHQ/SHAFT_ENGINE#3467](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3467),
which has since closed). All three exist today, and SHAFT_ENGINE's #3634-#3642
batch just shipped Run/Navigate on the Tests tab and a file/last-run-class
correlation check for watch mode, so the gap was worth closing.

Replaces the stale placeholder with an accurate description:
- Gutter run/debug icons on any TestNG/JUnit `@Test` method in a SHAFT project
- SHAFT Tests tab: double-click a row to run, Ctrl+double-click to navigate
- Watch mode: reruns the last test on save under `src/test/`; now checks the
  saved file's class against the last run's target class first, offering a
  "Run `<Class>`" action on a mismatch instead of silently replaying stale

## Test plan
- [x] `node tests/docs-quality.test.js` → passed
- [x] `node scripts/check-doc-duplicates.mjs` → no duplicates found