### PR TITLE
Fix #4048: merge humanizer/taste-skill residue into DESIGN_LANGUAGE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Put recurring executable commands in `src/data/snippets.json` and render through `src/components/DocSnippets`.
 - Preserve AutoBot's HTTP contract, search exclusions, archive `noindex`, redirects, responsive behavior, dark mode, reduced motion, semantic HTML, and copyable fenced code.
 - Never restore unsupported adoption numbers, stale Java baselines, legacy coordinates as current guidance, secrets, or hardcoded "latest" versions.
+- `DESIGN_LANGUAGE.md` is the canonical style authority: palette and typography tokens, admonition severity, and the binding prose rules. Read it before writing docs prose or changing visible styling.
 
 ## Graphify
 

--- a/DESIGN_LANGUAGE.md
+++ b/DESIGN_LANGUAGE.md
@@ -79,6 +79,9 @@ Only these weights are allowed for reusable UI styles: `400|500|600|700`.
 5. Ensure landing, docs cards, `code`/`pre`, and Mermaid visuals remain on the same blue-centric palette.
 6. Run a quick grep for `landing-` and hard-coded palette values before handoff.
 7. Document any justified token exceptions in this file and this checklist.
+8. Interactive components ship focus, loading, empty, and error states. Match
+   a loading placeholder to the real layout's dimensions instead of a
+   centered spinner.
 
 ## Admonition severity vocabulary
 
@@ -103,3 +106,30 @@ Binding rules for prose in `docs/`:
 4. **Short paragraphs.** Prefer two to four sentences per paragraph; break up longer explanations with lists or subheadings.
 5. **Runnable example required.** Every doc includes at least one fenced, runnable code example relevant to its topic.
 6. **Second-person imperative tone.** Address the reader directly and lead with verbs ("Run…", "Add…", "Configure…") rather than passive or third-person phrasing.
+7. **Sparing em dashes.** Prefer a period, comma, colon, or parentheses. The
+   public docs currently average about four to five em dashes per page, which
+   reads as generated rather than written. Table cells and numeric ranges are
+   exempt.
+8. **No inflated vocabulary.** Do not use `seamless`/`seamlessly`, `robust`,
+   `leverage` (as a verb), `comprehensive`, or `essential` as praise. Say what
+   the thing does. "Integrates seamlessly with" is "works with"; "leverage
+   the fluent API" is "use the fluent API".
+9. **Plain copulas.** Prefer "is", "are", "has" over "serves as", "stands
+   as", "represents a", "boasts".
+
+### Editing pass
+
+When rewriting existing prose rather than authoring new prose, run one pass
+before committing: draft the rewrite, then ask two questions of it.
+
+1. What still marks this as generated rather than written?
+2. Does the rewrite state any fact, name, number, version, or citation that
+   is not in the source or verified against engine source?
+
+A rewrite that invents a specific detail is a defect even when it reads
+better than the vague original. Opinion and phrasing are yours to change;
+factual claims are not.
+
+Rules 7-9 and the editing pass above are re-expressed from blader/humanizer
+(MIT, Copyright (c) 2025 Siqi Chen); the states rule in the PR checklist below
+is re-expressed from leonxlnx/taste-skill (MIT, Copyright (c) 2026 Leonxlnx).

--- a/docs/reference/actions/API/API_Authentication.md
+++ b/docs/reference/actions/API/API_Authentication.md
@@ -7,7 +7,7 @@ keywords: [SHAFT, API authentication, basic auth, digest auth, OAuth2, bearer to
 tags: [api, authentication, security, rest-assured]
 ---
 
-SHAFT Engine supports multiple API authentication strategies through `setAuthentication()` and the fluent request builder. All authentication methods integrate seamlessly with the existing `SHAFT.API` request-building API.
+SHAFT Engine supports multiple API authentication strategies through `setAuthentication()` and the fluent request builder. All authentication methods work with the existing `SHAFT.API` request-building API.
 
 ---
 

--- a/docs/reference/actions/TestData_Management.md
+++ b/docs/reference/actions/TestData_Management.md
@@ -9,7 +9,7 @@ tags: [test-data, json, excel, csv]
 
 ## Overview
 
-Test data management is a critical aspect of test automation. SHAFT Engine provides robust support for managing test data across different file formats, making it easy to maintain, scale, and share test data across your automation projects.
+Test data management is a critical aspect of test automation. SHAFT Engine supports managing test data across different file formats, making it easy to maintain, scale, and share test data across your automation projects.
 
 SHAFT Engine supports the following test data formats:
 - **JSON** - Ideal for structured data, API payloads, and complex nested data
@@ -626,7 +626,7 @@ List<String> items = testData.getListAs("items", String.class);
 - Supports comments (`#`) — helpful for documenting test data
 - Handles nested structures and lists natively
 - Ideal replacement for properties files when you need hierarchy
-- Works seamlessly with SHAFT's type-safe API
+- Works with SHAFT's type-safe API
 
 ### Best Practices for YAML
 
@@ -920,7 +920,7 @@ public void databaseTest() throws Exception {
 
 ## Summary
 
-SHAFT Engine provides comprehensive test data management capabilities:
+SHAFT Engine provides these test data management capabilities:
 
 1. **JSON**: Best for structured, hierarchical data and API testing
 2. **CSV**: Ideal for simple tabular data and bulk test inputs
@@ -935,7 +935,7 @@ SHAFT Engine provides comprehensive test data management capabilities:
 - Handle sensitive data securely
 - Load test data efficiently
 
-By following these guidelines and examples, you can build a robust and maintainable test data management strategy for your SHAFT Engine automation projects.
+By following these guidelines and examples, you can build a maintainable test data management strategy for your SHAFT Engine automation projects.
 
 ---
 

--- a/docs/reference/actions/Validations.md
+++ b/docs/reference/actions/Validations.md
@@ -11,7 +11,7 @@ SHAFT Engine allows you to perform assertions and verifications easily using the
 
 ## Overview {/* #overview */}
 
-Assertions and verifications are essential components in test automation. Each serves a distinct purpose:
+Assertions and verifications are core parts of test automation. Each serves a distinct purpose:
 
 1. **Assertions (Hard Assertions)** — If the assertion condition is not met, test execution is **aborted** immediately. The remaining steps in the test case are skipped and the result is marked as **failed**. Use assertions for business-critical checkpoints.
 2. **Verifications (Soft Assertions)** — Even if the verification condition is not met, test execution **continues** until the last step completes. All failures are collected and reported at the end of the test run. Use verifications when you want to validate multiple conditions in a single test.

--- a/docs/reference/guides/Solution_Design.md
+++ b/docs/reference/guides/Solution_Design.md
@@ -216,7 +216,7 @@ public class CheckoutTest extends BaseTest {
 
 1. **Start with POM** — it is the industry standard and scales well.
 2. **Use a base class** for driver setup/teardown, but keep it thin.
-3. **Leverage SHAFT's fluent API** inside your page object methods for readability.
+3. **Use SHAFT's fluent API** inside your page object methods for readability.
 4. **Avoid deep inheritance hierarchies** — prefer composition over inheritance when sharing behavior between page objects.
 5. **Choose one primary pattern and be consistent** across your project — mixing too many patterns creates confusion.
 

--- a/docs/reference/guides/Test_Structure.md
+++ b/docs/reference/guides/Test_Structure.md
@@ -125,7 +125,7 @@ TestNG's `@Test(priority = N)` attribute controls execution order, but it has im
 | Controls order but does **not** skip dependents on failure | Explicitly skips dependent tests when a prerequisite fails |
 | All tests still run even if early ones fail | Failing early stops the chain — saves time and avoids noise |
 | Implicit relationship — hard to understand at a glance | Explicit dependency — self-documenting |
-| Fragile when tests are added or reordered | Robust — dependencies are declared by name |
+| Fragile when tests are added or reordered | Stable — dependencies are declared by name |
 
 :::warning
 Using `priority` to order tests creates a hidden dependency. If a test with `priority=1` fails, the test with `priority=2` still runs — often producing confusing, cascading failures that waste debugging time.

--- a/docs/reference/guides/Tool_Selection.md
+++ b/docs/reference/guides/Tool_Selection.md
@@ -51,7 +51,7 @@ SHAFT includes **Allure reporting** out of the box — with screenshots, videos,
 - Can configuration be overridden from the command line?
 - Is there built-in support for generating portable artifacts?
 
-SHAFT supports [headless execution and CLI-based property overrides](CI_CD_Integration) for seamless pipeline integration.
+SHAFT supports [headless execution and CLI-based property overrides](CI_CD_Integration) for direct pipeline integration.
 
 ### 5. Maintenance Cost
 
@@ -64,7 +64,7 @@ SHAFT handles **automatic waits, smart scrolling, element retry, and screenshot 
 ### 6. Learning Curve
 
 - How long does it take a new team member to write their first test?
-- Is the documentation clear and comprehensive?
+- Is the documentation clear and complete?
 - Are there working examples and templates?
 
 SHAFT provides a [one-command project setup](/docs/start/installation),

--- a/docs/testing/mobile.md
+++ b/docs/testing/mobile.md
@@ -111,7 +111,7 @@ context inspection.
 
 ## Flutter applications
 
-SHAFT Engine now supports automated testing of Flutter applications using the Appium Flutter Driver. This integration allows you to seamlessly test Flutter apps on both Android and iOS platforms.
+SHAFT Engine now supports automated testing of Flutter applications using the Appium Flutter Driver. This integration lets you test Flutter apps on both Android and iOS platforms.
 
 ## Prerequisites
 
@@ -378,7 +378,7 @@ driver.element()
 
 ## Cloud Execution
 
-SHAFT Engine's Flutter integration works seamlessly with cloud providers:
+SHAFT Engine's Flutter integration works with these cloud providers:
 
 ### BrowserStack
 
@@ -462,7 +462,7 @@ SHAFT.Properties.log4j.set().logLevel("DEBUG");
    SHAFT.Properties.timeouts.set().elementIdentificationTimeout(30);
    ```
 
-4. **Use Fluent API**: Leverage SHAFT's fluent API for readable tests:
+4. **Use Fluent API**: SHAFT's fluent API makes tests more readable:
    ```java
    driver.element()
          .type(usernameField, "user")

--- a/tests/docs-quality.test.js
+++ b/tests/docs-quality.test.js
@@ -30,6 +30,15 @@ const markdownImage = /!\[([^\]]*)\]\([^)]*\)/g;
 const genericAltText = new Set(['image', 'screenshot', 'img']);
 const headingLine = /^(#{1,6})\s+/gm;
 
+// #4048: DESIGN_LANGUAGE.md Content style guide rules 7-8, re-expressed from
+// blader/humanizer (MIT, Copyright (c) 2025 Siqi Chen).
+const inflatedVocabulary = /\b(seamlessly?|robust|comprehensive|leverage|essential)\b/i;
+// Ratchet, not a rewrite mandate: the measured worst public-docs file today
+// is 37 em dashes (agentic/intellij.md). This locks in that ceiling instead
+// of demanding a 300+-instance corpus rewrite for zero functional gain.
+const EM_DASH_MAX_PER_FILE = 40;
+const emojiChar = /\p{Extended_Pictographic}/u;
+
 function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
@@ -42,6 +51,15 @@ function withoutFences(content) {
 
 function lineAt(content, index) {
   return content.slice(0, index).split('\n').length;
+}
+
+// Blank out table rows too, for the em-dash density check only — table cells
+// are an explicit exemption in DESIGN_LANGUAGE.md's Content style guide #7.
+function withoutTableRows(content) {
+  return content
+    .split('\n')
+    .map((line) => (/^\s*\|.*\|\s*$/.test(line) ? line.replace(/[^\n]/g, ' ') : line))
+    .join('\n');
 }
 
 function publicDocs(directory = docsRoot, files = []) {
@@ -142,6 +160,31 @@ for (const {fullPath, relativePath} of docs) {
     );
     previousLevel = level;
   }
+
+  // Rule 6: no emoji in headings (DESIGN_LANGUAGE.md is already clean here;
+  // this is a regression lock, not a rewrite. blog/ is a separate corpus and
+  // this scan never reaches it — its release-note emoji headings are a
+  // deliberate convention, not slop).
+  for (const line of proseOnly.split('\n')) {
+    if (/^#{1,6}\s+/.test(line) && emojiChar.test(line)) {
+      assert(false, `${relativePath} has an emoji in a heading ("${line.trim()}") — keep headings emoji-free.`);
+    }
+  }
+
+  // Rule 7: no inflated-vocabulary praise words (Content style guide #8).
+  for (const line of proseOnly.split('\n')) {
+    const match = line.match(inflatedVocabulary);
+    if (match) {
+      assert(false, `${relativePath} uses inflated vocabulary word "${match[0]}" in "${line.trim()}" — say what the thing does instead (Content style guide #8).`);
+    }
+  }
+
+  // Rule 8: em-dash density ratchet (Content style guide #7).
+  const emDashCount = (withoutTableRows(proseOnly).match(/—/g) || []).length;
+  assert(
+    emDashCount <= EM_DASH_MAX_PER_FILE,
+    `${relativePath} has ${emDashCount} em dashes (ratchet max ${EM_DASH_MAX_PER_FILE} per page) — prefer a period, comma, colon, or parentheses (Content style guide #7).`,
+  );
 }
 
 function docsContaining(pattern) {


### PR DESCRIPTION
## Summary
Closes the gap the ShaftHQ/SHAFT_ENGINE#4048 architecture spec found: `DESIGN_LANGUAGE.md` calls itself the canonical style authority but `AGENTS.md` never pointed at it — every other change in this PR was inert until that closed.

- `AGENTS.md`: routing line to `DESIGN_LANGUAGE.md`.
- `DESIGN_LANGUAGE.md`: Content style guide rules 7-9 (sparing em dashes, no inflated vocabulary, plain copulas) plus an editing-pass mechanism — re-expressed from `blader/humanizer` (MIT, Copyright (c) 2025 Siqi Chen). PR checklist item 8 adds the interactive-states rule, re-expressed from `leonxlnx/taste-skill` (MIT, Copyright (c) 2026 Leonxlnx).
- `tests/docs-quality.test.js`: three new enforced checks over the same six public docs directories the file already scopes — emoji-free headings, the inflated-vocabulary shortlist, and an em-dash density ratchet set at today's worst file (37, `agentic/intellij.md`) with slack (40). This is a non-regression ratchet, not a rewrite mandate. `blog/`'s emoji-heading release-note convention (117 hits, 25 files) is untouched — `publicDocs()` only walks `docs/`, never `blog/`.
- Six docs files fixed the 13 measured `seamless(ly)`/`robust`/`comprehensive`/`leverage`/`essential` hits so the new vocabulary check starts green in this PR rather than red.

Rejected from the source repos (spec-kit process vocabulary, taste-skill's Tailwind/Framer specs, 27 of humanizer's 33 patterns that measured zero hits) per the architecture spec's anti-duplication pass on ShaftHQ/SHAFT_ENGINE#4048.

Companion PR ShaftHQ/SHAFT_ENGINE#4058 carries the two SHAFT-side residues (`standards.txt`, `work-github` playbook `[P]` marker) and is the one that actually closes the tracking issue.

## Test plan
- [x] `yarn test` — full suite green, including `tests/docs-quality.test.js`.
- [x] Proved each new check bites: the vocabulary check failed red against the real corpus before the content fixes (watched, then fixed); the emoji-heading and em-dash-ratchet checks were proven via a temporary fixture (emoji heading, then 44 em dashes) that failed red naming the fixture, then deleted — corpus is clean under both without a fixture.
- [x] `yarn typecheck` — pass.
- [x] `yarn build` — pass (pre-existing untruncated-blog-post warnings only, unrelated to this diff).

Part of ShaftHQ/SHAFT_ENGINE#4048

🤖 Generated with [Claude Code](https://claude.com/claude-code)