### PR TITLE
Fix cold-cache hash-scroll: react to layout growth, not a fixed budget

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -3,6 +3,27 @@ import React, { Suspense, useEffect, useState } from 'react';
 const LazyAutoBot = React.lazy(() => import('@site/src/components/AutoBot'));
 
 const HASH_SCROLL_RETRY_DELAYS_MS = [0, 150, 450, 900];
+// The fixed schedule above assumes layout finishes shifting within 900ms.
+// That's true for most pages, but a slow-rendering client-side widget (e.g. a
+// Mermaid diagram positioned above the hash target -- see #859) can grow the
+// page taller after the schedule is exhausted, permanently stranding the
+// target below where the last retry scrolled to (nothing else re-corrects
+// it). Once the fixed schedule ends, keep watching for further DOM growth via
+// MutationObserver and re-align for this bounded extra window. (ResizeObserver
+// on document.body/documentElement was tried first and doesn't work here --
+// this site's body has a sticky-footer min-height:100vh layout, so body's own
+// rendered box stays pinned at the viewport height and never reports a resize
+// even as its content/scrollHeight grows; MutationObserver reacts to the
+// actual DOM insertion instead, which is unaffected by that.)
+const HASH_SCROLL_OBSERVER_MAX_MS = 6000;
+// Real user-initiated scroll gestures (as opposed to our own programmatic
+// target.scrollIntoView() calls, which never dispatch these) -- once any of
+// these fire, the user has taken control of the scroll position, and we must
+// never override it again. Doing so would be a worse UX bug (scroll-jacking)
+// than the one this is fixing. Known gap: dragging the scrollbar thumb itself
+// isn't covered (no reliable, low-complexity signal for it); wheel/touch/key
+// covers the overwhelming majority of real navigation.
+const USER_SCROLL_INTENT_EVENTS = ['wheel', 'touchmove', 'keydown'] as const;
 
 function DeferredAutoBot(): JSX.Element | null {
   const AUTOBOT_DEFER_TIMEOUT_MS = 5000;
@@ -74,8 +95,25 @@ function HashTargetScrollSync(): JSX.Element | null {
 
     if (!targetId) return;
 
+    let userTookOver = false;
+    const markUserTookOver = () => {
+      userTookOver = true;
+      // Setting the flag alone stops *future* corrections, but html's global
+      // `scroll-behavior: smooth` (src/css/custom.css) means a scrollIntoView
+      // call already in flight keeps animating toward its target for its own
+      // remaining frames regardless -- the flag can't interrupt an animation
+      // that already started. Re-issuing an instant scroll to the current
+      // position cancels that in-progress animation immediately, so user
+      // input always wins outright rather than fighting a settling tail.
+      window.scrollTo({top: window.scrollY, left: window.scrollX, behavior: 'auto'});
+    };
+    USER_SCROLL_INTENT_EVENTS.forEach((eventName) => {
+      window.addEventListener(eventName, markUserTookOver, { passive: true, once: true });
+    });
+
     const frameIds: number[] = [];
     const scrollToTarget = () => {
+      if (userTookOver) return;
       const target = document.getElementById(targetId);
       if (!target) return;
 
@@ -86,9 +124,42 @@ function HashTargetScrollSync(): JSX.Element | null {
       frameIds.push(window.requestAnimationFrame(scrollToTarget));
     }, delay));
 
+    // Beyond the fixed schedule: watch for the page's content still growing
+    // (e.g. a Mermaid diagram finishing its render late, inserting a large
+    // SVG) and re-align for as long as that keeps happening, bounded by
+    // HASH_SCROLL_OBSERVER_MAX_MS so a continually-mutating page can't hold
+    // onto scroll control indefinitely. A busy page can fire many mutation
+    // batches in quick succession (React re-renders, reveal-animation state,
+    // unrelated widgets); coalesce them into at most one pending correction
+    // instead of stacking a redundant rAF per mutation batch.
+    let correctionScheduled = false;
+    const scheduleCorrection = () => {
+      if (userTookOver || correctionScheduled) return;
+      correctionScheduled = true;
+      frameIds.push(window.requestAnimationFrame(() => {
+        correctionScheduled = false;
+        scrollToTarget();
+      }));
+    };
+
+    let mutationObserver: MutationObserver | undefined;
+    let observerCapId = 0;
+    if (typeof MutationObserver !== 'undefined') {
+      mutationObserver = new MutationObserver(scheduleCorrection);
+      mutationObserver.observe(document.body, { childList: true, subtree: true });
+      observerCapId = window.setTimeout(() => {
+        mutationObserver?.disconnect();
+      }, HASH_SCROLL_OBSERVER_MAX_MS);
+    }
+
     return () => {
+      USER_SCROLL_INTENT_EVENTS.forEach((eventName) => {
+        window.removeEventListener(eventName, markUserTookOver);
+      });
       timeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId));
       frameIds.forEach((frameId) => window.cancelAnimationFrame(frameId));
+      mutationObserver?.disconnect();
+      window.clearTimeout(observerCapId);
     };
   }, [location.hash, location.pathname]);
 

--- a/tests/e2e/hash-scroll-sync.spec.js
+++ b/tests/e2e/hash-scroll-sync.spec.js
@@ -1,0 +1,112 @@
+const {expect, test} = require('@playwright/test');
+
+// Regression guard for #859. src/theme/Root.tsx's HashTargetScrollSync
+// re-aligns the scroll position against a hash-linked heading after a
+// client-side navigation, since Docusaurus's SPA routing doesn't get the
+// browser's native hash-scroll behavior for free. It originally did this via
+// a fixed retry schedule (0/150/450/900ms) alone -- fine for ordinary pages,
+// but a slow-rendering client-side widget positioned above the target (e.g.
+// the Mermaid "Workflow map" diagram on docs/start/quick-start.mdx, above
+// `#new-project-generation`) can, on a cold cache/JIT, finish growing the
+// page *after* that fixed schedule is exhausted. Nothing then re-corrects the
+// scroll, permanently stranding the target far below where the last retry
+// landed -- a real bug for first-time/slow-device visitors, not just a test
+// artifact (see #859 for the full empirical trace).
+//
+// #860's homepage.spec.js test intentionally pre-warms the Mermaid renderer
+// before its navigation (to avoid *that* test flaking on this exact race) --
+// which means it is structurally unable to exercise the cold-cache path this
+// bug lives in. This spec is the only coverage for that path: it forces a
+// cold render by CPU-throttling the page (Chrome DevTools Protocol) rather
+// than relying on ambient system load, so the race is reproducible on
+// demand instead of intermittent.
+
+test('anchor scroll self-corrects when a Mermaid diagram above the target renders slowly (cold cache, #859)', async ({page, context}) => {
+  const client = await context.newCDPSession(page);
+
+  await page.goto('/');
+  const installCta = page.getByTestId('landing-hero-install-cta');
+  await installCta.waitFor({state: 'visible'});
+
+  // Throttle CPU only for the navigation itself, so the click action and
+  // initial homepage hydration aren't affected -- this isolates the slowdown
+  // to the target page's own rendering (including Mermaid), matching a real
+  // slower device rather than a generally sluggish test browser. 2x reliably
+  // pushes Mermaid's first render past the fixed retry schedule's 900ms
+  // budget (empirically: ~3-5s to finish under this rate, vs ~1.5-2s
+  // unthrottled) without making the test itself slow.
+  await client.send('Emulation.setCPUThrottlingRate', {rate: 2});
+  try {
+    await Promise.all([
+      page.waitForURL('**/docs/start/quick-start#new-project-generation'),
+      installCta.click(),
+    ]);
+
+    // Confirm this test actually exercises the slow-render path it claims to
+    // -- if Mermaid doesn't even show up, the rest of the assertion would be
+    // meaningless (a passing gap check for the wrong reason).
+    await expect(page.locator('.docusaurus-mermaid-container svg')).toBeVisible({timeout: 15_000});
+  } finally {
+    await client.send('Emulation.setCPUThrottlingRate', {rate: 1});
+  }
+
+  // Give MutationObserver-driven corrections (src/theme/Root.tsx) a moment to
+  // settle after Mermaid's DOM insertion, then assert the final position --
+  // same [8,120] navbar-clearance window as tests/e2e/homepage.spec.js's
+  // warm-cache assertion, since this is testing the same real UX guarantee.
+  await page.waitForTimeout(500);
+
+  const gap = await page.evaluate((id) => {
+    const target = document.getElementById(id);
+    const navbar = document.querySelector('.navbar');
+    if (!target || !navbar) return null;
+    return Math.round(target.getBoundingClientRect().top - navbar.getBoundingClientRect().bottom);
+  }, 'new-project-generation');
+
+  expect(gap, `anchor gap after cold Mermaid render: ${gap}, needs [8,120]`).toBeGreaterThanOrEqual(8);
+  expect(gap, `anchor gap after cold Mermaid render: ${gap}, needs [8,120]`).toBeLessThanOrEqual(120);
+});
+
+test('anchor auto-correction stops as soon as the user scrolls manually (no scroll-jacking)', async ({page, context}) => {
+  const client = await context.newCDPSession(page);
+
+  await page.goto('/');
+  const installCta = page.getByTestId('landing-hero-install-cta');
+  await installCta.waitFor({state: 'visible'});
+
+  await client.send('Emulation.setCPUThrottlingRate', {rate: 2});
+  try {
+    await Promise.all([
+      page.waitForURL('**/docs/start/quick-start#new-project-generation'),
+      installCta.click(),
+    ]);
+
+    // Let the fixed retry schedule run at least once, then take over with a
+    // real wheel gesture (a trusted input event, not a programmatic
+    // window.scrollTo -- Root.tsx specifically listens for wheel/touchmove/
+    // keydown to distinguish genuine user intent from its own scrollIntoView
+    // calls, which never dispatch those) while Mermaid is still slowly
+    // rendering -- exactly the window in which the late MutationObserver-
+    // driven correction would otherwise still be armed.
+    await page.waitForTimeout(200);
+    await page.mouse.wheel(0, 120);
+    await page.waitForTimeout(50);
+    const scrollYAfterUserTookOver = await page.evaluate(() => window.scrollY);
+
+    // Whether or not Mermaid has finished by now, the auto-correction must
+    // never override the user's own position from this point on.
+    await expect(page.locator('.docusaurus-mermaid-container svg')).toBeVisible({timeout: 15_000});
+
+    // Give any (incorrectly) still-armed auto-correction every chance to fire.
+    await page.waitForTimeout(1500);
+
+    const finalScrollY = await page.evaluate(() => window.scrollY);
+    expect(
+      finalScrollY,
+      `scroll position moved from ${scrollYAfterUserTookOver} to ${finalScrollY} after the user took over -- ` +
+        'the auto-correction scroll-jacked the page',
+    ).toBe(scrollYAfterUserTookOver);
+  } finally {
+    await client.send('Emulation.setCPUThrottlingRate', {rate: 1});
+  }
+});


### PR DESCRIPTION
## Summary

Closes #859.

`src/theme/Root.tsx`'s `HashTargetScrollSync` re-aligned the anchor scroll position against a **fixed** `[0, 150, 450, 900]`ms retry schedule alone. That assumes layout finishes shifting within 900ms -- true for most pages, but not for a slow-rendering client-side widget positioned above the target: concretely, the Mermaid "Workflow map" diagram above `docs/start/quick-start.mdx`'s `#new-project-generation` heading, which on a cold cache/JIT can take longer than 900ms to render. When it does, the diagram grows the page taller *after* the last retry has already fired, and nothing else re-corrects the scroll -- permanently stranding the target ~480px below where it landed. This is a real bug for first-time/slow-device visitors (a hash-navigation analog of Cumulative Layout Shift), not just a test artifact -- filed as #859 while diagnosing the unrelated `homepage.spec.js` flake in #855. #860's fix for that test deliberately pre-warms Mermaid to sidestep the race, which is correct for that test but leaves this product bug unaddressed.

## The fix: react to layout growth, not a fixed budget

Kept the fixed schedule (still handles the common case cheaply and immediately) and **augmented** it with a `MutationObserver` that watches for further DOM growth once the schedule ends, re-correcting for a bounded extra window (`HASH_SCROLL_OBSERVER_MAX_MS = 6000`ms).

**`ResizeObserver` was tried first and doesn't work on this site.** `document.body` uses a sticky-footer `min-height: 100vh` layout, so body's own rendered box stays pinned at the viewport height and never reports a resize even as its content/`scrollHeight` grows underneath it. Confirmed via direct instrumentation: 0 `ResizeObserver` callbacks after the initial connection-time one, vs. `MutationObserver` correctly firing on the Mermaid SVG's DOM insertion. Mutation batches are coalesced into at most one pending `requestAnimationFrame`-scheduled correction rather than stacking one per batch (a busy page can fire many mutation batches in quick succession -- React re-renders, the reveal-animation system, unrelated widgets).

## Scroll-jacking safety (the harder half of this fix)

Per the explicit brief: any real user-initiated scroll gesture (`wheel`/`touchmove`/`keydown` -- signals our own `scrollIntoView()` calls never dispatch) permanently disables *all* further correction for that navigation, checked both by the fixed-schedule path and the mutation-observer path.

This alone left an ~8px residual drift in testing, traced to `html`'s global `scroll-behavior: smooth` (`src/css/custom.css:9`): disabling future *scheduling* doesn't interrupt a `scrollIntoView` animation already in flight. Fixed by re-issuing an instant scroll to the current position the moment user intent is detected, which cancels the in-progress animation outright rather than letting its tail keep drifting.

**Known gap, documented in-code**: dragging the scrollbar thumb itself isn't covered (no reliable, low-complexity signal for it without more invasive pointer-event tracking); wheel/touch/keyboard covers the overwhelming majority of real navigation.

## Tests (`tests/e2e/hash-scroll-sync.spec.js`, new file)

`#860`'s `homepage.spec.js` pre-warm test intentionally can't exercise this cold path (that's the whole point of the pre-warm), so this is the **only** coverage for it -- kept both per the brief.

- **Cold-render test**: forces the race deterministically via CDP `Emulation.setCPUThrottlingRate` (2x, applied only around the navigation itself so the click action and homepage hydration aren't affected) rather than relying on ambient system load -- reproduces the failure on demand instead of intermittently. Confirms the final anchor gap lands in the same `[8,120]` navbar-clearance window `homepage.spec.js` already asserts, and confirms Mermaid actually rendered (so a passing gap check can't be vacuous).
- **No-scroll-jacking test**: drives a real wheel gesture mid-render (while Mermaid is still slowly rendering, throttled) and asserts the scroll position never moves again afterward, even once Mermaid finishes late.

### TDD: RED confirmed on the *unmodified* `Root.tsx`

Reverted `Root.tsx` (`git stash`) and ran both new tests against the original code first:
- Cold-render test failed at **gap=481**, matching #859's own empirical trace exactly.
- No-scroll-jacking test **also failed** (`1534 -> 1572`) -- surfacing a second, previously-unknown latent bug in the *original* code: the fixed schedule had no user-scroll guard at all, so a retry landing after a manual scroll would silently override it. Both bugs are fixed by the same change.

Restored the fix; both GREEN. (First pass at the fix still showed a small residual 8px drift on the scroll-jacking test -- that's what led to the `scroll-behavior:smooth` finding and the explicit animation-cancel above.)

## Verification

- New tests: green across 3 repeated runs.
- Full e2e suite (12 tests): green across **4 consecutive runs at default parallelism**.
- `npx playwright test --workers=1`: green.
- `yarn build`: green.
- `yarn typecheck` (`tsc --noEmit`): green.
- **Manual verification** (scripted, separate from the automated test, per the explicit ask): navigated with a hash, scrolled *away* from the target (wheel up) mid-render while CPU-throttled, then polled `window.scrollY` every 300ms for ~5 seconds while Mermaid finished rendering in the background. Position held rock-steady the entire time (`scrollY` never moved from the user's chosen value), confirmed Mermaid did finish rendering by the end of the observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk
