### PR TITLE
Fix hero wordmark WCAG AA contrast with a deep-alt backdrop plate

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -58,6 +58,9 @@
   display: block;
   width: max-content;
   margin: 0 auto 1.2rem;
+  padding: 0.3rem 0.9rem;
+  background: var(--site-color-deep-alt);
+  border-radius: 999px;
   color: var(--site-color-primary);
   font-size: var(--site-font-card-title-lg);
   font-weight: var(--site-font-weight-bold);

--- a/tests/e2e/hero-contrast.spec.js
+++ b/tests/e2e/hero-contrast.spec.js
@@ -1,0 +1,113 @@
+const {expect, test} = require('@playwright/test');
+
+// Regression guard for #837: `.heroBrand` (the "SHAFT" wordmark) sits on the hero's
+// composited/gradient background (src/pages/index.module.css .hero), which
+// tests/design-contrast.test.js structurally cannot model -- that test only audits
+// solid (fg token, bg token) pairs parsed straight out of src/css/custom.css, and has
+// no way to represent "the actual blended pixel color behind this element" for a
+// multi-layer gradient background. This test closes that gap by rendering the real
+// homepage and pixel-sampling the actual composited output via Playwright screenshot +
+// canvas getImageData, the same technique used to originally discover the failure.
+
+function relativeLuminance({r, g, b}) {
+  const channel = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const [rl, gl, bl] = [r, g, b].map(channel);
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrastRatio(a, b) {
+  const lA = relativeLuminance(a);
+  const lB = relativeLuminance(b);
+  const [lighter, darker] = lA >= lB ? [lA, lB] : [lB, lA];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// WCAG 2.x SC 1.4.3: 3:1 for text >=24px, or >=18.66px (14pt) at bold (>=700) weight;
+// 4.5:1 otherwise. Computed dynamically (not hardcoded) so a future font-size/weight
+// change that drops the wordmark out of the "large text" exemption is also caught.
+function requiredRatio(fontSizePx, fontWeight) {
+  const isBold = fontWeight >= 700;
+  const isLarge = fontSizePx >= 24 || (isBold && fontSizePx >= 18.66);
+  return isLarge ? 3 : 4.5;
+}
+
+async function measureHeroBrandContrast(page) {
+  const glyph = await page.evaluate(() => {
+    const el = document.querySelector('a[class*="heroBrand"]');
+    const rect = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    const colorMatch = style.color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    return {
+      rect: {x: rect.x, y: rect.y, width: rect.width, height: rect.height},
+      fg: {r: +colorMatch[1], g: +colorMatch[2], b: +colorMatch[3]},
+      fontSizePx: parseFloat(style.fontSize),
+      fontWeight: parseFloat(style.fontWeight),
+    };
+  });
+
+  const screenshot = (await page.screenshot()).toString('base64');
+
+  // Sample the plate background at the horizontal midpoint of the top and bottom
+  // padding rows: safely inside the pill's straight (non-rounded) edge and clear of
+  // the glyph ink, regardless of the wordmark's exact letterforms.
+  const bg = await page.evaluate(async ({screenshot, rect}) => {
+    const img = new Image();
+    img.src = `data:image/png;base64,${screenshot}`;
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+    });
+    const canvas = document.createElement('canvas');
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+
+    const pixelAt = (x, y) => {
+      const d = ctx.getImageData(Math.round(x), Math.round(y), 1, 1).data;
+      return {r: d[0], g: d[1], b: d[2]};
+    };
+
+    const midX = rect.x + rect.width / 2;
+    return [pixelAt(midX, rect.y + 2), pixelAt(midX, rect.y + rect.height - 2)];
+  }, {screenshot, rect: glyph.rect});
+
+  const bgAvg = {
+    r: (bg[0].r + bg[1].r) / 2,
+    g: (bg[0].g + bg[1].g) / 2,
+    b: (bg[0].b + bg[1].b) / 2,
+  };
+
+  return {
+    ratio: contrastRatio(glyph.fg, bgAvg),
+    required: requiredRatio(glyph.fontSizePx, glyph.fontWeight),
+    fg: glyph.fg,
+    bg: bgAvg,
+  };
+}
+
+test('hero wordmark clears WCAG AA contrast against its real composited background', async ({page}) => {
+  await page.setViewportSize({width: 1280, height: 900});
+
+  await page.goto('/');
+  const light = await measureHeroBrandContrast(page);
+  expect(
+    light.ratio,
+    `light theme: fg rgb(${light.fg.r},${light.fg.g},${light.fg.b}) on measured bg ` +
+      `rgb(${light.bg.r.toFixed(1)},${light.bg.g.toFixed(1)},${light.bg.b.toFixed(1)}) = ` +
+      `${light.ratio.toFixed(2)}:1, needs >= ${light.required}:1`,
+  ).toBeGreaterThanOrEqual(light.required);
+
+  await page.getByLabel(/Switch between dark and light mode/).click();
+  await page.waitForTimeout(200);
+  const dark = await measureHeroBrandContrast(page);
+  expect(
+    dark.ratio,
+    `dark theme: fg rgb(${dark.fg.r},${dark.fg.g},${dark.fg.b}) on measured bg ` +
+      `rgb(${dark.bg.r.toFixed(1)},${dark.bg.g.toFixed(1)},${dark.bg.b.toFixed(1)}) = ` +
+      `${dark.ratio.toFixed(2)}:1, needs >= ${dark.required}:1`,
+  ).toBeGreaterThanOrEqual(dark.required);
+});


### PR DESCRIPTION
## Summary

Closes #837.

`.heroBrand` (the "SHAFT" wordmark, top of the hero section) sits on `.hero`'s composited/gradient background (`src/pages/index.module.css:1-13`), which `tests/design-contrast.test.js` structurally can't audit — that test only checks solid `(fg token, bg token)` pairs parsed out of `src/css/custom.css`, and has no way to represent "the actual blended pixel color behind this element" for a multi-layer gradient.

## Measurement

Text is `21.6px` / `font-weight: 700` (`--site-font-card-title-lg` = `1.35rem`, `--site-font-weight-bold` = `700`), which clears WCAG's large-text cutoff (>=18.66px bold), so the **3:1 large-text threshold** applies, not 4.5:1.

Measured by rendering the real homepage (`yarn build` + `yarn serve`) and pixel-sampling the actual composited background behind the wordmark via Playwright screenshot + canvas `getImageData`:

| Theme | Before | After |
|---|---|---|
| Light | fg `#006ec0` on measured bg `~rgb(21,58,82)` = **2.26:1** (FAIL, needs 3:1) | fg `#006ec0` on plate `#181f2a` = **3.15:1** (PASS) |
| Dark | fg `#4cc2ff` on measured bg `~rgb(23,58,80)` = **6.00:1** (PASS) | fg `#4cc2ff` on plate `#102a31` = **7.49:1** (PASS, improved) |

(Light-theme before-ratio is close to, not identical to, the issue's ~2.28:1 — both are real measurements of the same gradient at slightly different sample offsets; both clearly fail 3:1.)

## Fix

`.heroBrand` gets a solid `background: var(--site-color-deep-alt)` pill (padding + `border-radius: 999px`) instead of a color change. This puts the wordmark on a deterministic solid background instead of the gradient, using only the two `--site-color-*` tokens already in the approved palette (`primary` text unchanged, `deep-alt` as the plate) — no new colors introduced, brand blue preserved exactly. Visually this reads as a small "SHAFT" badge at the top of the hero rather than bare text directly on the gradient.

## Regression guard

`design-contrast.test.js`'s token-pair model can't represent gradient/composited backgrounds (that's why this escaped it — see #837's history with #832). Added `tests/e2e/hero-contrast.spec.js`, wired into the existing Playwright e2e harness (`yarn test:playwright` / `npx playwright test`, same harness as `tests/e2e/homepage.spec.js`). It renders the homepage, screenshots it, pixel-samples the real composited background behind `.heroBrand` via canvas `getImageData`, computes the WCAG ratio, and asserts it clears the applicable threshold (computed dynamically from measured font-size/weight, not hardcoded) — in both light and dark theme (toggled via the real theme-switch button).

Confirmed RED against the unfixed CSS first (`2.26:1`, error message matched the pre-fix measurement), then GREEN after the fix.

**Enforcement gap**: this new spec runs via `npx playwright test` / `yarn test:playwright`, not via the default `yarn test` (which only runs `tests/*.test.js`, matching the existing split — `homepage.spec.js` isn't in `yarn test` either). CI/pre-merge gating on `yarn test:playwright` is unchanged by this PR; if it isn't already a required check, that's a pre-existing gap this PR doesn't widen.

## Adjacent finding (not fixed here, per #837's own note)

`.statusChip` and `.audienceLane h2` also use `color: var(--site-color-primary)` over partially-transparent backgrounds layered on `deep`/`deep-alt` (same structural root cause) — `#837` flagged these as "worth including in the same follow-up" but this PR's scope was the wordmark only, per the delegate spec. Not measured or touched here.

## Verification

- `yarn build` — green
- `yarn test` — green (design-contrast, homepage-performance, chat-history, release-template all pass)
- `npx playwright test` — 4/4 green, including the new `hero-contrast.spec.js`
- Before/after screenshots captured locally (not committed — throwaway evidence, same convention as PR #838)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk