### PR TITLE
Full landing-page composited-contrast audit (#851): fix .eyebrow

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -101,12 +101,20 @@
   content: '';
 }
 
+/* Repointed from --site-color-muted: unlike heroBrand/statusChip/audienceLane,
+   every real .eyebrow usage sits on the normal flipping Infima page background
+   (pathSection/surfaceSection/proof/allureSection/agentBand), not the fixed-dark
+   deep/deep-alt family --site-color-muted is designed to pair with. In light
+   theme that read pale muted-blue-grey text on a near-white background
+   (~1.3-1.5:1, see #851). --ifm-color-emphasis-800 is the token this same file
+   already uses for secondary text on these exact sections (.pathCard span,
+   .allureFrame figcaption, .loopStep span) and adapts correctly per theme. */
 .eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
   margin-bottom: 0.9rem;
-  color: var(--site-color-muted);
+  color: var(--ifm-color-emphasis-800);
   font-family: var(--ifm-font-family-monospace);
   font-size: var(--site-font-small);
   font-weight: var(--site-font-weight-medium);

--- a/tests/e2e/composited-contrast.spec.js
+++ b/tests/e2e/composited-contrast.spec.js
@@ -1,25 +1,48 @@
 const {expect, test} = require('@playwright/test');
 
-// Regression guard for #837. Three elements render brand-primary text over a
-// composited/blended background (a multi-layer CSS gradient, or a translucent
-// rgba() fill stacked on one) that tests/design-contrast.test.js structurally
-// cannot audit -- that test only checks solid (fg token, bg token) pairs parsed
+// Regression guard for #837 and #851. Several elements render text over a
+// composited/blended background (a multi-layer CSS gradient, a translucent
+// rgba() fill stacked on one, or an element's own opaque fill sitting on a
+// gradient ancestor) that tests/design-contrast.test.js structurally cannot
+// audit -- that test only checks solid (fg token, bg token) pairs parsed
 // straight out of src/css/custom.css, with no way to represent "the actual
-// blended pixel color behind this element" once gradients/opacity are involved:
+// blended pixel color behind this element" once gradients/opacity/an element's
+// own fill are involved. Guards here cover the elements #851's full-page audit
+// found most at risk of a silent regression:
 //
 //   - `.heroBrand` (src/pages/index.module.css .heroBrand) -- the "SHAFT"
-//     wordmark on `.hero`'s composited gradient/glow background.
+//     wordmark on `.hero`'s composited gradient/glow background. (#837)
 //   - `.statusChip` (src/pages/index.module.css .statusChip) -- the "Pass" /
 //     "evidence attached" pill, whose own rgba(primary, 0.1) fill sits on
-//     `.codePanel`/`.handledPanel`'s deep-alt background.
+//     `.codePanel`/`.handledPanel`'s deep-alt background. (#837)
 //   - `.audienceLane h2` (src/pages/index.module.css .audienceLane) -- lane
 //     titles on a translucent rgba(deep-alt, 0.5) fill over `.audienceSection`'s
-//     deep-to-deep-alt gradient.
+//     deep-to-deep-alt gradient. (#837)
+//   - `.eyebrow` (src/pages/index.module.css .eyebrow) -- section kicker labels
+//     ("Guided paths", "Testing surfaces", etc.) on the normal flipping Infima
+//     page background layered with a subtle primary-tinted gradient. Found
+//     genuinely failing in light theme (~1.3-1.5:1) during #851's audit --
+//     `--site-color-muted` is designed for the fixed-dark deep/deep-alt family,
+//     not this flipping background. Repointed to `--ifm-color-emphasis-800`.
+//   - `.heroMeta` span (src/pages/index.module.css .heroMeta) -- the
+//     "io.github.shafthq : shaft-engine · Java 25 · ..." coordinates line, a
+//     translucent rgba(muted, 0.82) fill on `.hero`'s composited background.
+//   - `.finalKicker` (src/pages/index.module.css .finalKicker) -- the
+//     "run complete · evidence attached · exit 0" line on `.finalCta`'s
+//     composited gradient/glow background (the same "always-dark" family as
+//     `.hero`, with its own radial-gradient glow layer).
+//   - hero `button--primary` CTA ("Start a new project") -- an element with
+//     its OWN opaque solid fill (Infima's button background, unrelated to the
+//     `--site-color-*` palette) sitting on `.hero`'s composited background;
+//     included because that "own opaque fill on a gradient ancestor" shape
+//     caused a real sampling bug during #851's audit (sampling just outside
+//     the button's box reads the hero backdrop, not the button's actual fill)
+//     and is worth guarding against the same mistake recurring.
 //
 // This closes that gap by rendering the real homepage and pixel-sampling the
 // actual composited output via Playwright screenshot + canvas getImageData --
 // the same technique used to originally discover the `.heroBrand` failure
-// (issue #837) and to measure the other two (#837 item 2).
+// (issue #837) and to run the full-page audit (#851).
 
 function relativeLuminance({r, g, b}) {
   const channel = (c) => {
@@ -151,6 +174,26 @@ async function assertClearsContrast(page, label, selector, samplePoints) {
   ).toBeGreaterThanOrEqual(dark.required);
 }
 
+// Default sampler for plain text with no background of its own: a thin sliver
+// just above and below the element's box, at horizontal center. Safe whenever
+// the element isn't its own filled/padded box (the common case: text painted
+// directly on an ancestor section's background).
+function adjacentSampler(rect) {
+  const cx = rect.x + rect.width / 2;
+  return [{x: cx, y: rect.y - 4}, {x: cx, y: rect.y + rect.height + 4}];
+}
+
+// Sampler for elements with their OWN filled box (button chrome, pill plates):
+// sampling just outside the box would read the ancestor's (different)
+// background instead of the element's real fill. Samples the left/right
+// padding gutters at vertical mid-height, inset far enough to clear icons/text.
+function interiorSampler(inset) {
+  return (rect) => {
+    const midY = rect.y + rect.height / 2;
+    return [{x: rect.x + inset, y: midY}, {x: rect.x + rect.width - inset, y: midY}];
+  };
+}
+
 test.beforeEach(async ({page}) => {
   await page.setViewportSize({width: 1280, height: 900});
   await page.goto('/');
@@ -188,4 +231,25 @@ test('audience lane heading clears WCAG AA contrast against its real composited 
     {x: rect.x + rect.width - 5, y: rect.y + 2},
   ];
   await assertClearsContrast(page, '.audienceLane h2', '[class*="audienceLane"] h2', samplePoints);
+});
+
+test('section eyebrow labels clear WCAG AA contrast against their real composited background', async ({page}) => {
+  await assertClearsContrast(page, '.eyebrow', '[class*="eyebrow"]', adjacentSampler);
+});
+
+test('hero coordinates line clears WCAG AA contrast against its real composited background', async ({page}) => {
+  await assertClearsContrast(page, '.heroMeta span', '[class*="heroMeta"] span', adjacentSampler);
+});
+
+test('final CTA kicker clears WCAG AA contrast against its real composited background', async ({page}) => {
+  await assertClearsContrast(page, '.finalKicker', '[class*="finalKicker"]', adjacentSampler);
+});
+
+test('hero primary CTA clears WCAG AA contrast against its own button fill', async ({page}) => {
+  await assertClearsContrast(
+    page,
+    'hero button--primary',
+    '[data-testid="landing-hero-install-cta"]',
+    interiorSampler(10),
+  );
 });


### PR DESCRIPTION
## Summary

Closes #851. Audited every visible text element on the homepage (36 distinct element/background combinations, both themes) with the pixel-sampling harness introduced in #848/#853 (Playwright screenshot -> canvas `getImageData`), extending it to handle two new sampling shapes found during the audit: elements with their own opaque fill (buttons, pills) vs. plain text painted directly on an ancestor's background.

**One real, previously-undiscovered failure found and fixed: `.eyebrow`** (light theme, all 5 usages, ~1.3-1.5:1, needs 4.5:1). Everything else (35 of 36) passed.

## Full measurement table (both themes)

| Element | Size / weight | Threshold | Light ratio | Dark ratio | Result |
|---|---|---|---|---|---|
| heroBrand (#837/#848, seed) | 21.6px / 700 | 3:1 | 3.15:1 | 7.49:1 | PASS |
| statusChip (#837/#853, seed) | 11.52px / 600 | 4.5:1 | 10.00:1 | 9.89:1 | PASS |
| audienceLane h2 (#837/#853, seed) | 20px / 700 | 3:1 | 3.04:1 | 8.33:1 | PASS |
| heroMeta span (coordinates line) | 19.52px / 500 | 4.5:1 | 8.82:1 | 12.51:1 | PASS |
| heroCopy h1 | 64px / 700 | 3:1 | 12.44:1 | 15.18:1 | PASS |
| heroCopy > p (muted part) | 19.52px / 500 | 4.5:1 | 8.96:1 | 15.79:1 | PASS |
| heroCopy > p > strong | 19.52px / 700 | 3:1 | 13.35:1 | 18.04:1 | PASS |
| hero button--secondary (Read quick start) | 16.8px / 700 | 4.5:1 | 11.35:1 | 15.45:1 | PASS |
| hero button--primary (Start a new project) | 16.8px / 700 | 4.5:1 | 5.26:1 | 10.47:1 | PASS |
| heroTrustLinks a (Maven Central) | 14.08px / 600 | 4.5:1 | 9.68:1 | 16.78:1 | PASS |
| **eyebrow (Guided paths)** | 13.12px / 600 | 4.5:1 | **1.39:1 -> 8.56:1** | 14.9:1 -> 14.44:1 | **FAIL -> PASS** |
| **eyebrow (Code proof)** | 13.12px / 600 | 4.5:1 | **1.48:1 -> 9.07:1** | 15.2:1 -> 14.66:1 | **FAIL -> PASS** |
| **eyebrow (Testing surfaces)** | 13.12px / 600 | 4.5:1 | **1.33:1 -> 8.17:1** | 15.0:1 -> 14.54:1 | **FAIL -> PASS** |
| **eyebrow (Run evidence)** | 13.12px / 600 | 4.5:1 | **1.34:1 -> 8.23:1** | 14.5:1 -> 14.04:1 | **FAIL -> PASS** |
| **eyebrow (Diagnostic loop)** | 13.12px / 600 | 4.5:1 | **1.33:1 -> 8.20:1** | 14.8:1 -> 14.31:1 | **FAIL -> PASS** |
| audienceLane p | 16.8px / 400 | 4.5:1 | 10.90:1 | 14.48:1 | PASS |
| audienceLane li | 16.8px / 400 | 4.5:1 | 10.95:1 | 14.24:1 | PASS |
| pathCard small | 13.12px / 700 | 4.5:1 | 4.88:1 | 6.92:1 | PASS |
| pathCard strong | 20px / 700 | 3:1 | 16.05:1 | 11.38:1 | PASS |
| pathCard span | 16.8px / 400 | 4.5:1 | 9.00:1 | 12.92:1 | PASS |
| pathCard em | 14.08px / 700 | 4.5:1 | 5.26:1 | 7.65:1 | PASS |
| proofCard strong | 20px / 700 | 3:1 | 5.26:1 | 7.65:1 | PASS |
| proofCard span | 16.8px / 400 | 4.5:1 | 9.07:1 | 13.09:1 | PASS |
| proofCard small | 13.33px / 700 | 4.5:1 | 16.71:1 | 11.96:1 | PASS |
| loopStep small | 13.12px / 700 | 4.5:1 | 4.92:1 | 7.00:1 | PASS |
| loopStep strong | 20px / 700 | 3:1 | 5.15:1 | 7.44:1 | PASS |
| loopStep span | 16.8px / 400 | 4.5:1 | 9.07:1 | 13.09:1 | PASS |
| inlineCta | 16px / 700 | 4.5:1 | 4.89:1 | 8.57:1 | PASS |
| finalKicker | 19.52px / 600 | 4.5:1 | 9.50:1 | 10.96:1 | PASS |
| finalCta h2 | 43.52px / 700 | 3:1 | 14.43:1 | 12.86:1 | PASS |
| finalCta p | 19.52px / 400 | 4.5:1 | 10.11:1 | 13.20:1 | PASS |
| finalCta button--secondary | 16.8px / 700 | 4.5:1 | 13.27:1 | 13.38:1 | PASS |
| featureLinks a (MCP setup) | 16px / 600 | 4.5:1 | 4.69:1 | 8.58:1 | PASS |
| footerBadges strong | 14.08px / 700 | 4.5:1 | 15.03:1 | 18.37:1 | PASS |
| footerBadges small | 14.08px / 400 | 4.5:1 | 10.18:1 | 16.69:1 | PASS |
| footerLinks a | 14.08px / 400 | 4.5:1 | 10.18:1 | 16.69:1 | PASS |

(The footerBadges/footerLinks/codeCompare solid deep/deep-alt pairs are also covered as hard-gated token pairs in tests/design-contrast.test.js; included here for audit completeness since #851 asked for every visible element, not re-guarded a second time in the Playwright suite.)

## The .eyebrow bug

`src/pages/index.module.css:104-123` (kicker labels: "Guided paths", "Testing surfaces", "Code proof", "Run evidence", "Diagnostic loop") used `color: var(--site-color-muted)`. That token is designed to pair with the fixed-dark deep/deep-alt family (hero, footer, audienceSection, finalCta, codeCompare) -- deliberately dark in *both* site themes. But every real `.eyebrow` usage (confirmed via `rg -n styles.eyebrow src/pages/index.tsx`) sits inside `.sectionHeading`, inside pathSection/surfaceSection/proofSection (no override, plain page background)/allureSection/agentBand -- all built on the normal flipping `--ifm-background-color` (white-ish in light theme, dark in dark theme), just with a subtle (4-7%) primary-tinted gradient layered on top.

In light theme that's pale blue-grey text (#c8d6e7) on a near-white background: measured ~1.3-1.5:1 across all 5 instances, badly failing the 4.5:1 normal-text threshold (13.12px/600 is nowhere near the large-text exemption). Dark theme happened to pass (~14.5-15.2:1) because the flipping background is dark there, which is exactly why light-theme-only visual QA would miss this.

Fixed by repointing to `--ifm-color-emphasis-800` -- the token this same file already uses for secondary/muted text on these exact sections (.pathCard span, .allureFrame figcaption, .loopStep span, all confirmed passing both themes above). Reuses an established, already-proven-safe pattern instead of introducing a new color; zero visual redesign, the eyebrow keeps its monospace/uppercase/letter-spaced styling.

## A false alarm, chased down and closed (not a bug)

Hero button--primary ("Start a new project") initially measured as a dark-theme FAIL: fg rgb(0,0,0) (black) on a sampled bg of rgb(7.9,23.8,37.8) (dark navy) = 1.17:1. Investigated directly (getComputedStyle) before touching any code: the button's actual fill is rgb(76,194,255) (dark theme's bright primary, Infima's default button--primary background), and its text genuinely is black by Infima's own contrast-color logic -- black-on-bright-blue is 10.47:1, comfortably passing. The FAIL was a sampler bug: sampling just outside the button's box read the .hero's dark backdrop, not the button's own opaque solid fill. Fixed by adding an interiorSampler (padding-gutter, vertical mid-height) for any element with its own filled/padded box, distinct from the existing adjacentSampler (thin sliver above/below) used for plain text with no background of its own. Screenshot-verified visually before and after to confirm this was a measurement artifact, not a rendering issue.

## Test changes

Extended tests/e2e/composited-contrast.spec.js (from #848/#853) with guards for the elements this audit flagged as most at risk of a silent regression:
- `.eyebrow` -- the fix itself.
- `.heroMeta` span and `.finalKicker` -- translucent rgba(muted, ...) fills on composited gradient/glow backgrounds, the same risk shape as `.heroBrand`.
- hero button--primary -- the "own opaque fill on a gradient ancestor" pattern that caused the false-alarm sampling bug above; guarded so the same mistake can't silently reintroduce a real regression undetected.

Not every one of the 36 measured elements got a dedicated guard (that would multiply the suite for elements on well-established, already-tested token families like --ifm-color-emphasis-800/--ifm-font-color-base on plain surface backgrounds) -- matches #851's own ask for guards on "the elements most at risk," not exhaustive coverage.

TDD: confirmed RED (1.32:1) for the new eyebrow guard against the unfixed CSS, then GREEN after the fix.

## Verification

- `yarn build` -- green.
- `yarn test` -- green (full suite).
- `npx playwright test --workers=1` (single-worker per issue #855's flagged parallel-worker flake) -- 10/10 green (7 composited-contrast.spec.js + 3 homepage.spec.js).
- Before/after full-page screenshots captured locally for the .eyebrow fix (light + dark theme, pathfinder and surfaces sections) and for the button--primary false-alarm investigation -- not committed (throwaway evidence, same convention as #838/#848/#853), available on request. The measurement table above, generated directly from the harness's JSON output, is the primary evidence.

## Adjacent note

Two elements pass with a tighter-than-typical margin worth knowing about, not fixing: pathCard small (4.88:1) and featureLinks a (4.69:1), both ~0.2-0.4 above the 4.5:1 floor. Both use the theme-adaptive --site-color-primary token correctly (not a token-family mismatch like .eyebrow's bug) -- this is just --site-color-primary's natural contrast margin against a white background, consistent with design-contrast.test.js's own "on-dark text / primary background" pair (5.26:1). Not a bug; flagging only because #851 asked for full-page visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk
