### PR TITLE
Repoint 3 WCAG-AA-unfixable contrast pairs off primary instead of allowlisting them

### DIFF
--- a/src/components/AutoBot/styles.module.css
+++ b/src/components/AutoBot/styles.module.css
@@ -531,6 +531,14 @@
   background: var(--ifm-background-surface-color);
 }
 
+/* Repointed from the primary-based gradient (#832): .headerText h3 sits on this
+   fill and can't reach WCAG AA with on-dark text on solid primary in dark mode
+   (see tests/design-contrast.test.js, "on-dark text / primary background").
+   deep-alt already passes there; light mode is untouched (already passing). */
+[data-theme='dark'] .chatHeader {
+  background: var(--site-color-deep-alt);
+}
+
 [data-theme='dark'] .chatMessages {
   background: linear-gradient(180deg, rgba(var(--site-color-primary-rgb), 0.08), transparent 150px), var(--ifm-background-surface-color);
 }
@@ -552,7 +560,15 @@
   color: var(--site-color-muted);
 }
 
-[data-theme='dark'] .userMessage .messageBubble,
+/* Repointed from --ifm-color-primary-light (#832): on-dark text on that fill
+   can't reach WCAG AA (see tests/design-contrast.test.js, "on-dark text /
+   primary background"). deep-alt already passes there; the primary-colored
+   border keeps the bubble's brand-blue identity without using it as a fill. */
+[data-theme='dark'] .userMessage .messageBubble {
+  border: 1px solid var(--site-color-primary);
+  background: var(--site-color-deep-alt);
+}
+
 [data-theme='dark'] .sendButton,
 [data-theme='dark'] .messageAvatar {
   background: var(--ifm-color-primary-light);

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -103,7 +103,7 @@
   align-items: center;
   gap: 0.55rem;
   margin-bottom: 0.9rem;
-  color: var(--site-color-primary);
+  color: var(--site-color-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: var(--site-font-small);
   font-weight: var(--site-font-weight-medium);
@@ -286,11 +286,19 @@
   line-height: 1.35;
 }
 
-.pathCard small,
+.pathCard small {
+  display: block;
+  color: var(--site-color-primary);
+  font-weight: var(--site-font-weight-bold);
+}
+
+/* Repointed from --site-color-primary (#832): these captions sit on the
+   deep-alt code-panel background, where primary text can't reach WCAG AA
+   (see tests/design-contrast.test.js). muted already passes there. */
 .codePanel figcaption,
 .handledPanel > span {
   display: block;
-  color: var(--site-color-primary);
+  color: var(--site-color-muted);
   font-weight: var(--site-font-weight-bold);
 }
 
@@ -415,10 +423,13 @@
   white-space: pre;
 }
 
+/* Repointed from --site-color-primary (#832): this text sits on the
+   .codeCompare pre's deep background, where primary text can't reach WCAG AA
+   (see tests/design-contrast.test.js). muted already passes there. */
 .codeAnnotation,
 .codeKeyword,
 .codeCall {
-  color: var(--site-color-primary);
+  color: var(--site-color-muted);
 }
 
 .codeFunction {

--- a/tests/design-contrast.test.js
+++ b/tests/design-contrast.test.js
@@ -93,6 +93,8 @@ function contrastRatio(hexA, hexB) {
 // records the smallest/heaviest-weight real usage of that pair, which is what determines
 // whether the WCAG "large text" 3:1 allowance applies (>=24px normal, or >=18.66px bold) --
 // every pair here renders below that cutoff at its smallest use, so all are held to 4.5:1.
+// `themes` (optional) restricts a pair to the theme(s) where a selector actually renders it;
+// omit it when the same selector/token combination is real in both themes.
 const pairs = [
   {
     name: 'on-dark text / deep background',
@@ -109,8 +111,10 @@ const pairs = [
     size: 'normal',
     citation:
       'src/pages/index.module.css:846-865 (.finalCta bg gradient deep-alt->deep, h2 color=on-dark); ' +
-      "src/components/AutoBot/styles.module.css:538-541 ([data-theme='dark'] .assistantMessage .messageBubble bg=deep-alt, color=on-dark)",
-    smallestUse: 'AutoBot assistant message bubble text at --site-font-body (1.05rem / 16.8px), regular weight',
+      "src/components/AutoBot/styles.module.css:538-541 ([data-theme='dark'] .assistantMessage .messageBubble bg=deep-alt, color=on-dark); " +
+      "src/components/AutoBot/styles.module.css:555-561 ([data-theme='dark'] .userMessage .messageBubble bg=deep-alt, color=on-dark, #832); " +
+      "src/components/AutoBot/styles.module.css:534-537 ([data-theme='dark'] .chatHeader bg=deep-alt, color=on-dark, #832)",
+    smallestUse: 'AutoBot assistant/user message bubble text at --site-font-body (1.05rem / 16.8px), regular weight',
   },
   {
     name: 'muted text / deep background',
@@ -130,34 +134,27 @@ const pairs = [
     size: 'normal',
     citation:
       'src/pages/index.module.css:307-312 (.codeCompare > div/figure bg=deep-alt, color=muted); ' +
-      "src/components/AutoBot/styles.module.css:550-552 ([data-theme='dark'] .chatFooter bg=deep-alt, color=muted)",
+      "src/components/AutoBot/styles.module.css:550-552 ([data-theme='dark'] .chatFooter bg=deep-alt, color=muted); " +
+      'src/pages/index.module.css:290-296 (.codePanel figcaption / .handledPanel > span color=muted, repointed off primary in #832); ' +
+      'src/pages/index.module.css:418-423 (.codeAnnotation/.codeKeyword/.codeCall color=muted, repointed off primary in #832)',
     smallestUse: '.codeCompare code at --site-font-code-small (0.76rem / 12.16px), regular weight',
   },
   {
-    name: 'primary text / deep-alt background',
-    fg: 'primary',
-    bg: 'deep-alt',
-    size: 'normal',
-    citation:
-      'src/pages/index.module.css:101-112 (.eyebrow color=primary on .hero bg, deep-alt at gradient origin); ' +
-      'src/pages/index.module.css:289-312 (.codePanel figcaption / .handledPanel > span color=primary on .codeCompare div bg=deep-alt)',
-    smallestUse: '.codePanel figcaption at --site-font-label (0.88rem / 14.08px), font-weight 700',
-  },
-  {
-    name: 'primary text / deep background',
-    fg: 'primary',
-    bg: 'deep',
-    size: 'normal',
-    citation:
-      'src/pages/index.module.css:397 (.codeCompare pre bg=deep) + :418-422 (.codeAnnotation/.codeKeyword/.codeCall color=primary)',
-    smallestUse: '.codeAnnotation/.codeKeyword/.codeCall at --site-font-code-small (0.76rem / 12.16px), regular weight',
-  },
-  {
+    // #832: .eyebrow, .codePanel figcaption/.handledPanel > span, and .codeAnnotation/
+    // .codeKeyword/.codeCall were repointed off `primary` (see the two `muted text / deep(-alt)
+    // background` citations above); .userMessage .messageBubble and .chatHeader were repointed
+    // off `primary` in dark mode only (see `on-dark text / deep-alt background` above). Light
+    // mode's .userMessage .messageBubble / .chatHeader keep the primary fill unchanged -- it
+    // already passes there (5.26:1) -- so this pair stays real, but light-theme-only now: no
+    // selector renders on-dark text on a solid primary fill in dark mode anymore.
     name: 'on-dark text / primary background',
     fg: 'on-dark',
     bg: 'primary',
     size: 'normal',
-    citation: 'src/components/AutoBot/styles.module.css:225-227 (.userMessage .messageBubble bg=primary, color=on-dark)',
+    themes: ['light'],
+    citation:
+      'src/components/AutoBot/styles.module.css:225-227 (.userMessage .messageBubble bg=primary, color=on-dark, light theme only); ' +
+      'src/components/AutoBot/styles.module.css:72-74 (.chatHeader bg gradient reaching solid primary, color=on-dark, light theme only)',
     smallestUse: '.messageBubble p at --site-font-body (1.05rem / 16.8px), regular weight',
   },
 ];
@@ -167,6 +164,7 @@ const thresholds = {normal: 4.5, large: 3};
 function auditPalette(themeName, palette) {
   const rows = [];
   for (const pair of pairs) {
+    if (pair.themes && !pair.themes.includes(themeName)) continue;
     const fgHex = palette[pair.fg];
     const bgHex = palette[pair.bg];
     const ratio = contrastRatio(fgHex, bgHex);
@@ -187,35 +185,16 @@ function auditPalette(themeName, palette) {
 
 const allRows = [...auditPalette('light', lightPalette), ...auditPalette('dark', darkPalette)];
 
-// --- Known, proven-infeasible failures (WS-E investigation, see WCAG_CONTRAST_FINDINGS below) --
-// These 3 pairs fail WCAG AA and CANNOT be fixed by adjusting `--site-color-*` VALUES alone
-// without collateral damage: the math is a hard ceiling, not a tuning problem.
-//   - light primary(#006ec0) vs pure black (the maximum possible contrast against ANY
-//     background, of ANY hue/lightness) is only 3.99:1 -- already short of 4.5:1. Primary
-//     itself must lighten to have a chance, but it is independently capped at L~41.3% (HSL)
-//     by its own real, passing use as normal-weight link/label text on the white page
-//     background elsewhere (.pathCard em, .inlineCta, McpApplications .manualLink/.copyButton
-//     hover -- all <=16px, needing 4.5:1, currently only 5.26:1 of margin). The two
-//     constraints leave a ~0.5-point-wide window where success is *only* possible if the dark
-//     background is pushed to literal #000000 (destroying deep/deep-alt's navy hue and the
-//     "keep hue identity" requirement) -- and even then the margin is ~0.05, not a real fix.
-//   - dark on-dark(#f5fdff) vs primary(#4cc2ff) fill: exhaustive joint search over both
-//     tokens' lightness (holding hue/saturation fixed) found no combination that satisfies
-//     on-dark-vs-primary >=4.5 without on-dark collapsing under its OWN passing deep/deep-alt
-//     pairs (currently 18.37:1 / 14.58:1 of headroom) -- even at on-dark's absolute floor
-//     against those (L=37.4%), no primary lightness satisfies all three constraints together.
-// The real fix is a CSS-selector change (repoint these specific rules at an already-passing
-// `--site-color-*` token, e.g. `muted` or `deep-alt`), which is a design decision (it changes
-// which token-approved color renders, e.g. removing the user-chat-bubble's brand-blue fill,
-// or muting the hero eyebrow/code-panel accent color) outside this task's "adjust token
-// VALUES only" mandate. Tracked as a known limitation pending that design call -- see the
-// PR/session report for the full proof. Any *other* pair beyond this exact allowlist must
-// still pass; this list intentionally does not use wildcards.
-const knownLimitations = new Set([
-  'light|primary text / deep-alt background',
-  'light|primary text / deep background',
-  'dark|on-dark text / primary background',
-]);
+// --- Known, proven-infeasible failures ----------------------------------------------------
+// Empty as of #832: the 3 pairs formerly tracked here (light primary/deep-alt, light
+// primary/deep, dark on-dark/primary) could not reach WCAG AA by adjusting `--site-color-*`
+// VALUES alone -- see PR #831 / issue #832 for the original mathematical proof. The resolution
+// was the design decision #832 called for: repoint the affected selectors to a different,
+// already-passing token instead of tuning the palette (see the `pairs` citations above for
+// exactly which selectors moved and to what). Kept as a `Set` (not deleted) so the staleness
+// guard below still runs and a future regression can't silently reintroduce an allowlisted
+// failure without this guard catching it.
+const knownLimitations = new Set([]);
 
 // --- Report the full audit table (always -- passing or failing) --------------------------
 console.log('WCAG contrast audit -- DESIGN_LANGUAGE.md --site-color-* palettes\n');


### PR DESCRIPTION
Closes #832

## Summary

`tests/design-contrast.test.js` tracked 3 fg/bg pairs as WCAG-AA-unfixable-via-token-value known limitations, each with a mathematical proof in-file. Per #832's design decision, this PR repoints the CSS selectors that consumed those failing combinations to already-passing tokens instead of tuning the palette. `knownLimitations` is now **empty**.

## Pairs fixed (old ratio → new ratio, selector changed)

### 1. Light theme: primary text / deep-alt background — 3.15:1 → n/a (pair removed, no longer occurs)
- `.codePanel figcaption`, `.handledPanel > span` (`src/pages/index.module.css:289-296`): `color: var(--site-color-primary)` → `var(--site-color-muted)`. These captions sit on `.codeCompare > div/figure`'s `deep-alt` background (`muted`/`deep-alt` already measures 11.22:1).
- `.eyebrow` (`src/pages/index.module.css:106`): `color: var(--site-color-primary)` → `var(--site-color-muted)`, per the issue's explicit example.
- Split off `.pathCard small` (unaffected — it sits on a light card background, not `deep-alt`; kept `primary`) into its own rule instead of the original 3-selector compound.

### 2. Light theme: primary text / deep background — 2.86:1 → n/a (pair removed, no longer occurs)
- `.codeAnnotation`, `.codeKeyword`, `.codeCall` (`src/pages/index.module.css:418-423`): `color: var(--site-color-primary)` → `var(--site-color-muted)`. These render inside `.codeCompare pre`'s `deep` background (`muted`/`deep` already measures 10.18:1).

### 3. Dark theme: on-dark text / primary background — 1.95:1 → 14.58:1 (via deep-alt)
- AutoBot `.userMessage .messageBubble`, dark theme only (`src/components/AutoBot/styles.module.css:562-569`): fill `--ifm-color-primary-light` → `var(--site-color-deep-alt)`, with a `1px solid var(--site-color-primary)` border added so the bubble keeps some brand-blue identity without using it as text-bearing fill.
- **AutoBot `.chatHeader`, dark theme only** (`src/components/AutoBot/styles.module.css:534-541`): the primary-based gradient fill → `var(--site-color-deep-alt)`. This was a **second, previously-uncited real occurrence** of the same failing pair — the `.headerText h3` title ("AutoBot") renders on-dark text over the solid-primary portion of the header's gradient. Fixing only the message bubble left the pair still genuinely failing; found by empirically sampling rendered pixel colors with Playwright (screenshot → canvas `getImageData`) rather than trusting the CSS alone.
- Light theme is untouched for both selectors — it already passed at 5.26:1.

## Test changes

`pairs` in `tests/design-contrast.test.js` now matches what's actually rendered:
- Removed `primary text / deep-alt background` and `primary text / deep background` — verified (via `rg` across `src/`) that no selector renders primary text on a solid `deep`/`deep-alt` background anymore.
- Added optional per-pair `themes` scoping (`themes: ['light']`) to `on-dark text / primary background`, since after the dark-theme repoint that combination is only real in light theme. Evaluating it against the dark palette would otherwise re-flag a combination nothing renders anymore.
- Updated citations on the `muted text / deep(-alt) background` and `on-dark text / deep-alt background` pairs to include the newly-repointed selectors.
- `knownLimitations` is now `new Set([])`, kept (not deleted) so the staleness guard keeps running against future regressions.

Full audit output after the fix — 9 of 9 pairs pass, 0 known limitations:

```
theme  | pair                               | fg        | bg        | ratio   | threshold | result
-------|------------------------------------|-----------|-----------|---------|-----------|-------
light  | on-dark text / deep background     | #ffffff   | #102a31   | 15.03:1 | 4.5:1     | PASS
light  | on-dark text / deep-alt background | #ffffff   | #181f2a   | 16.56:1 | 4.5:1     | PASS
light  | muted text / deep background       | #c8d6e7   | #102a31   | 10.18:1 | 4.5:1     | PASS
light  | muted text / deep-alt background   | #c8d6e7   | #181f2a   | 11.22:1 | 4.5:1     | PASS
light  | on-dark text / primary background  | #ffffff   | #006ec0   | 5.26:1  | 4.5:1     | PASS
dark   | on-dark text / deep background     | #f5fdff   | #07111f   | 18.37:1 | 4.5:1     | PASS
dark   | on-dark text / deep-alt background | #f5fdff   | #102a31   | 14.58:1 | 4.5:1     | PASS
dark   | muted text / deep background       | #dff5f4   | #07111f   | 16.69:1 | 4.5:1     | PASS
dark   | muted text / deep-alt background   | #dff5f4   | #102a31   | 13.24:1 | 4.5:1     | PASS

9 of 9 --site-color-* contrast pairs meet WCAG AA; 0 pair(s) are tracked known limitations.
```

## Visual effect

- Hero eyebrow labels, code-panel captions, and code keyword/call/annotation highlighting in the "Code proof" section switch from brand-blue to muted grey-blue.
- The AutoBot chat header and the user's own message bubbles switch from bright primary-blue fill to the same navy `deep-alt` fill the assistant's bubbles already use, in dark mode only; the user bubble keeps a blue border for visual identity.

## Verification

- `node tests/design-contrast.test.js` — RED confirmed first (emptied `knownLimitations` against the *unfixed* CSS, reproduced the exact tracked ratios: 3.15:1 / 2.86:1 / 1.95:1), then GREEN after the CSS + test changes.
- `yarn test` (full suite: docs, homepage, history, release-template) — all green.
- `yarn build` — production build succeeds.
- Empirically verified the dark-theme chat header/bubble fix and the "no other real occurrence" claims for the removed pairs with a throwaway Playwright pixel-sampling script (not committed) rather than trusting the CSS/citations alone.

## Adjacent finding filed, not fixed here

While verifying no other selector still renders primary text on a solid `deep`/`deep-alt` background, empirical pixel-sampling turned up `.heroBrand` (the "SHAFT" wordmark in the hero) sitting on a *composited/gradient* background this test structurally can't represent as a token pair — measured light-theme contrast is **~2.28:1**, worse than either pair fixed here. Filed as ShaftHQ/shafthq.github.io#837 rather than fixed inline; it's a different class of problem (gradient/composited backgrounds, not a solid-token repoint) and out of #832's scope.

## Evidence

Before/after screenshots (dark-theme AutoBot chat window, and the "Code proof" section) captured locally during implementation — not committed to the repo, available on request. Computed contrast ratios above are the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk
