### PR TITLE
Add PR build gate: Docs Build check on pull_request

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,21 @@
+name: PR Build Gate
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary

Closes #870.

Adds `.github/workflows/pr-build.yml`: a minimal `Docs Build` job that runs
on every `pull_request` -- checkout, setup-node, install, build. This is the
missing PR-time verification called out in #870 (no branch protection and
no PR-triggered workflow exists on this repo today, so a broken docusaurus
build was only discovered at deploy time).

Kept intentionally minimal per the issue's scope: build is the gate, no
lint/test scaffolding this repo doesn't otherwise run in CI.

**Deviation from the issue's literal wording:** the issue text says
`npm ci` / `npm run build`, but this repo has no `package-lock.json` --
only `yarn.lock`, and `package.json` pins `packageManager: yarn@1.22.22`.
`deploy.yml` itself uses `yarn install` / `yarn build`. `npm ci` would fail
outright (it requires a lockfile that doesn't exist), so the gate uses
`yarn install --frozen-lockfile` / `yarn build` to match deploy.yml and the
repo's actual tooling, while mirroring deploy.yml's `node-version: 20` and
`cache: yarn` setup-node config exactly.

## Local build evidence

Verified in an isolated git worktree off `origin/master` (not the shared
checkout) before pushing:

- `yarn install --frozen-lockfile` -> exit 0, ~55.6s
- `yarn build` (runs `build-autobot-index.mjs` + `build-llms-txt.mjs` +
  `docusaurus build`) -> exit 0, ~90.7s, `[SUCCESS] Generated static files
  in "build".`
- Workflow YAML validated with `py -3` (`yaml.safe_load`) -> parses cleanly.

## Test plan

- [x] `yarn install --frozen-lockfile` exits 0 locally
- [x] `yarn build` exits 0 locally, produces `build/`
- [x] Workflow YAML parses cleanly
- [ ] `Docs Build` check appears and passes on this PR itself (live proof
      the workflow triggers correctly on `pull_request`)
- [ ] Follow-up (issue #870 step 2, out of scope here): once this proves
      out, add a repository ruleset for `master` requiring the `Docs Build`
      status check, blocking force pushes/deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H