### PR TITLE
Sidebar metadata cleanup: dead sidebar_position + reference-areas link text

### DIFF
--- a/docs/agentic/capture.md
+++ b/docs/agentic/capture.md
@@ -3,7 +3,6 @@ id: capture
 title: Record tests with Capture
 description: Record browser activity and generate reviewable deterministic TestNG source.
 slug: /agentic/capture
-sidebar_position: 4
 tags: [capture, recording, generation]
 ---
 

--- a/docs/agentic/cli.md
+++ b/docs/agentic/cli.md
@@ -3,7 +3,6 @@ id: cli
 title: shaft-cli command line
 description: Run all shaft-mcp tools from the command line with one-shot commands or a persistent session.
 slug: /agentic/cli
-sidebar_position: 3
 tags: [cli, mcp, agents, guide, capture, doctor]
 ---
 

--- a/docs/agentic/doctor.mdx
+++ b/docs/agentic/doctor.mdx
@@ -3,7 +3,6 @@ id: doctor
 title: Diagnose failures with Doctor
 description: Build deterministic, portable diagnoses from explicitly allowlisted test evidence.
 slug: /agentic/doctor
-sidebar_position: 5
 tags: [doctor, diagnosis, allure, mcp]
 ---
 

--- a/docs/agentic/heal.mdx
+++ b/docs/agentic/heal.mdx
@@ -3,7 +3,6 @@ id: heal
 title: Recover locators with Heal
 description: Enable deterministic, explainable WebDriver locator recovery.
 slug: /agentic/heal
-sidebar_position: 6
 tags: [heal, locator, webdriver]
 ---
 

--- a/docs/agentic/intellij.md
+++ b/docs/agentic/intellij.md
@@ -3,7 +3,6 @@ id: intellij
 title: IntelliJ IDEA plugin
 description: Use the SHAFT coding partner front door for Assistant, Coding Partner, MCP tools, Recorder, Doctor, Healer, Inspector, Projects, and Guide search from IntelliJ IDEA.
 slug: /agentic/intellij
-sidebar_position: 3
 tags: [intellij, idea, mcp, recorder, doctor, healer, inspector, projects, assistant]
 ---
 

--- a/docs/agentic/mcp.mdx
+++ b/docs/agentic/mcp.mdx
@@ -3,7 +3,6 @@ id: mcp
 title: Connect shaft-mcp
 description: Run SHAFT browser, guide search, Capture, Doctor, and healer tools from Codex, Copilot, and other MCP clients.
 slug: /agentic/mcp
-sidebar_position: 2
 tags: [mcp, codex, copilot, chatgpt, claude, gemini, agents, guide, locators, api, cli]
 ---
 

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -3,7 +3,6 @@ id: overview
 title: Agentic testing
 description: Understand how the IntelliJ plugin, MCP, Pilot, Capture, Doctor, and Heal fit together.
 slug: /agentic/overview
-sidebar_position: 1
 tags: [mcp, pilot, capture, doctor, heal]
 ---
 

--- a/docs/agentic/pilot.md
+++ b/docs/agentic/pilot.md
@@ -3,7 +3,6 @@ id: pilot
 title: SHAFT Pilot
 description: Capture, generation, diagnosis, reviewed repairs, and MCP interoperability — plus downloadable credential-free Pilot example assets.
 slug: /agentic/pilot
-sidebar_position: 3
 keywords: [SHAFT, pilot, capture, doctor, mcp, examples, pilot examples, credential-free, repair proposal, ollama advisory]
 tags: [pilot, capture, doctor, mcp, examples]
 ---

--- a/docs/agentic/providers.md
+++ b/docs/agentic/providers.md
@@ -3,7 +3,6 @@ id: providers
 title: Optional AI providers
 description: Consent, redaction, budgets, and provider controls for optional SHAFT AI advice.
 slug: /agentic/providers
-sidebar_position: 7
 tags: [ai, privacy, providers]
 ---
 

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -3,7 +3,6 @@ id: architecture
 title: Architecture
 description: SHAFT runtime, module, facade, and agent integration architecture — plus where SHAFT fits in a general test automation stack and the engine-vs-framework distinction.
 slug: /features/architecture
-sidebar_position: 1
 keywords: [SHAFT, architecture, test automation architecture, framework layers, engine vs framework, modules, facade]
 tags: [architecture, modules, best-practices, framework-design]
 ---

--- a/docs/features/modules.md
+++ b/docs/features/modules.md
@@ -3,7 +3,6 @@ id: modules
 title: Features and modules
 description: Select the core engine and optional SHAFT modules by capability — plus the underlying technology stack and sponsors/adopters.
 slug: /features/modules
-sidebar_position: 2
 keywords: [SHAFT, features, modules, dependencies, technology, ecosystem, Selenium, Appium, REST Assured, TestNG, JUnit, Cucumber, Allure, partners, sponsors, adopters, community]
 tags: [features, modules, dependencies, technology, partners, sponsors, community]
 ---

--- a/docs/features/reporting.md
+++ b/docs/features/reporting.md
@@ -3,7 +3,6 @@ id: reporting
 title: Reporting and evidence
 description: How SHAFT records actions, screenshots, logs, and Allure results.
 slug: /features/reporting
-sidebar_position: 3
 tags: [reporting, allure, screenshots, evidence]
 ---
 

--- a/docs/features/test-automation-pillars.mdx
+++ b/docs/features/test-automation-pillars.mdx
@@ -3,7 +3,6 @@ id: test-automation-pillars
 title: Pillars of successful test automation
 description: How SHAFT helps teams build scalable, reliable, and maintainable test automation frameworks.
 slug: /features/test-automation-pillars
-sidebar_position: 2
 tags: [architecture, scalability, reliability, maintainability]
 ---
 

--- a/docs/integrations/browserstack.md
+++ b/docs/integrations/browserstack.md
@@ -3,7 +3,6 @@ id: browserstack
 title: BrowserStack
 description: Choose direct BrowserStack sessions or the optional SDK orchestration module.
 slug: /integrations/browserstack
-sidebar_position: 1
 tags: [browserstack, cloud]
 ---
 

--- a/docs/integrations/desktop-and-video.md
+++ b/docs/integrations/desktop-and-video.md
@@ -3,7 +3,6 @@ id: desktop-and-video
 title: Desktop and video
 description: Optional local desktop recording and SikuliX image-based desktop automation.
 slug: /integrations/desktop-and-video
-sidebar_position: 3
 keywords: [SHAFT, video recording, shaft-video, desktop recording, FFmpeg, SikuliX, shaft-sikulix, image automation, desktop automation]
 tags: [video, recording, sikulix, desktop, image-automation]
 ---

--- a/docs/integrations/visual.md
+++ b/docs/integrations/visual.md
@@ -3,7 +3,6 @@ id: visual
 title: Visual testing
 description: Add reference-image assertions and image-based touch operations.
 slug: /integrations/visual
-sidebar_position: 2
 keywords: [SHAFT, visual testing, image comparison, visual regression, OpenCV, Applitools Eyes, matchesReferenceImage, matchesScreenshot, VisualValidationEngine, screenshot comparison]
 tags: [visual, opencv, applitools, visual-testing, image-comparison]
 ---

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -30,10 +30,10 @@ guides.
 
 | Area | Reference |
 |---|---|
-| Browser and element actions | [GUI actions](/docs/reference/actions/GUI/Browser_Actions) |
+| Browser and element actions | [GUI Actions](/docs/reference/actions/GUI/Browser_Actions) |
 | REST API | [API request builder](/docs/reference/actions/API/Request_Builder) |
-| CLI | [Terminal actions](/docs/reference/actions/CLI/Terminal_Actions) |
-| Database | [Database actions](/docs/reference/actions/DB/DB_Actions) |
+| CLI | [CLI Actions](/docs/reference/actions/CLI/Terminal_Actions) |
+| Database | [Database Actions](/docs/reference/actions/DB/DB_Actions) |
 | Configuration | [Property types](/docs/reference/properties/PropertyTypes) |
 | Assertions | [Validations](/docs/reference/actions/Validations) |
 | Engineering practices | [Solution design](/docs/reference/guides/Solution_Design) |

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -20,7 +20,7 @@ guides.
 | Open a browser, click, type, wait, and assert | [Web testing](/docs/testing/web) |
 | Choose resilient web locators | [Web locator strategy](/docs/testing/web#locator-strategy) |
 | Send REST requests and validate responses | [API testing](/docs/testing/api) |
-| Configure browser, API, mobile, retry, or reporting behavior | [Property types](/docs/reference/properties/PropertyTypes) |
+| Configure browser, API, mobile, retry, or reporting behavior | [Property Types](/docs/reference/properties/PropertyTypes) |
 | Generate a custom `.properties` file | [Config Generator tab](/docs/reference/properties/PropertiesList?PropertyTypes=generator) on the Properties Reference |
 | Attach evidence and understand reports | [Reporting](/docs/reference/reporting/) |
 | Diagnose flaky or failed runs | [How SHAFT reduces flakiness](/docs/testing/flakiness) |

--- a/docs/start/installation.mdx
+++ b/docs/start/installation.mdx
@@ -3,7 +3,6 @@ id: installation
 title: Install SHAFT
 description: Generate a new SHAFT project or upgrade an existing automation project.
 slug: /start/installation
-sidebar_position: 2
 tags: [installation, maven, java-25]
 ---
 

--- a/docs/start/overview.mdx
+++ b/docs/start/overview.mdx
@@ -3,7 +3,6 @@ id: overview
 title: SHAFT at a glance
 description: One Java automation engine for Web, Mobile, API, CLI, and Database testing.
 slug: /start/overview
-sidebar_position: 1
 tags: [overview, web, mobile, api, cli, database]
 ---
 

--- a/docs/start/quick-start.mdx
+++ b/docs/start/quick-start.mdx
@@ -3,7 +3,6 @@ id: quick-start
 title: Quick start
 description: Choose the right SHAFT setup path, then run a first test.
 slug: /start/quick-start
-sidebar_position: 3
 tags: [quick-start, example]
 ---
 

--- a/docs/start/upgrade.mdx
+++ b/docs/start/upgrade.mdx
@@ -3,7 +3,6 @@ id: upgrade
 title: Upgrade to modular SHAFT
 description: Transactionally migrate legacy or native Maven projects to modular SHAFT.
 slug: /start/upgrade
-sidebar_position: 4
 tags: [upgrade, migration, maven]
 ---
 

--- a/docs/testing/api.mdx
+++ b/docs/testing/api.mdx
@@ -3,7 +3,6 @@ id: api
 title: API testing
 description: Build, execute, inspect, and assert REST API requests with SHAFT.
 slug: /testing/api
-sidebar_position: 3
 tags: [api, rest-assured, example]
 ---
 

--- a/docs/testing/cli.md
+++ b/docs/testing/cli.md
@@ -3,7 +3,6 @@ id: cli
 title: CLI testing
 description: Execute and validate local, Docker, and SSH commands with SHAFT.
 slug: /testing/cli
-sidebar_position: 4
 tags: [cli, terminal, docker, ssh]
 ---
 

--- a/docs/testing/contracts.mdx
+++ b/docs/testing/contracts.mdx
@@ -3,7 +3,6 @@ id: contracts
 title: UI and API contract replay
 description: Record browser and SHAFT.API traffic, replay captured responses, and validate live traffic against deterministic contracts.
 slug: /testing/contracts
-sidebar_position: 2
 tags: [web, api, contracts, replay]
 ---
 

--- a/docs/testing/database.md
+++ b/docs/testing/database.md
@@ -3,7 +3,6 @@ id: database
 title: Database testing
 description: Connect, query, and validate databases through SHAFT.
 slug: /testing/database
-sidebar_position: 5
 tags: [database, jdbc]
 ---
 

--- a/docs/testing/flakiness.mdx
+++ b/docs/testing/flakiness.mdx
@@ -3,7 +3,6 @@ id: flakiness
 title: How SHAFT reduces flakiness
 description: How SHAFT reduces common automation flakiness through semantic locators, synchronization, retry evidence, and optional locator recovery.
 slug: /testing/flakiness
-sidebar_position: 2
 tags: [flakiness, synchronization, locators, retry, heal]
 ---
 

--- a/docs/testing/mobile.md
+++ b/docs/testing/mobile.md
@@ -3,7 +3,6 @@ id: mobile
 title: Mobile and Flutter testing
 description: Configure Appium and automate Android, iOS, mobile web, and Flutter applications.
 slug: /testing/mobile
-sidebar_position: 2
 tags: [mobile, appium, flutter]
 ---
 

--- a/docs/testing/web.mdx
+++ b/docs/testing/web.mdx
@@ -3,7 +3,6 @@ id: web
 title: Web testing
 description: A minimal SHAFT browser test with lifecycle, actions, and assertions.
 slug: /testing/web
-sidebar_position: 1
 tags: [web, selenium, example]
 ---
 


### PR DESCRIPTION
## Summary

Full mechanical consistency pass over the two items reported (not fixed) by the IA PR C delegate (#852), extended per orchestrator review to close out both adjacent findings from that same PR in one PR rather than a paper trail of follow-up issues:

- Remove dead `sidebar_position` frontmatter from all 27 docs whose category uses an explicit `sidebars.js` `items` array — `docs/testing/*` (7), `docs/agentic/*` (9), `docs/features/*` (4), `docs/start/*` (4, including `upgrade.mdx`, positioned by an explicit id reference in `Reference` regardless of its own frontmatter), `docs/integrations/*` (3). Explicit arrays always win over position-based ordering, so the key never influenced sidebar order in any of these.
- Align `docs/reference/overview.md`'s link text with the actual target labels:
  - "Reference areas" table: `GUI actions` → `GUI Actions`, `Terminal actions` → `CLI Actions` (the real category name — there is no "Terminal" category), `Database actions` → `Database Actions`, matching the Title Case `_category_.json` labels PR #852 introduced.
  - "I want to..." table: `Property types` → `Property Types`, matching the linked page's own `title:`.

## Scope notes

- `docs/reference/` is autogenerated (`{type: 'autogenerated', dirName: 'reference'}`), so `docs/reference/overview.md`'s own `sidebar_position: 1` is live and was left untouched.
- `API request builder`, `Validations`, and `Solution design` in the "Reference areas" table were left as-is — not named in the issue/PR #852's adjacent-finding note, and they don't follow the "X actions"/category-echo pattern the others did.

## Evidence

- **Deadness proof (both commits):** built the site before and after each removal batch. Every affected page's HTML differed only in `runtime~main.<hash>.js` and (for the second batch) `main.<hash>.js` — webpack chunk hashes that are identical across every page within one build but shift with *any* site-wide content edit (confirmed: same two hashes appear on every page in a given build, e.g. `agentic/overview.html`, `start/quick-start.html`, `testing/mobile.html` all share the same `main.<hash>.js`). Normalizing those hashes out of both builds made every page byte-identical (`diff -rq` exit 0) — proof the frontmatter removal changed nothing about rendered sidebar order or page content.
- `yarn build` — green on both commits, `onBrokenLinks`/`onBrokenAnchors`/`onBrokenMarkdownLinks: 'throw'` gates pass.
- `yarn test` — green on both commits (docs-quality, docs-loader, properties coverage, design-contrast, doc-duplicates, homepage, chat-history, release-blog-template).

## Test plan

- [x] `yarn build` succeeds with broken-link/anchor gates on
- [x] `yarn test` passes
- [x] Byte-identical (post-hash-normalization) built HTML for all 27 affected docs, before vs. after removing `sidebar_position`
- [x] `docs/reference/overview.md` link text in both tables matches current `_category_.json` labels / linked-page titles

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk