### PR TITLE
Docs: layered lazy-loading readiness + properties catalog sensitivity fix

### DIFF
--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -770,6 +770,9 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | waitForLazyLoadingTimeout           | `30`          | (seconds)       | Timeout in seconds for SHAFT's browser lazy-loading synchronization.               |
 | lazyLoadingNetworkIdleInitialObservationMillis | `200` | (milliseconds)  | Initial network observation window in milliseconds when no requests were seen.     |
 | lazyLoadingNetworkIdleQuietWindowMillis | `500`     | (milliseconds)  | Required network quiet window in milliseconds after observed activity.             |
+| lazyLoadingPollingIntervalMillis    | `200`         | (milliseconds)  | Polling interval in milliseconds for the browser-readiness `fluentWait` loop.       |
+| lazyLoadingDomStabilityQuietWindowMillis | `0`      | (milliseconds); `0` disables DOM-stability folding | Required DOM-mutation quiet window in milliseconds before the browser-readiness wait treats the DOM as stable. |
+| lazyLoadingScrollSweepMaxSteps      | `20`          | (steps)         | Maximum number of progressive-scroll steps that `driver.browser().scrollToLoadAll()` performs while sweeping a page for scroll-triggered lazy content. |
 | browserNavigationTimeout            | `30`          | (seconds)       | Timeout in seconds for browser navigation.                                         |
 | pageLoadTimeout                     | `30`          | (seconds)       | Timeout in seconds for page load.                                                  |
 | scriptExecutionTimeout              | `30`          | (seconds)       | Timeout in seconds for script execution.                                           |
@@ -1244,27 +1247,27 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | pilot.ai.redaction.patterns                      | ` `            |                   | Double-semicolon-separated custom regular expressions. |
 | pilot.ai.openai.endpoint                         | `https://api.openai.com/v1/responses` |   | OpenAI Responses endpoint. |
 | pilot.ai.openai.model                            | ` `            |                   | Configured OpenAI model. |
-| pilot.ai.openai.apiKeyEnvironmentVariable        | ` `            |                   | Environment variable containing the OpenAI credential. |
+| pilot.ai.openai.apiKeyEnvironmentVariable        | `OPENAI_API_KEY` |                 | Environment variable containing the OpenAI credential. |
 | pilot.ai.openai.processingLocation               | `remote`       |                   | Explicit OpenAI endpoint processing location. |
 | pilot.ai.anthropic.endpoint                      | `https://api.anthropic.com/v1/messages` | | Anthropic Messages endpoint. |
 | pilot.ai.anthropic.model                         | ` `            |                   | Configured Anthropic model. |
-| pilot.ai.anthropic.apiKeyEnvironmentVariable     | ` `            |                   | Environment variable containing the Anthropic credential. |
+| pilot.ai.anthropic.apiKeyEnvironmentVariable     | `ANTHROPIC_API_KEY` |               | Environment variable containing the Anthropic credential. |
 | pilot.ai.anthropic.processingLocation            | `remote`       |                   | Explicit Anthropic endpoint processing location. |
 | pilot.ai.anthropic.version                       | `2023-06-01`   |                   | Anthropic API contract version. |
 | pilot.ai.gemini.endpoint                         | `https://generativelanguage.googleapis.com/v1beta/models` | | Gemini models endpoint. |
 | pilot.ai.gemini.model                            | `gemini-3.5-flash` |               | Configured Gemini model. |
-| pilot.ai.gemini.apiKeyEnvironmentVariable        | ` `            |                   | Environment variable containing the Gemini credential. |
+| pilot.ai.gemini.apiKeyEnvironmentVariable        | `GEMINI_API_KEY` |                 | Environment variable containing the Gemini credential. |
 | pilot.ai.gemini.processingLocation               | `remote`       |                   | Explicit Gemini endpoint processing location. |
 | pilot.ai.github.endpoint                         | `https://models.github.ai/inference/chat/completions` | | GitHub Models chat-completions endpoint. |
 | pilot.ai.github.model                            | ` `            |                   | Configured GitHub Models model. |
-| pilot.ai.github.apiKeyEnvironmentVariable        | ` `            |                   | Environment variable containing the GitHub credential. |
+| pilot.ai.github.apiKeyEnvironmentVariable        | `GITHUB_TOKEN` |                   | Environment variable containing the GitHub credential. |
 | pilot.ai.github.processingLocation               | `remote`       |                   | Explicit GitHub Models endpoint processing location. |
 | pilot.ai.ollama.endpoint                         | `http://127.0.0.1:11434/api/chat` |       | Ollama chat endpoint. |
 | pilot.ai.ollama.model                            | ` `            |                   | Configured Ollama model. |
 | pilot.ai.ollama.processingLocation               | `local`        |                   | Explicit Ollama endpoint processing location. |
 | pilot.ai.ollama.apiKeyEnvironmentVariable        | ` `            |                   | Optional environment variable containing an on-prem Ollama gateway credential. |
-| pilot.ai.ollama.apiKeyHeader                     | ` `            |                   | Optional Ollama gateway credential header. |
-| pilot.ai.ollama.apiKeyPrefix                     | ` `            |                   | Optional Ollama gateway credential prefix. |
+| pilot.ai.ollama.apiKeyHeader                     | `Authorization` |                  | Optional Ollama gateway credential header. |
+| pilot.ai.ollama.apiKeyPrefix                     | `Bearer `      |                   | Optional Ollama gateway credential prefix. |
 
   </TabItem>
 </Tabs>

--- a/docs/testing/flakiness.mdx
+++ b/docs/testing/flakiness.mdx
@@ -90,6 +90,50 @@ synchronization uses `waitForLazyLoadingTimeout`; its network quiet behavior can
 be tuned with `lazyLoadingNetworkIdleInitialObservationMillis` and
 `lazyLoadingNetworkIdleQuietWindowMillis`.
 
+Lazy-loading readiness itself is layered, so the default wait adapts to what a
+page actually does without any test-code changes:
+
+- **JS readiness engine** (default, always on) polls `document.readyState`,
+  in-flight `fetch`/XHR/`sendBeacon` activity, resource-timing changes, jQuery
+  and Angular activity, and a main-thread idle probe
+  (`requestIdleCallback` → `requestAnimationFrame` → `setTimeout` fallback)
+  every `lazyLoadingPollingIntervalMillis` (default `200`ms). Long-lived
+  `EventSource`/`WebSocket` connections are observed but never block idle, so
+  SSE and long-poll pages don't pin every action at the timeout ceiling.
+- **DOM-stability quiet window** (opt-in, off by default) adds a
+  `MutationObserver`-backed check: once enabled, readiness also requires
+  `lazyLoadingDomStabilityQuietWindowMillis` of DOM-mutation silence. It
+  defaults to `0` (disabled) because carousels, tickers, and React re-renders
+  would otherwise pin every action at the 30-second ceiling; turn it on only
+  for pages you know settle and stay settled.
+- **Advisory BiDi network layer** (gated on `platform.enableBiDi()`) tracks
+  in-flight requests via WebDriver BiDi network events when BiDi is enabled.
+  This signal is advisory only: it can extend the quiet window while requests
+  are genuinely in flight (aged out after 10 seconds; SSE/WebSocket upgrades
+  excluded), but it never hard-gates readiness, preserving the same tolerance
+  for long-poll and SSE-style pages as the JS-only path.
+
+```properties title="src/main/resources/properties/custom.properties"
+lazyLoadingPollingIntervalMillis=200
+lazyLoadingDomStabilityQuietWindowMillis=0
+waitForLazyLoadingTimeout=30
+```
+
+For content that only loads on scroll — infinite lists, or sections behind an
+`IntersectionObserver` that hydrate only once visible — call
+`scrollToLoadAll()` right before a full-page assertion or screenshot. It sweeps
+the page in bounded, viewport-height steps (up to
+`lazyLoadingScrollSweepMaxSteps`, default `20`), waiting for lazy-loading
+readiness between each step, then restores the original scroll position. It is
+never invoked automatically by any readiness wait — sweeping an entire page is
+not a safe default before an arbitrary action — so call it explicitly:
+
+```java title="ScrollToLoadAll.java"
+driver.browser().navigateToURL("https://example.test/catalog")
+        .scrollToLoadAll()
+        .captureScreenshot();
+```
+
 ```java title="ExplicitStateWait.java"
 driver.browser().navigateToURL("https://example.test/orders")
         .and().element().click("Refresh orders")

--- a/scripts/generate-properties-catalog.mjs
+++ b/scripts/generate-properties-catalog.mjs
@@ -158,9 +158,26 @@ const NON_SENSITIVE_ALLOWLIST = [
   'pilot.ai.maxOutputTokens',
 ];
 
-function isSensitive(key) {
+// Credential-pointer suffixes: a key ending in one of these names *references* where a secret
+// lives (an environment-variable name, an HTTP header name, a header-value prefix) rather than
+// holding the secret itself, so it matches the "apikey" substring above without being one.
+// Regression fix for #829: the Pilot pilot.ai.<provider>.apiKeyEnvironmentVariable / .apiKeyHeader
+// / .apiKeyPrefix properties default to real, non-secret values (env-var names like
+// OPENAI_API_KEY, header names like Authorization, prefixes like "Bearer ") that must not be
+// blanked. Suffix-based (not a per-provider allowlist) so it covers every current and future
+// Pilot provider without needing an entry per provider.
+const NON_SENSITIVE_KEY_SUFFIXES = [
+  'apiKeyEnvironmentVariable',
+  'apiKeyHeader',
+  'apiKeyPrefix',
+];
+
+export function isSensitive(key) {
   // Check allowlist first: these keys match a sensitive substring but are not sensitive
   if (NON_SENSITIVE_ALLOWLIST.includes(key)) {
+    return false;
+  }
+  if (NON_SENSITIVE_KEY_SUFFIXES.some((suffix) => key.endsWith(suffix))) {
     return false;
   }
   const lower = key.toLowerCase();
@@ -307,11 +324,19 @@ function parseJavaFile(filePath) {
   return parseJavaSource(readFileSync(filePath, 'utf8'));
 }
 
-/** Parses PropertiesList.mdx's per-section "Default Values" GFM tables into a key -> row map. */
+/** Reads PropertiesList.mdx from disk and parses it via parseMdxDefaultsTablesFromContent. */
 function parseMdxDefaultsTables(mdxPath) {
-  const content = readFileSync(mdxPath, 'utf8');
+  return parseMdxDefaultsTablesFromContent(readFileSync(mdxPath, 'utf8'));
+}
+
+/**
+ * Parses PropertiesList.mdx's per-section "Default Values" GFM tables into a key -> row map
+ * (pure -- no I/O, exported for testing). Section headers in PropertiesList.mdx are `## Name`
+ * (h2, one level below the page's own h1 title) -- e.g. `## Platform`, `## Timeouts`.
+ */
+export function parseMdxDefaultsTablesFromContent(content) {
   const lookup = new Map();
-  const sectionRe = /^### .+$/gmu;
+  const sectionRe = /^## .+$/gmu;
   const sectionStarts = [...content.matchAll(sectionRe)].map((mm) => mm.index);
   sectionStarts.push(content.length);
 

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -410,8 +410,8 @@
     "targetFile": "custom.properties",
     "type": "text",
     "defaultValue": "",
-    "possibleValues": "",
-    "description": "Raw Appium platformName capability (e.g. Android, iOS). Usually derived automatically from targetOperatingSystem; set this to override it directly."
+    "possibleValues": "example: Android, iOS",
+    "description": "Raw Appium platformName capability. Usually derived automatically from targetOperatingSystem; set this to override it directly."
   },
   {
     "section": "Mobile",
@@ -609,7 +609,7 @@
     "targetFile": "custom.properties",
     "type": "number",
     "defaultValue": "500",
-    "possibleValues": "",
+    "possibleValues": "integer",
     "description": "Maximum number of network transactions to retain per capture session."
   },
   {
@@ -618,8 +618,8 @@
     "targetFile": "custom.properties",
     "type": "text",
     "defaultValue": "",
-    "possibleValues": "",
-    "description": "Comma-separated glob patterns; when non-empty, only matching URLs are captured."
+    "possibleValues": "comma-separated glob patterns",
+    "description": "When non-empty, only URLs matching one of these glob patterns are captured."
   },
   {
     "section": "Capture",
@@ -627,8 +627,8 @@
     "targetFile": "custom.properties",
     "type": "text",
     "defaultValue": "",
-    "possibleValues": "",
-    "description": "Comma-separated glob patterns; matching URLs are always excluded from capture."
+    "possibleValues": "comma-separated glob patterns",
+    "description": "URLs matching one of these glob patterns are always excluded from capture."
   },
   {
     "section": "Flags",
@@ -1230,8 +1230,8 @@
     "targetFile": "custom.properties",
     "type": "text",
     "defaultValue": "auto",
-    "possibleValues": "",
-    "description": "Auto, light, or dark."
+    "possibleValues": "auto, light, dark",
+    "description": "Controls the Allure 3 Awesome plugin report theme."
   },
   {
     "section": "Allure",
@@ -1240,7 +1240,7 @@
     "type": "boolean",
     "defaultValue": "true",
     "possibleValues": "true, false",
-    "description": "True to enforce configured Allure 3 CLI usage; false for legacy PATH-first behavior."
+    "description": "true enforces the configured Allure 3 CLI version; false falls back to legacy PATH-first CLI resolution."
   },
   {
     "section": "Allure",
@@ -1329,7 +1329,7 @@
     "targetFile": "custom.properties",
     "type": "number",
     "defaultValue": "30",
-    "possibleValues": "",
+    "possibleValues": "(seconds)",
     "description": "Timeout in seconds for SHAFT's browser lazy-loading synchronization."
   },
   {
@@ -1338,7 +1338,7 @@
     "targetFile": "custom.properties",
     "type": "number",
     "defaultValue": "200",
-    "possibleValues": "",
+    "possibleValues": "(milliseconds)",
     "description": "Initial network observation window in milliseconds when no requests were seen."
   },
   {
@@ -1347,8 +1347,35 @@
     "targetFile": "custom.properties",
     "type": "number",
     "defaultValue": "500",
-    "possibleValues": "",
+    "possibleValues": "(milliseconds)",
     "description": "Required network quiet window in milliseconds after observed activity."
+  },
+  {
+    "section": "Timeouts",
+    "key": "lazyLoadingPollingIntervalMillis",
+    "targetFile": "custom.properties",
+    "type": "number",
+    "defaultValue": "200",
+    "possibleValues": "(milliseconds)",
+    "description": "Polling interval in milliseconds for the browser-readiness fluentWait loop."
+  },
+  {
+    "section": "Timeouts",
+    "key": "lazyLoadingDomStabilityQuietWindowMillis",
+    "targetFile": "custom.properties",
+    "type": "number",
+    "defaultValue": "0",
+    "possibleValues": "(milliseconds); 0 disables DOM-stability folding",
+    "description": "Required DOM-mutation quiet window in milliseconds before the browser-readiness wait treats the DOM as stable."
+  },
+  {
+    "section": "Timeouts",
+    "key": "lazyLoadingScrollSweepMaxSteps",
+    "targetFile": "custom.properties",
+    "type": "number",
+    "defaultValue": "20",
+    "possibleValues": "(steps)",
+    "description": "Maximum number of progressive-scroll steps that driver.browser().scrollToLoadAll() performs while sweeping a page for scroll-triggered lazy content."
   },
   {
     "section": "Timeouts",
@@ -2077,8 +2104,8 @@
     "targetFile": "custom.properties",
     "type": "number",
     "defaultValue": "0",
-    "possibleValues": "",
-    "description": "Confidence threshold 0..1 below which AI fallback is triggered."
+    "possibleValues": "0-1",
+    "description": "Confidence threshold below which AI fallback is triggered."
   },
   {
     "section": "Natural Actions",
@@ -2283,10 +2310,9 @@
     "key": "pilot.ai.openai.apiKeyEnvironmentVariable",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "OPENAI_API_KEY",
     "possibleValues": "",
-    "description": "Environment variable containing the OpenAI credential.",
-    "sensitive": true
+    "description": "Environment variable containing the OpenAI credential."
   },
   {
     "section": "Pilot",
@@ -2320,10 +2346,9 @@
     "key": "pilot.ai.anthropic.apiKeyEnvironmentVariable",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "ANTHROPIC_API_KEY",
     "possibleValues": "",
-    "description": "Environment variable containing the Anthropic credential.",
-    "sensitive": true
+    "description": "Environment variable containing the Anthropic credential."
   },
   {
     "section": "Pilot",
@@ -2366,10 +2391,9 @@
     "key": "pilot.ai.gemini.apiKeyEnvironmentVariable",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "GEMINI_API_KEY",
     "possibleValues": "",
-    "description": "Environment variable containing the Gemini credential.",
-    "sensitive": true
+    "description": "Environment variable containing the Gemini credential."
   },
   {
     "section": "Pilot",
@@ -2403,10 +2427,9 @@
     "key": "pilot.ai.github.apiKeyEnvironmentVariable",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "GITHUB_TOKEN",
     "possibleValues": "",
-    "description": "Environment variable containing the GitHub credential.",
-    "sensitive": true
+    "description": "Environment variable containing the GitHub credential."
   },
   {
     "section": "Pilot",
@@ -2451,28 +2474,25 @@
     "type": "text",
     "defaultValue": "",
     "possibleValues": "",
-    "description": "Optional environment variable containing an on-prem Ollama gateway credential.",
-    "sensitive": true
+    "description": "Optional environment variable containing an on-prem Ollama gateway credential."
   },
   {
     "section": "Pilot",
     "key": "pilot.ai.ollama.apiKeyHeader",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "Authorization",
     "possibleValues": "",
-    "description": "Optional Ollama gateway credential header.",
-    "sensitive": true
+    "description": "Optional Ollama gateway credential header."
   },
   {
     "section": "Pilot",
     "key": "pilot.ai.ollama.apiKeyPrefix",
     "targetFile": "custom.properties",
     "type": "text",
-    "defaultValue": "",
+    "defaultValue": "Bearer ",
     "possibleValues": "",
-    "description": "Optional Ollama gateway credential prefix.",
-    "sensitive": true
+    "description": "Optional Ollama gateway credential prefix."
   },
   {
     "section": "Paths",

--- a/tests/generate-properties-catalog-regex.test.js
+++ b/tests/generate-properties-catalog-regex.test.js
@@ -14,8 +14,74 @@ const {pathToFileURL} = require('node:url');
 
 async function main() {
   const modUrl = pathToFileURL(path.join(__dirname, '..', 'scripts', 'generate-properties-catalog.mjs')).href;
-  const {parseJavaSource} = await import(modUrl);
+  const {parseJavaSource, isSensitive, parseMdxDefaultsTablesFromContent} = await import(modUrl);
   assert.ok(typeof parseJavaSource === 'function', 'generate-properties-catalog.mjs must export parseJavaSource for testing');
+  assert.ok(typeof isSensitive === 'function', 'generate-properties-catalog.mjs must export isSensitive for testing');
+  assert.ok(typeof parseMdxDefaultsTablesFromContent === 'function', 'generate-properties-catalog.mjs must export parseMdxDefaultsTablesFromContent for testing');
+
+  // --- Regression guard: PropertiesList.mdx's section headers are `## Name` (h2), not `### Name`
+  // (h3) -- confirmed unchanged back to the commit that introduced this generator (#819). A
+  // section-header regex anchored on `###` never matches any section, so parseMdxDefaultsTables's
+  // per-section "Default Values" table lookup is silently empty and the generator falls back to
+  // humanized/javadoc descriptions for every property instead of reusing the richer hand-written
+  // mdx prose it exists to reuse (see this file's own header comment, source-of-truth order #2).
+  const mdxSnippet = `## Platform
+
+- Platform properties.
+
+<Tabs groupId="PropertyTypes" queryString="Platform">
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name | Default Value | Possible Values | Description |
+| -------------- | -------------- | ---------------- | ------------------------------ |
+| SHAFT.CrossBrowserMode | \`off\` | \`off\`, \`sequential\` | Rich hand-written description reused from mdx. |
+
+  </TabItem>
+</Tabs>
+
+## Web
+
+<Tabs groupId="PropertyTypes" queryString="Web">
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name | Default Value | Possible Values | Description |
+| -------------- | -------------- | ---------------- | ------------------------------ |
+| baseURL | \` \` | | Base URL description. |
+
+  </TabItem>
+</Tabs>
+`;
+  const mdxLookup = parseMdxDefaultsTablesFromContent(mdxSnippet);
+  assert.strictEqual(mdxLookup.size, 2, `Expected 2 rows parsed from '## '-headed mdx sections, got ${mdxLookup.size} -- the section-header regex must match '## Name' (h2), not '### Name' (h3)`);
+  assert.strictEqual(mdxLookup.get('SHAFT.CrossBrowserMode')?.description, 'Rich hand-written description reused from mdx.',
+    'parseMdxDefaultsTablesFromContent must capture the Default Values row for a key under an h2 (## ) section header');
+
+  // --- Regression guard for #829: isSensitive() flags any key containing "apikey", which wrongly
+  // blanked the catalog defaultValue for Pilot's *.apiKeyEnvironmentVariable / apiKeyHeader /
+  // apiKeyPrefix properties -- their real Java @DefaultValue is an env-var/header *name*
+  // (OPENAI_API_KEY, Authorization, "Bearer ", ...), a credential *pointer*, not the credential
+  // itself. These must NOT be flagged sensitive, across every current Pilot provider.
+  for (const nonSecretKey of [
+    'pilot.ai.openai.apiKeyEnvironmentVariable',
+    'pilot.ai.anthropic.apiKeyEnvironmentVariable',
+    'pilot.ai.gemini.apiKeyEnvironmentVariable',
+    'pilot.ai.github.apiKeyEnvironmentVariable',
+    'pilot.ai.ollama.apiKeyEnvironmentVariable',
+    'pilot.ai.ollama.apiKeyHeader',
+    'pilot.ai.ollama.apiKeyPrefix',
+  ]) {
+    assert.strictEqual(isSensitive(nonSecretKey), false,
+      `${nonSecretKey} references where a credential lives (env var/header/prefix name), not the credential itself -- must not be flagged sensitive (#829)`);
+  }
+
+  // Genuine secret-valued keys must still be blanked -- this fix must not weaken real detection.
+  for (const secretKey of [
+    'applitoolsApiKey', 'browserStack.accessKey', 'browserStack.userName', 'LambdaTest.accessKey',
+    'ga4ApiSecret', 'authorization', 'tinkey.kms.credentialPath',
+  ]) {
+    assert.strictEqual(isSensitive(secretKey), true,
+      `${secretKey} holds/points at a genuine credential and must still be flagged sensitive`);
+  }
 
   // --- Behavioral pinning: representative snippet covering the exact shape CodeQL's alert
   // targets -- a `//` line comment between `@DefaultValue(...)` and the getter -- plus a blank

--- a/tests/properties-catalog.test.js
+++ b/tests/properties-catalog.test.js
@@ -80,4 +80,34 @@ for (const [tokenCountKey, expectedDefault, expectedType] of [
   assert(property.type === expectedType, `${tokenCountKey} must have type '${expectedType}', got '${property.type}'`);
 }
 
+// Non-sensitive credential-pointer regression guard for #829: these keys contain "apikey" but
+// hold the *name* of an environment variable/header/prefix that points at a credential, not the
+// credential itself, so their real Java defaults must be published, not blanked.
+for (const [pointerKey, expectedDefault] of [
+  ['pilot.ai.openai.apiKeyEnvironmentVariable', 'OPENAI_API_KEY'],
+  ['pilot.ai.anthropic.apiKeyEnvironmentVariable', 'ANTHROPIC_API_KEY'],
+  ['pilot.ai.gemini.apiKeyEnvironmentVariable', 'GEMINI_API_KEY'],
+  ['pilot.ai.github.apiKeyEnvironmentVariable', 'GITHUB_TOKEN'],
+  ['pilot.ai.ollama.apiKeyHeader', 'Authorization'],
+  ['pilot.ai.ollama.apiKeyPrefix', 'Bearer '],
+]) {
+  const property = catalog.find((p) => p.key === pointerKey);
+  assert(property, `Missing expected non-sensitive credential-pointer property ${pointerKey}`);
+  assert(property.sensitive !== true, `${pointerKey} must NOT be flagged sensitive (#829): it names where a credential lives, not the credential itself`);
+  assert(property.defaultValue === expectedDefault, `${pointerKey} must publish its real default '${expectedDefault}', got '${property.defaultValue}'`);
+}
+
+// Lazy-loading readiness properties shipped by SHAFT_ENGINE #3775 (layered JS + advisory BiDi
+// readiness, and the explicit scrollToLoadAll() scroll sweep) must be present with their defaults.
+for (const [lazyKey, expectedDefault] of [
+  ['waitForLazyLoadingTimeout', '30'],
+  ['lazyLoadingPollingIntervalMillis', '200'],
+  ['lazyLoadingDomStabilityQuietWindowMillis', '0'],
+  ['lazyLoadingScrollSweepMaxSteps', '20'],
+]) {
+  const property = catalog.find((p) => p.key === lazyKey);
+  assert(property, `Missing expected lazy-loading property ${lazyKey} (SHAFT_ENGINE #3775)`);
+  assert(property.defaultValue === expectedDefault, `${lazyKey} must publish its real default '${expectedDefault}', got '${property.defaultValue}'`);
+}
+
 console.log(`Properties catalog checks passed (${catalog.length} properties, ${new Set(catalog.map((p) => p.section)).size} sections).`);


### PR DESCRIPTION
## Summary

Documentation companion to SHAFT_ENGINE PR [#3775](https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3775) (layered lazy-loading readiness, merged to main), which also fixes #829.

1. **#829 heuristic fix (TDD)**: `scripts/generate-properties-catalog.mjs`'s `isSensitive()` flagged any key containing `apikey`, which blanked the real Java defaults for `pilot.ai.<provider>.apiKeyEnvironmentVariable` / `.apiKeyHeader` / `.apiKeyPrefix` — these are credential *pointers* (env-var names, header names, prefixes like `Bearer `), not the credential itself. Added a `NON_SENSITIVE_KEY_SUFFIXES` rule (suffix-based, covers every current and future Pilot provider) with a failing-first regression test in `tests/generate-properties-catalog-regex.test.js`, plus a catalog-level regression guard in `tests/properties-catalog.test.js`. Genuine secrets (`applitoolsApiKey`, `browserStack.accessKey`, `authorization`, etc.) remain blanked and flagged sensitive — covered by both the pre-existing and new tests.

2. **Bonus fix found in-path**: while regenerating the catalog to verify #829, discovered `parseMdxDefaultsTables`'s section-header regex expected `### Name` (h3) but `PropertiesList.mdx` has always used `## Name` (h2) — confirmed unchanged back to the commit that introduced the generator. This silently emptied `mdxLookup`, so the generator discarded every rich hand-written mdx description in favor of humanized/javadoc fallbacks on every run. Refactored `parseMdxDefaultsTables` into a pure, testable `parseMdxDefaultsTablesFromContent` (TDD, same pattern as `parseJavaSource`) and fixed the regex.

3. **Catalog regen**: ran `yarn generate:properties-catalog` against the merged SHAFT_ENGINE tree (commit `88f85f8648`). Picks up the 3 new lazy-loading properties from #3775 (`lazyLoadingPollingIntervalMillis`, `lazyLoadingDomStabilityQuietWindowMillis`, `lazyLoadingScrollSweepMaxSteps`) and restores the #829-fixed defaults for the 7 previously-blanked `apiKey*` keys. `--check` is idempotent after regen.

4. **PropertiesList.mdx backfill**: added rows for the 3 new lazy-loading properties (Timeouts section) and restored real default values for the 7 `pilot.ai.*.apiKey*` rows (Pilot section). `tests/properties-list-coverage.test.js` is green with 0 exclusions.

5. **Wait-strategies guide**: `docs/testing/flakiness.mdx`'s "Automatic Synchronization" section now documents the layered lazy-loading readiness shipped in #3775 — the default JS readiness engine (with `lazyLoadingPollingIntervalMillis`), the opt-in DOM-stability quiet window (`lazyLoadingDomStabilityQuietWindowMillis`, off by default), the advisory BiDi network layer (gated on `platform.enableBiDi()`), and `driver.browser().scrollToLoadAll()` (bounded scroll sweep, `lazyLoadingScrollSweepMaxSteps`) with a code sample in SHAFT's fluent style.

## Test plan

- [x] `node tests/generate-properties-catalog-regex.test.js` — watched red before each fix (isSensitive suffix rule, mdx header regex), green after
- [x] `node tests/properties-catalog.test.js` — green, including new #829/lazy-loading regression guards
- [x] `node tests/properties-list-coverage.test.js` — green, 0 exclusions
- [x] `yarn test` — full suite green (docs, homepage, history, release-template)
- [x] `yarn build` — green (pre-existing untruncated-blog-post warnings only, unrelated to this change)

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk