### PR TITLE
Capture docs: recorder always runs the managed browser locally

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -35,6 +35,12 @@ navigation, browsing-context, prompt, and preload-script signals when
 available. A JavaScript listener drained through ordinary WebDriver provides
 deterministic interaction capture and remains the compatibility fallback.
 
+The recorder always runs the managed browser locally: any configured
+`executionAddress` (remote Selenium Grid) is intentionally ignored at
+recording time, because an interactive recording needs the browser on your
+own screen to click through. Generated tests still honor your configured
+`executionAddress` when they run.
+
 Use the Capture commands on
 [Connect shaft-mcp](/docs/agentic/mcp#mcp-command-reference). That page owns
 the runnable MCP command reference and classpath notes.


### PR DESCRIPTION
Companion to ShaftHQ/SHAFT_ENGINE#3733: documents in the "Managed browser recording" section that the interactive recorder intentionally ignores `executionAddress` (remote Selenium Grid) at recording time — the browser must be on the user's own screen to click through — while generated tests still honor the configured address at replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs