### PR TITLE
Fix agent-guidance.md ownership table for paths that do not exist here

### DIFF
--- a/docs/maintainers/agent-guidance.md
+++ b/docs/maintainers/agent-guidance.md
@@ -58,7 +58,19 @@ canonical rule file; they do not copy the canonical body into
 
 ## Audit
 
-Budgets and routing rules live in `scripts/ci/agent_guidance_budget.json`.
+This repository's own checks run via `yarn test` (including
+`tests/docs-quality.test.js`, which enforces the admonition vocabulary and
+content style guide rules from `DESIGN_LANGUAGE.md`), `yarn typecheck`, and
+`yarn build`:
+
+```bash
+yarn test
+yarn typecheck
+yarn build
+```
+
+`ShaftHQ/SHAFT_ENGINE` runs a separate audit against its own agent-guidance
+corpus, not present in this repository:
 
 ```bash
 python3 scripts/ci/validate_agent_guidance.py
@@ -66,10 +78,10 @@ python3 -m unittest tests.scripts.test_validate_agent_guidance
 git diff --check
 ```
 
-The audit checks file and host context budgets, both skill roots, local links,
-path scopes, stale references, costly mandates, duplicate paragraphs, and the
-manual paid-refresh gate.
-
-The refresh workflow runs only by manual dispatch. It invokes paid AI review
-only when the deterministic audit fails or a maintainer supplies a reason and
-forces review.
+Budgets and routing rules for that audit live in
+`scripts/ci/agent_guidance_budget.json` in `SHAFT_ENGINE`. It checks file and
+host context budgets, both skill roots, local links, path scopes, stale
+references, costly mandates, duplicate paragraphs, and the manual
+paid-refresh gate; its refresh workflow runs only by manual dispatch, and
+invokes paid AI review only when the deterministic audit fails or a
+maintainer supplies a reason and forces review.

--- a/docs/maintainers/agent-guidance.md
+++ b/docs/maintainers/agent-guidance.md
@@ -16,18 +16,30 @@ procedures belong in runbooks or skills.
 
 ## Ownership
 
+This repository's own canonical guidance lives here:
+
 | Content | Canonical location |
 |---|---|
+| Repository identity, defaults, content rules, validation | `AGENTS.md` |
+| Style authority: palette, typography tokens, prose rules | `DESIGN_LANGUAGE.md` |
+| Host-only behavior | `.github/copilot-instructions.md` |
+| Product and maintainer documentation | Docusaurus routes under `docs/` |
+| Executable behavior and history | `ShaftHQ/SHAFT_ENGINE` (a separate repository) configuration, source, and Git history |
+
+`ShaftHQ/SHAFT_ENGINE` keeps its own agent-guidance layout, referenced above
+but not present in this repository:
+
+| Content | Canonical location in `SHAFT_ENGINE` |
+|---|---|
 | Repository identity, global safety, routing, validation | `AGENTS.md` |
-| Host-only behavior | `CLAUDE.md`, `.github/copilot-instructions.md` |
+| Host-only behavior | `CLAUDE.md` |
 | Codex skill discovery metadata | `.agents/skills/*/SKILL.md` |
 | Production and test Java rules | `.github/instructions/*.instructions.md` |
 | CI, flaky-test, and release workflows | `.github/skills/*/SKILL.md` |
-| Product and maintainer documentation | Docusaurus routes in this repository |
-| Executable behavior and history | SHAFT_ENGINE configuration, source, and Git history |
 
-Codex bridge skills contain frontmatter and a link to one canonical rule file.
-Do not copy the canonical body into `.agents/skills/`.
+Codex bridge skills in `SHAFT_ENGINE` contain frontmatter and a link to one
+canonical rule file; they do not copy the canonical body into
+`.agents/skills/`.
 
 ## Update Rules
 


### PR DESCRIPTION
## Summary
- `docs/maintainers/agent-guidance.md`'s ownership table named `CLAUDE.md`, `.agents/skills/`, `.github/instructions/`, and `.github/skills/` as this repository's canonical guidance locations. None of the four exist here; they describe `ShaftHQ/SHAFT_ENGINE`'s layout.
- Split the table: this repository's own canonical guidance (`AGENTS.md`, `DESIGN_LANGUAGE.md` as the style authority, `.github/copilot-instructions.md`, Docusaurus `docs/` routes) stays in the "Ownership" table; the SHAFT_ENGINE-specific paths move into a second table explicitly labeled as SHAFT_ENGINE's own layout, not this repo's.
- The page's "Audit" section had the identical defect a few lines down: `scripts/ci/agent_guidance_budget.json`, `scripts/ci/validate_agent_guidance.py`, and `tests.scripts.test_validate_agent_guidance` are also absent here (`scripts/ci` doesn't exist in this repo at all) and are SHAFT_ENGINE-only. Applied the same two-block framing there: this repository's real checks (`yarn test`, `yarn typecheck`, `yarn build`) first, SHAFT_ENGINE's audit tooling explicitly labeled second.
- Swept the rest of the page (Goal, Update Rules) for the same defect; found none — those sections make no claims about paths existing in this repository.
- Verified all path claims (both the original four and the Audit-section three) are genuinely absent from this repository before editing.

Closes ShaftHQ/SHAFT_ENGINE#4054

## Test plan
- [x] `yarn test` (all suites, including `docs-quality.test.js`) — passed
- [x] `yarn typecheck` — passed
- [x] `yarn build` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)