### PR TITLE
Close literal-API search vocabulary gaps on top reference pages

### DIFF
--- a/docs/reference/actions/GUI/Element_Actions.md
+++ b/docs/reference/actions/GUI/Element_Actions.md
@@ -3,7 +3,7 @@ id: Element_Actions
 title: Element Actions
 sidebar_label: Element
 description: "Interact with web elements using SHAFT Engine — click, type, drag and drop, select from dropdowns, handle iframes, and more."
-keywords: [SHAFT, element actions, click, type, drag and drop, select, iframe, web automation, Selenium]
+keywords: [SHAFT, element actions, click, type, sendKeys, drag and drop, select, iframe, web automation, Selenium, isDisplayed]
 tags: [web, element, actions, selenium]
 ---
 
@@ -18,7 +18,8 @@ For trust-gated natural-language element workflows such as
 Typing actions show the value being entered in the Allure step title. SHAFT
 caps long or multiline values in the title so reports stay readable, keeps the
 locator in step metadata, and adds the resolved element name only when the
-engine captures one. Secure typing remains masked.
+engine captures one. Secure typing remains masked. If you're coming from
+plain Selenium, `type()` is SHAFT's equivalent of `WebElement.sendKeys()`.
 
 ### type()
 

--- a/docs/reference/actions/Validations.md
+++ b/docs/reference/actions/Validations.md
@@ -3,11 +3,11 @@ id: Validations
 title: Validations
 sidebar_label: Validations
 description: "SHAFT Engine's built-in assertions and verifications — browser, element, file, object, number, and API response validation, JSON schema validation, force fail, and soft vs hard assertion strategy."
-keywords: [SHAFT, validations, assertions, verifications, overview, browser validations, element validations, text validation, attribute validation, visual testing, OpenCV, file validations, object validations, number validations, api response validations, json schema validation, contract testing, force fail, soft vs hard assertions, assertThat, verifyThat]
+keywords: [SHAFT, validations, assertions, verifications, overview, browser validations, element validations, text validation, attribute validation, visual testing, OpenCV, file validations, object validations, number validations, api response validations, json schema validation, contract testing, force fail, soft vs hard assertions, assertThat, verifyThat, assertEquals, assertTrue, assertFalse, assertNull, assertNotNull, verify]
 tags: [validations, assertions, browser, element, file, object, number, response, json-schema, contract-testing, force-fail, soft-assertions, hard-assertions]
 ---
 
-SHAFT Engine allows you to perform assertions and verifications easily using the `Validations` class or the fluent driver-based API.
+SHAFT Engine allows you to perform assertions and verifications easily using the `Validations` class or the fluent driver-based API. If you're coming from JUnit or TestNG, SHAFT's fluent equivalents to `assertEquals`/`assertTrue`/`assertFalse`/`assertNull` are `isEqualTo()`, `isTrue()`, `isFalse()`, and `isNull()` chained off `assertThat()` (hard assertion) or `verifyThat()` (soft assertion, i.e. "verify").
 
 ## Overview {/* #overview */}
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -3,7 +3,7 @@ id: PropertiesList
 title: Complete Properties Reference
 sidebar_label: Properties Reference
 description: "Full reference of all SHAFT Engine configuration properties — web, mobile, API, timeouts, paths, reporting, and integrations."
-keywords: [SHAFT, properties list, configuration reference, web properties, mobile properties, API properties, timeout settings, allure properties]
+keywords: [SHAFT, properties list, configuration reference, web properties, mobile properties, API properties, timeout settings, allure properties, custom.properties]
 tags: [configuration, properties, reference]
 ---
 

--- a/docs/start/quick-start.mdx
+++ b/docs/start/quick-start.mdx
@@ -3,6 +3,7 @@ id: quick-start
 title: Quick start
 description: Choose the right SHAFT setup path, then run a first test.
 slug: /start/quick-start
+keywords: [SHAFT, quick start, quickstart, getting started, installation, setup, new project, project generator, Maven, first test]
 tags: [quick-start, example]
 ---
 


### PR DESCRIPTION
## Summary

Closes #867. Follow-up to #865/#866: the fixed 12-query relevance evaluation left exactly one shared complete miss — `assertEquals` — because `Validations.md` never used that literal term. This is a docs-vocabulary gap, independent of the search plugin.

## Changes

- **`docs/reference/actions/Validations.md`** — added `assertEquals`, `assertTrue`, `assertFalse`, `assertNull`, `assertNotNull`, `verify` to frontmatter `keywords`, plus an intro-prose sentence mapping JUnit/TestNG assertion names to SHAFT's fluent equivalents (`isEqualTo()`, `isTrue()`, `isFalse()`, `isNull()` chained off `assertThat()`/`verifyThat()`) — all of which are genuinely documented further down the same page.
- **`docs/reference/actions/GUI/Element_Actions.md`** — added `sendKeys`/`isDisplayed` keywords plus a one-line note ("`type()` is SHAFT's equivalent of `WebElement.sendKeys()`"). Grounded: `type()` wraps Selenium's `sendKeys()`; `isDisplayed()` is a real `Actions` method (`shaft-engine/.../Actions.java:1951`), not just Selenium jargon.
- **`docs/reference/properties/PropertiesList.mdx`** — added `custom.properties`, the actual file-based config filename the page's own body already names. (A `shaft.properties` candidate was dropped — grounding against `SHAFT_ENGINE` showed no such literal file exists; the earlier grep hit was the `com.shaft.properties` **package** name, not a filename.)
- **`docs/start/quick-start.mdx`** — had no `keywords` frontmatter field at all despite being a top destination page; added a short, grounded set (`quickstart`, `getting started`, `installation`, `Maven`, `project generator`).

Every keyword was checked against the real SHAFT_ENGINE API surface (`rg` over the engine repo) before being added — kept short and honest, no stuffing.

## Evidence — 12-query re-evaluation (before → after)

Replicated the #865/#866 methodology: `yarn build` + `docusaurus serve`, a Playwright script driving the real navbar search UI (`@easyops-cn/docusaurus-search-local`), top-5 results scraped per query, run once before and once after this change.

| Query | Before | After | Notes |
|---|---|---|---|
| `assertEquals` | **No results (miss)** | **Rank 1** — Validations (title/keyword match), rank 2 content match from the new prose sentence | Fixed — the target of this issue |
| `shaft.properties` | Rank 1 (Programmatic Properties Configuration) | identical | No change |
| `self healing` | Rank 1 (Locators_And_Self_Healing) | identical | No change |
| `grid` | Rank 1 (Example: Product Grid) | identical | No change |
| `junit` | Rank 1 (JUnit Integration) | identical | No change |
| `wait` | Rank 1 (Waits_And_Synchronization) | identical | No change |
| `element actions` | Rank 1 (Element Actions) | identical | No change |
| `screenshot` | Rank 1 (Screenshots, Element Actions) | identical | No change |
| `propreties` (typo) | Rank 1 (Property Types) | identical | No change |
| `selfhealing` (no space) | Rank 1 (Self-healing locators) | identical | No change |
| `browser actions` | Rank 1 (Browser Actions) | identical | No change |
| `API request` | Rank 2 (Request Builder) | identical | No change |

The other 11 queries returned byte-identical top-5 result sets (same titles, same paths, same order) before and after — zero regressions. Success criterion from #867 met: `assertEquals` now resolves to Validations.md in top-5 (rank 1) without regressing any of the other 11 queries.

## Validation

- `yarn build` — clean.
- `yarn test:docs` — full suite green (docs-loader, cloudflare-autobot, enhanced-instruction, properties-catalog, generate-properties-catalog-regex, properties-list-coverage, docs-quality, design-contrast, check-doc-duplicates).
- Scratch Playwright harness used for the evaluation was never committed (kept in a worktree-local `.scratch-harness/` dir, removed before commit).
- `docusaurus.config.js` and `.github/workflows/**` untouched, per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H