### PR TITLE
Docs: codegen param defaults, full-content skill scaffolding (act-as-mohab), vscode/opencode init loops

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -257,7 +257,11 @@ locator summaries, action summaries, missing code, suggested proof calls, and a
 focused verification command before code blocks are generated. Then call
 `capture_code_blocks` for WebDriver or `playwright_capture_code_blocks` for
 Playwright, or use `capture_record_at_target_code_blocks` when the plan found a
-specific insertion target. If a focus or click mistake pollutes the recording,
+specific insertion target. Only the recording matters for a quick generation:
+`outputDirectory`, `packageName`, `className`, `overwrite`, and
+`driverVariableName` are optional and default to `generated-tests`,
+`tests.generated`, `RecordedFlowTest`, `false`, and `driver` (`page` for
+Playwright). If a focus or click mistake pollutes the recording,
 the Assistant discard/re-record commands stop with `discard=true` before
 starting a fresh capture. The agent should show the generated result and ask
 whether the user wants the complete Java snippet or wants the agent to insert

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -187,9 +187,13 @@ the `shaft-mcp` jar, so the generated set always tracks the shaft-mcp build
 instead of a hand-duplicated copy. Existing files are left untouched unless
 `overwrite: true`; a skipped file is reported as a warning instead of failing
 the call, since `targetDirectory` is expected to be an existing repository
-that may already carry its own agent configuration. `vscode` and `opencode`
-loops are tracked in
-[ShaftHQ/SHAFT_ENGINE#3463](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3463).
+that may already carry its own agent configuration. `opencode` uses the same
+layout under `.opencode/skills/`, and `vscode` writes
+`.github/instructions/<skill>.instructions.md` files instead. Skills marked
+`distribution: full` in their frontmatter (such as the `act-as-mohab`
+methodology skill) are scaffolded as their complete SKILL.md text rather than
+a thin bridge, so a project with no prior agent instructions gets the full
+ways-of-working document.
 
 ```json
 {"tool": "shaft_project_init_agents", "arguments": {"loop": "claude", "targetDirectory": ".", "overwrite": false}}


### PR DESCRIPTION
Docs sync for ShaftHQ/SHAFT_ENGINE#3720:

- `capture_code_blocks` / `playwright_capture_code_blocks` / `capture_record_at_target_code_blocks`: optional parameters with stated defaults (`generated-tests`, `tests.generated`, `RecordedFlowTest`, `false`, `driver`/`page`).
- `shaft_project_init_agents`: documents the implemented `vscode`/`opencode` loops (replacing the stale #3463 tracking pointer) and the new `distribution: full` full-content scaffolding used by the `act-as-mohab` methodology skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4