### PR TITLE
Update GitHub Actions snippets to v7 with single-file Allure upload pattern

### DIFF
--- a/docs/reference/guides/CI_CD_Integration.md
+++ b/docs/reference/guides/CI_CD_Integration.md
@@ -28,7 +28,6 @@ mvn -e test \
 |---|---|
 | `headlessExecution=true` | No display available in CI — run the browser without a GUI |
 | `allure.automaticallyOpen=false` | Do not try to open a browser to show the report |
-| `allure.generateArchive=true` | Generate a portable ZIP of the Allure report for artifact publishing |
 
 ---
 
@@ -40,7 +39,6 @@ Create a `custom.properties` file with sensible defaults for CI, then override i
 # CI/CD defaults
 headlessExecution=true
 allure.automaticallyOpen=false
-allure.generateArchive=true
 retryMaximumNumberOfAttempts=2
 createAnimatedGif=false
 videoParams_recordVideo=false
@@ -75,15 +73,16 @@ jobs:
         run: |
           mvn -e test \
             -DheadlessExecution=true \
-            -Dallure.automaticallyOpen=false \
-            -Dallure.generateArchive=true
+            -Dallure.automaticallyOpen=false
 
       - name: Upload Allure report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-report
-          path: allure-report-archive/
+          path: allure-report/*.html
+          archive: false
+          if-no-files-found: ignore
 ```
 
 ---
@@ -157,10 +156,9 @@ This lets you run the same test suite against staging, production, or different 
 
 1. **Always use headless mode** in pipelines — there is no display server.
 2. **Disable auto-opening reports** — set `allure.automaticallyOpen=false`.
-3. **Generate report archives** — use `allure.generateArchive=true` and publish them as pipeline artifacts.
+3. **Archive test artifacts** — always upload reports and logs, even on failure (use `if: always()` in GitHub Actions or `post { always { } }` in Jenkins). GitHub Actions v7+ with `archive: false` uploads HTML files directly without zipping.
 4. **Set retry attempts** — `retryMaximumNumberOfAttempts=2` allows two retries after the first failure. Keep the budget small; JUnit retries still run setup and teardown for isolated attempts.
 5. **Parameterize everything** — use CLI properties so the same test suite works across environments.
-6. **Archive test artifacts** — always upload reports and logs, even on failure (use `if: always()` in GitHub Actions or `post { always { } }` in Jenkins).
 
 ## Related
 

--- a/docs/reference/guides/Test_Artifacts.md
+++ b/docs/reference/guides/Test_Artifacts.md
@@ -55,16 +55,9 @@ SHAFT writes convenience scripts to your project root on first run:
 generate_allure_report.bat
 ```
 
-### Generating a Portable Archive for CI/CD
+### Publishing to CI/CD
 
-Enable the archive property to create a ZIP file you can publish as a pipeline artifact:
-
-```properties title="src/main/resources/properties/custom.properties"
-allure.generateArchive=true
-allure.automaticallyOpen=false
-```
-
-The archive is written to `allure-report-archive/` and contains a self-contained HTML report.
+With GitHub Actions v7+, you can upload Allure HTML files directly without archiving. See the [Publishing Artifacts in CI/CD](#publishing-artifacts-in-cicd) section below for examples.
 
 ---
 
@@ -87,14 +80,16 @@ The generated file is written to the `execution-summary/` directory.
 ```yaml title=".github/workflows/tests.yml"
 - name: Upload Allure report
   if: always()
-  uses: actions/upload-artifact@v4
+  uses: actions/upload-artifact@v7
   with:
     name: allure-report
-    path: allure-report-archive/
+    path: allure-report/*.html
+    archive: false
+    if-no-files-found: ignore
 
 - name: Upload execution summary
   if: always()
-  uses: actions/upload-artifact@v4
+  uses: actions/upload-artifact@v7
   with:
     name: execution-summary
     path: execution-summary/


### PR DESCRIPTION
## Summary
- Update `actions/upload-artifact` from v4 to v7 in CI/CD integration guides
- Implement single-file Allure HTML upload pattern with `archive: false`
- Remove outdated `allure.generateArchive` property references from documentation and examples
- Update guide prose to reflect new direct-upload pattern for Allure reports

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk