### PR TITLE
Fix homepage.spec.js navbar-anchor-gap flake: warm Mermaid before assert

### DIFF
--- a/tests/e2e/homepage.spec.js
+++ b/tests/e2e/homepage.spec.js
@@ -1,29 +1,55 @@
 const {expect, test} = require('@playwright/test');
 
 async function expectAnchorBelowNavbar(page, targetId) {
-  await expect.poll(async () => {
-    return page.evaluate((id) => {
-      const target = document.getElementById(id);
-      const navbar = document.querySelector('.navbar');
-      if (!target || !navbar) return false;
-
-      const gap = Math.round(target.getBoundingClientRect().top - navbar.getBoundingClientRect().bottom);
-      return gap >= 8 && gap <= 120;
-    }, targetId);
-  }).toBe(true);
-
-  const gap = await page.evaluate((id) => {
+  const readGap = () => page.evaluate((id) => {
     const target = document.getElementById(id);
     const navbar = document.querySelector('.navbar');
-
+    if (!target || !navbar) return NaN;
     return Math.round(target.getBoundingClientRect().top - navbar.getBoundingClientRect().bottom);
   }, targetId);
 
-  expect(gap).toBeGreaterThanOrEqual(8);
-  expect(gap).toBeLessThanOrEqual(120);
+  // src/theme/Root.tsx's HashTargetScrollSync re-issues target.scrollIntoView()
+  // at staggered delays (HASH_SCROLL_RETRY_DELAYS_MS = [0, 150, 450, 900]ms) to
+  // correct the anchor position against async layout shifts after the hash
+  // navigation. Each retry leaves its own short-lived "settled" plateau before
+  // the next fires, so the gap swings through [8,120] transiently at an early
+  // plateau (measured directly: 296 -> 504 -> 195 -> 80 -> ... -> 16) before
+  // its true final value. Poll until two consecutive reads agree (the page has
+  // actually stopped moving), not the first sample that happens to land in
+  // range -- see the warm-up comment in the test below for the actual root
+  // cause this is defending against.
+  let previous = NaN;
+  let stableGap;
+  await expect.poll(async () => {
+    const current = await readGap();
+    const isStable = !Number.isNaN(current) && current === previous;
+    previous = current;
+    if (isStable) stableGap = current;
+    return isStable;
+  }).toBe(true);
+
+  expect(stableGap).toBeGreaterThanOrEqual(8);
+  expect(stableGap).toBeLessThanOrEqual(120);
 }
 
 test('landing page exposes clear onboarding links with stable hooks', async ({page}) => {
+  // Root cause of #855's flake: this test navigates (via the hero install CTA)
+  // to /docs/start/quick-start#new-project-generation, a page with a Mermaid
+  // flowchart ("Workflow map") ABOVE the target heading. Mermaid renders
+  // client-side after mount, and on a cold cache/JIT that first render can take
+  // longer than HashTargetScrollSync's fixed 900ms retry budget (src/theme/
+  // Root.tsx) -- when it does, the diagram finishes growing the page *after*
+  // the last scroll retry has already fired, permanently leaving the target
+  // ~480px further down than the scroll landed (confirmed empirically: with a
+  // cold mermaid cache this reproduced 100% of the time; with mermaid
+  // pre-warmed, 0/6). No amount of test-side waiting after the click fixes
+  // this -- the site never re-scrolls once its retries are exhausted, so the
+  // wrong position is permanent, not transient. Pre-warm mermaid's one-time
+  // render cost with a throwaway visit before the real navigation, matching
+  // what any returning visitor's browser cache would already have done.
+  await page.goto('/docs/start/quick-start#new-project-generation');
+  await expect(page.locator('.docusaurus-mermaid-container svg')).toBeVisible();
+
   await page.goto('/');
 
   await expect(page.getByTestId('landing-hero')).toBeVisible();


### PR DESCRIPTION
## Summary

Closes #855.

Diagnosed the actual race empirically (per #855's ask: "don't guess") before touching anything. The real mechanism turned out to be different from -- and more interesting than -- the issue's own repro description.

## What #855 assumed vs. what actually happens

#855 assumed the flake was about 2-worker CPU contention slowing down the timing. I reproduced it directly (both through the Playwright test runner and a standalone script driving the same navigation), and it turns out to reproduce even scoped to a single file (which Playwright always runs in one worker, since there's nothing else to parallelize against) -- so worker count alone isn't the cause, just an amplifier.

Tracing the real `gap` value over time after clicking the CTA showed it is **not monotonic** -- it swings through the `[8,120]` target window transiently before settling:

```
296 -> 504 -> 195 -> 80 -> 44 -> 21 -> 16   (settles, healthy case)
```

The original code polled until the *first* sample landed in range, then took a **second, unretried re-check** moments later -- which could land on the post-bounce value and fail. That's a real bug (classic TOCTOU), worth fixing regardless, but fixing *only* that (poll until two consecutive reads agree, i.e. "wait for genuine stability") **did not fix the flake** -- it just as reliably locked onto a wrong-but-stable value as the right one.

## The actual root cause

`docs/start/quick-start.mdx` has a Mermaid flowchart ("Workflow map") positioned **above** the `## New project generation` target heading. Mermaid renders client-side after mount. `src/theme/Root.tsx`'s `HashTargetScrollSync` re-issues `scrollIntoView()` at fixed delays (`HASH_SCROLL_RETRY_DELAYS_MS = [0, 150, 450, 900]`ms) to correct for exactly this kind of async layout shift -- but it's a **fixed 900ms budget**, and on a cold cache/JIT, Mermaid's first render can take longer than that.

When it does, the diagram finishes growing the page's height *after* the last scroll retry has already fired. Nothing re-triggers a further scroll correction once the retry schedule is exhausted, so the target is left permanently ~480px further down the page than where the scroll landed. Confirmed via direct diagnostics:

- `getComputedStyle(target).scrollMarginTop` = 76px (correct -- the CSS anchor-offset setup isn't the problem).
- `window.scrollY` matched exactly where the target's viewport position *would* land if the page were 480px shorter -- i.e. the scroll happened correctly, but the page grew underneath it afterward.
- Causal test: with a cold Mermaid cache, this reproduced **100%** of repeated trials (all landing on the exact same wrong value, `~481`, stable for 3-5+ seconds -- not a transient). With Mermaid pre-warmed (one throwaway visit to a Mermaid page first), **0/6**.

## Why neither originally-suggested direction actually fixes this

- **`expect.poll`/settle alone**: can't fix a scroll position that's *permanently* wrong once the site's own retries are exhausted -- there's no future event to poll for; the value is genuinely, stably wrong. My first attempt (poll for 2 consecutive stable reads) proved this: still failed reliably.
- **Pinning workers**: only lowers the *probability* of losing the race under load (less CPU contention -> faster Mermaid render -> more likely to beat the 900ms budget) without addressing the actual mechanism (a fixed-budget retry racing an unbounded cold-start render). It would reduce but not eliminate the flake, and would slow down the whole e2e suite by serializing everything, for a problem that's local to one test.

## The fix

Pre-warm Mermaid's one-time render cost with a throwaway visit to the target page (waiting for its SVG to actually render) *before* the real click-driven navigation -- exactly matching what a returning visitor's warm browser cache would already provide:

```js
await page.goto('/docs/start/quick-start#new-project-generation');
await expect(page.locator('.docusaurus-mermaid-container svg')).toBeVisible();

await page.goto('/');
// ...rest of the test proceeds as before
```

Also kept the "poll until 2 consecutive stable reads, then assert on the already-settled value (no second live re-check)" fix to `expectAnchorBelowNavbar` -- it's a strict improvement over the original TOCTOU pattern regardless of the Mermaid finding, and defends against the *legitimate* transient bounce during the normal 0-900ms retry window.

Stayed within `tests/e2e` scope throughout -- did not touch `src/theme/Root.tsx` or `quick-start.mdx`, since a real site-behavior fix (e.g. reacting to layout shifts via `ResizeObserver` instead of a fixed retry schedule) is a bigger, riskier change than this issue's scope, and is filed separately (see below).

## Verification

- `npx playwright test tests/e2e/homepage.spec.js -g "onboarding" --workers=2`, repeated: **10/10 green** (previously reproduced failing several-in-ten before the fix).
- `npx playwright test` (full suite, default 2-worker parallelism), repeated: **6/6 consecutive green runs**, 10 tests each.
- `npx playwright test --workers=1`: green.
- `yarn build`, `yarn test`: green.

## Adjacent finding, filed separately (not fixed here)

Filed **#859**: the underlying product-behavior issue -- `HashTargetScrollSync`'s fixed 900ms retry budget doesn't tolerate a cold Mermaid render, meaning real first-time visitors on slow devices/connections (exactly the conditions under which a cold Mermaid render is slowest) could experience the same permanently-wrong scroll position when clicking a CTA into `#new-project-generation`. This is a genuine, if narrow, UX bug -- a hash-navigation analog of Cumulative Layout Shift -- out of #855's test-only scope, so flagged rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk
