### PR TITLE
WS-E visual polish: WCAG AA contrast enforcement test + 75ch prose measure

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "npm run test:docs && npm run test:homepage && npm run test:history && npm run test:release-template",
     "test:history": "node tests/chat-history.test.js",
     "test:homepage": "node tests/homepage-performance.test.js",
-    "test:docs": "node tests/docs-loader.test.js && node tests/cloudflare-autobot.test.js && node tests/enhanced-instruction.test.js && node tests/properties-catalog.test.js && node tests/generate-properties-catalog-regex.test.js && node tests/properties-list-coverage.test.js && node tests/docs-quality.test.js && node scripts/check-doc-duplicates.mjs",
+    "test:docs": "node tests/docs-loader.test.js && node tests/cloudflare-autobot.test.js && node tests/enhanced-instruction.test.js && node tests/properties-catalog.test.js && node tests/generate-properties-catalog-regex.test.js && node tests/properties-list-coverage.test.js && node tests/docs-quality.test.js && node tests/design-contrast.test.js && node scripts/check-doc-duplicates.mjs",
     "test:api": "node tests/chatbot-api.test.js",
     "test:e2e": "npm run test:shaft",
     "test:playwright": "npx playwright test",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,6 +63,16 @@ html {
   scroll-margin-top: var(--site-anchor-offset);
 }
 
+/* WS-E typography audit: on desktop the doc article column measures ~823px at the 16px
+ * base body font (~95ch), well past the ~60-80ch readable range. Cap running prose (not
+ * tables/code blocks/images, which benefit from the full column width) to a ~75ch measure. */
+:where(.theme-doc-markdown, .markdown) > p,
+:where(.theme-doc-markdown, .markdown) > ul,
+:where(.theme-doc-markdown, .markdown) > ol,
+:where(.theme-doc-markdown, .markdown) > blockquote {
+  max-width: 75ch;
+}
+
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 :root[data-theme='dark'],
 body[data-theme='dark'],

--- a/tests/design-contrast.test.js
+++ b/tests/design-contrast.test.js
@@ -1,0 +1,277 @@
+// WS-E: WCAG AA contrast audit for the `--site-color-*` token palettes governed by
+// DESIGN_LANGUAGE.md ("Approved palette (site-wide)"). This is a permanent regression
+// guard, not a one-off script: it parses the live light and dark palettes straight out of
+// src/css/custom.css (never hardcodes hex values) and re-derives the same foreground/
+// background pairs that DESIGN_LANGUAGE.md's tokens actually render as across the site
+// (hero/footer/audience "dark sections", the AutoBot chat widget, and in-code syntax
+// highlighting) by reading how each pair is composed in the CSS -- not by guessing.
+//
+// Thresholds follow WCAG 2.x SC 1.4.3 (text) / 1.4.11 (non-text, unused here since every
+// pair below renders as real text at font sizes below the "large text" cutoff -- see each
+// pair's `smallestUse` note): 4.5:1 for normal text, 3:1 for large text (>=24px, or >=18.66px
+// bold) / UI components.
+
+import {readFileSync} from 'fs';
+import {fileURLToPath} from 'url';
+
+const cssPath = fileURLToPath(new URL('../src/css/custom.css', import.meta.url));
+const css = readFileSync(cssPath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// --- Token extraction -------------------------------------------------------------------
+// Pull the `:root { ... }` (light) and `:root[data-theme='dark'] { ... }` (dark) blocks out
+// of custom.css by brace-matching from the selector, then read every `--site-color-<name>:
+// #hex;` declaration inside. This intentionally ignores the `-rgb` companion variables
+// (comma-separated triplets, not hex) since the hex declarations are the source of truth.
+function extractBlock(source, selectorPattern) {
+  const selectorMatch = selectorPattern.exec(source);
+  assert(selectorMatch, `custom.css is missing a selector matching ${selectorPattern}`);
+  const braceStart = source.indexOf('{', selectorMatch.index);
+  assert(braceStart !== -1, `custom.css selector ${selectorMatch[0]} has no opening brace`);
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(braceStart + 1, i);
+    }
+  }
+  throw new Error(`custom.css selector ${selectorMatch[0]} never closes its brace`);
+}
+
+function parsePalette(block) {
+  const palette = {};
+  const tokenPattern = /--site-color-([a-z-]+?):\s*(#[0-9a-fA-F]{3,8})\s*;/g;
+  for (const match of block.matchAll(tokenPattern)) {
+    palette[match[1]] = match[2];
+  }
+  return palette;
+}
+
+const lightBlock = extractBlock(css, /:root\s*\{/);
+const darkBlock = extractBlock(css, /:root\[data-theme=(['"])dark\1\][^{]*\{/);
+const lightPalette = parsePalette(lightBlock);
+const darkPalette = parsePalette(darkBlock);
+
+const requiredTokens = ['primary', 'deep', 'deep-alt', 'muted', 'on-dark'];
+for (const token of requiredTokens) {
+  assert(lightPalette[token], `light :root palette is missing --site-color-${token}`);
+  assert(darkPalette[token], `dark :root[data-theme='dark'] palette is missing --site-color-${token}`);
+}
+
+// --- WCAG 2.x contrast math --------------------------------------------------------------
+function hexToRgb(hex) {
+  const normalized = hex.length === 4
+    ? `#${[...hex.slice(1)].map((c) => c + c).join('')}`
+    : hex;
+  const value = parseInt(normalized.slice(1, 7), 16);
+  return {r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255};
+}
+
+function relativeLuminance({r, g, b}) {
+  const channel = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const [rl, gl, bl] = [r, g, b].map(channel);
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrastRatio(hexA, hexB) {
+  const lA = relativeLuminance(hexToRgb(hexA));
+  const lB = relativeLuminance(hexToRgb(hexB));
+  const [lighter, darker] = lA >= lB ? [lA, lB] : [lB, lA];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// --- Meaningful foreground/background pairs ----------------------------------------------
+// Every pair below is a real (fg token, bg token) combination read directly out of the CSS
+// that consumes DESIGN_LANGUAGE.md's palette (not an invented combination). `smallestUse`
+// records the smallest/heaviest-weight real usage of that pair, which is what determines
+// whether the WCAG "large text" 3:1 allowance applies (>=24px normal, or >=18.66px bold) --
+// every pair here renders below that cutoff at its smallest use, so all are held to 4.5:1.
+const pairs = [
+  {
+    name: 'on-dark text / deep background',
+    fg: 'on-dark',
+    bg: 'deep',
+    size: 'normal',
+    citation: 'src/pages/index.module.css:911-932 (.landingFooter bg=deep, .footerBadges strong color=on-dark)',
+    smallestUse: '.footerBadges strong at --site-font-label (0.88rem / 14.08px), font-weight 700',
+  },
+  {
+    name: 'on-dark text / deep-alt background',
+    fg: 'on-dark',
+    bg: 'deep-alt',
+    size: 'normal',
+    citation:
+      'src/pages/index.module.css:846-865 (.finalCta bg gradient deep-alt->deep, h2 color=on-dark); ' +
+      "src/components/AutoBot/styles.module.css:538-541 ([data-theme='dark'] .assistantMessage .messageBubble bg=deep-alt, color=on-dark)",
+    smallestUse: 'AutoBot assistant message bubble text at --site-font-body (1.05rem / 16.8px), regular weight',
+  },
+  {
+    name: 'muted text / deep background',
+    fg: 'muted',
+    bg: 'deep',
+    size: 'normal',
+    citation:
+      'src/pages/index.module.css:136-139 (.heroCopy > p color=muted on .hero bg); ' +
+      'src/pages/index.module.css:397-398 (.codeCompare pre bg=deep, color=muted); ' +
+      'src/pages/index.module.css:910-912 (.landingFooter bg=deep, color=muted)',
+    smallestUse: '.footerLinks small / .footerBadges small at --site-font-label (0.88rem / 14.08px), regular weight',
+  },
+  {
+    name: 'muted text / deep-alt background',
+    fg: 'muted',
+    bg: 'deep-alt',
+    size: 'normal',
+    citation:
+      'src/pages/index.module.css:307-312 (.codeCompare > div/figure bg=deep-alt, color=muted); ' +
+      "src/components/AutoBot/styles.module.css:550-552 ([data-theme='dark'] .chatFooter bg=deep-alt, color=muted)",
+    smallestUse: '.codeCompare code at --site-font-code-small (0.76rem / 12.16px), regular weight',
+  },
+  {
+    name: 'primary text / deep-alt background',
+    fg: 'primary',
+    bg: 'deep-alt',
+    size: 'normal',
+    citation:
+      'src/pages/index.module.css:101-112 (.eyebrow color=primary on .hero bg, deep-alt at gradient origin); ' +
+      'src/pages/index.module.css:289-312 (.codePanel figcaption / .handledPanel > span color=primary on .codeCompare div bg=deep-alt)',
+    smallestUse: '.codePanel figcaption at --site-font-label (0.88rem / 14.08px), font-weight 700',
+  },
+  {
+    name: 'primary text / deep background',
+    fg: 'primary',
+    bg: 'deep',
+    size: 'normal',
+    citation:
+      'src/pages/index.module.css:397 (.codeCompare pre bg=deep) + :418-422 (.codeAnnotation/.codeKeyword/.codeCall color=primary)',
+    smallestUse: '.codeAnnotation/.codeKeyword/.codeCall at --site-font-code-small (0.76rem / 12.16px), regular weight',
+  },
+  {
+    name: 'on-dark text / primary background',
+    fg: 'on-dark',
+    bg: 'primary',
+    size: 'normal',
+    citation: 'src/components/AutoBot/styles.module.css:225-227 (.userMessage .messageBubble bg=primary, color=on-dark)',
+    smallestUse: '.messageBubble p at --site-font-body (1.05rem / 16.8px), regular weight',
+  },
+];
+
+const thresholds = {normal: 4.5, large: 3};
+
+function auditPalette(themeName, palette) {
+  const rows = [];
+  for (const pair of pairs) {
+    const fgHex = palette[pair.fg];
+    const bgHex = palette[pair.bg];
+    const ratio = contrastRatio(fgHex, bgHex);
+    const threshold = thresholds[pair.size];
+    rows.push({
+      theme: themeName,
+      pair: pair.name,
+      fgHex,
+      bgHex,
+      ratio,
+      threshold,
+      pass: ratio >= threshold,
+      smallestUse: pair.smallestUse,
+    });
+  }
+  return rows;
+}
+
+const allRows = [...auditPalette('light', lightPalette), ...auditPalette('dark', darkPalette)];
+
+// --- Known, proven-infeasible failures (WS-E investigation, see WCAG_CONTRAST_FINDINGS below) --
+// These 3 pairs fail WCAG AA and CANNOT be fixed by adjusting `--site-color-*` VALUES alone
+// without collateral damage: the math is a hard ceiling, not a tuning problem.
+//   - light primary(#006ec0) vs pure black (the maximum possible contrast against ANY
+//     background, of ANY hue/lightness) is only 3.99:1 -- already short of 4.5:1. Primary
+//     itself must lighten to have a chance, but it is independently capped at L~41.3% (HSL)
+//     by its own real, passing use as normal-weight link/label text on the white page
+//     background elsewhere (.pathCard em, .inlineCta, McpApplications .manualLink/.copyButton
+//     hover -- all <=16px, needing 4.5:1, currently only 5.26:1 of margin). The two
+//     constraints leave a ~0.5-point-wide window where success is *only* possible if the dark
+//     background is pushed to literal #000000 (destroying deep/deep-alt's navy hue and the
+//     "keep hue identity" requirement) -- and even then the margin is ~0.05, not a real fix.
+//   - dark on-dark(#f5fdff) vs primary(#4cc2ff) fill: exhaustive joint search over both
+//     tokens' lightness (holding hue/saturation fixed) found no combination that satisfies
+//     on-dark-vs-primary >=4.5 without on-dark collapsing under its OWN passing deep/deep-alt
+//     pairs (currently 18.37:1 / 14.58:1 of headroom) -- even at on-dark's absolute floor
+//     against those (L=37.4%), no primary lightness satisfies all three constraints together.
+// The real fix is a CSS-selector change (repoint these specific rules at an already-passing
+// `--site-color-*` token, e.g. `muted` or `deep-alt`), which is a design decision (it changes
+// which token-approved color renders, e.g. removing the user-chat-bubble's brand-blue fill,
+// or muting the hero eyebrow/code-panel accent color) outside this task's "adjust token
+// VALUES only" mandate. Tracked as a known limitation pending that design call -- see the
+// PR/session report for the full proof. Any *other* pair beyond this exact allowlist must
+// still pass; this list intentionally does not use wildcards.
+const knownLimitations = new Set([
+  'light|primary text / deep-alt background',
+  'light|primary text / deep background',
+  'dark|on-dark text / primary background',
+]);
+
+// --- Report the full audit table (always -- passing or failing) --------------------------
+console.log('WCAG contrast audit -- DESIGN_LANGUAGE.md --site-color-* palettes\n');
+const header = ['theme', 'pair', 'fg', 'bg', 'ratio', 'threshold', 'result'];
+const widths = [6, 34, 9, 9, 7, 9, 6];
+console.log(header.map((h, i) => h.padEnd(widths[i])).join(' | '));
+console.log(widths.map((w) => '-'.repeat(w)).join('-|-'));
+for (const row of allRows) {
+  const key = `${row.theme}|${row.pair}`;
+  const isKnownLimitation = !row.pass && knownLimitations.has(key);
+  const cells = [
+    row.theme,
+    row.pair,
+    row.fgHex,
+    row.bgHex,
+    `${row.ratio.toFixed(2)}:1`,
+    `${row.threshold}:1`,
+    row.pass ? 'PASS' : isKnownLimitation ? 'FAIL*' : 'FAIL',
+  ];
+  console.log(cells.map((c, i) => String(c).padEnd(widths[i])).join(' | '));
+}
+console.log(
+  '\n* FAIL rows marked with an asterisk are tracked, proven-infeasible-via-token-value known\n' +
+    '  limitations (see the comment above `knownLimitations`) and do not fail this test; every\n' +
+    '  other pair is a hard gate.\n',
+);
+
+const unexpectedFailures = allRows.filter((row) => !row.pass && !knownLimitations.has(`${row.theme}|${row.pair}`));
+if (unexpectedFailures.length > 0) {
+  for (const row of unexpectedFailures) {
+    console.error(
+      `FAIL [${row.theme}] ${row.pair}: ${row.fgHex} on ${row.bgHex} = ${row.ratio.toFixed(2)}:1, ` +
+        `needs >= ${row.threshold}:1 (smallest real use: ${row.smallestUse})`,
+    );
+  }
+}
+
+assert(
+  unexpectedFailures.length === 0,
+  `${unexpectedFailures.length} of ${allRows.length} --site-color-* contrast pair(s) failed WCAG AA outside the ` +
+    'known-limitations allowlist -- see FAIL lines above.',
+);
+
+// Guard the allowlist itself: if a "known limitation" pair starts passing (e.g. a future,
+// real token fix lands), the allowlist entry is now stale and must be removed, not left as
+// dead weight silently masking a would-be-caught regression.
+const staleAllowlistEntries = [...knownLimitations].filter(
+  (key) => !allRows.some((row) => `${row.theme}|${row.pair}` === key && !row.pass),
+);
+assert(
+  staleAllowlistEntries.length === 0,
+  `knownLimitations has stale entries that now pass WCAG AA -- remove them: ${staleAllowlistEntries.join(', ')}`,
+);
+
+const passCount = allRows.filter((row) => row.pass).length;
+console.log(
+  `${passCount} of ${allRows.length} --site-color-* contrast pairs meet WCAG AA; ` +
+    `${knownLimitations.size} pair(s) are tracked known limitations (see comment above).`,
+);


### PR DESCRIPTION
Final phase (WS-E) of tracking ticket #822.

## What

- **`tests/design-contrast.test.js`** (wired into `test:docs`): parses the light + dark `--site-color-*` palettes straight from `src/css/custom.css` and computes WCAG contrast for 7 real foreground/background pairs per palette (derived from actual CSS usage, cited in-test). Hard-gates the 11 passing pairs; 3 pairs are documented **known limitations** with in-file mathematical proof that no token-value change can reach 4.5:1 without breaking hue identity (e.g. light primary `#006ec0` vs pure black caps at 3.99:1). A staleness check fails the test if a listed pair ever starts passing without being un-listed.
- **75ch prose measure** (`src/css/custom.css`): doc-article running prose (`p`/`ul`/`ol`/`blockquote`) capped at 75ch — live-measured at ~95ch on desktop before, past the 60–80ch readable range. Tables, code blocks, and images deliberately keep the full column.
- **Typography audit**: line-height 1.65 and monotonic heading scale already pass — no change needed.
- **Accessibility sweep** (headless Chromium against live production; landing, guided paths, quick-start, one reference page): zero violations for image alt text, heading-level skips, and link accessible names. Before-screenshots archived outside the repo.

## Follow-ups filed separately

- Repointing the 3 known-limitation contrast pairs is a design decision (selector/token reassignment, changes brand accent usage) — tracked in a dedicated issue.
- Annotated IDE onboarding screenshots need curated IntelliJ assets — tracked in a dedicated issue.

## Verification

`yarn test:docs` green (9 checks incl. the new contrast gate); full `yarn build` green.

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk