### PR TITLE
Docs: sync Pilot timeout default

### DIFF
--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -1129,7 +1129,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
     .remoteConsent(false)
     .allowedEvidenceCategories("")
     .telemetryEnabled(false)
-    .timeoutSeconds(30)
+    .timeoutSeconds(300)
     .maxRequestBytes(1048576)
     .maxInputTokens(16000)
     .maxOutputTokens(2000)
@@ -1184,7 +1184,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   pilot.ai.consent.remote=false
   pilot.ai.allowedEvidenceCategories=
   pilot.ai.telemetry.enabled=false
-  pilot.ai.timeoutSeconds=30
+  pilot.ai.timeoutSeconds=300
   pilot.ai.maxRequestBytes=1048576
   pilot.ai.maxInputTokens=16000
   pilot.ai.maxOutputTokens=2000
@@ -1233,7 +1233,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | pilot.ai.consent.remote                          | `false`        | `true`, `false`  | Whether remote inference is approved. |
 | pilot.ai.allowedEvidenceCategories               | ` `            |                   | Comma-separated approved evidence categories. |
 | pilot.ai.telemetry.enabled                       | `false`        | `true`, `false`  | Whether optional external telemetry is enabled. |
-| pilot.ai.timeoutSeconds                          | `30`           |                   | Maximum provider timeout in seconds. |
+| pilot.ai.timeoutSeconds                          | `300`          |                   | Maximum provider timeout in seconds. |
 | pilot.ai.maxRequestBytes                         | `1048576`      |                   | Maximum serialized request size. |
 | pilot.ai.maxInputTokens                          | `16000`        |                   | Maximum estimated input tokens. |
 | pilot.ai.maxOutputTokens                         | `2000`         |                   | Maximum output tokens. |

--- a/scripts/generate-properties-catalog.mjs
+++ b/scripts/generate-properties-catalog.mjs
@@ -5,7 +5,7 @@
 // This is a maintainer-run refresh tool, not a build step (the docs site build does not depend
 // on a sibling engine checkout). Run it whenever engine properties change:
 //
-//   node scripts/generate-properties-catalog.mjs [--engine-path=<path>] [--check]
+//   node scripts/generate-properties-catalog.mjs [--engine-path=<path to properties/internal>] [--check]
 //
 // --check: do not write the file; exit non-zero if the generated catalog would differ from the
 //          committed one (used by tests/properties-catalog.test.js to catch drift in CI).

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -2184,7 +2184,7 @@
     "key": "pilot.ai.timeoutSeconds",
     "targetFile": "custom.properties",
     "type": "number",
-    "defaultValue": "30",
+    "defaultValue": "300",
     "possibleValues": "",
     "description": "Maximum provider timeout in seconds."
   },

--- a/tests/properties-catalog.test.js
+++ b/tests/properties-catalog.test.js
@@ -17,7 +17,7 @@ const allowedTypes = new Set(['boolean', 'text', 'number']);
 // scripts/generate-properties-catalog.mjs) -- 405 properties at the time this floor was set.
 // Keep this a floor, not an exact match: the engine gains properties over time and this test
 // must not need touching on every unrelated engine release. Regenerate with
-// `node scripts/generate-properties-catalog.mjs --engine-path=<path to SHAFT_ENGINE checkout>`.
+// `node scripts/generate-properties-catalog.mjs --engine-path=<path to shaft-engine/src/main/java/com/shaft/properties/internal>`.
 assert(catalog.length >= 400, `Properties catalog should include the full SHAFT property set (got ${catalog.length}).`);
 
 const seenKeys = new Set();
@@ -79,6 +79,10 @@ for (const [tokenCountKey, expectedDefault, expectedType] of [
   assert(property.defaultValue === expectedDefault, `${tokenCountKey} must publish its real numeric default '${expectedDefault}', got '${property.defaultValue}'`);
   assert(property.type === expectedType, `${tokenCountKey} must have type '${expectedType}', got '${property.type}'`);
 }
+
+const pilotTimeout = catalog.find((p) => p.key === 'pilot.ai.timeoutSeconds');
+assert(pilotTimeout, 'Missing expected property pilot.ai.timeoutSeconds');
+assert(pilotTimeout.defaultValue === '300', `pilot.ai.timeoutSeconds must publish default '300', got '${pilotTimeout.defaultValue}'`);
 
 // Non-sensitive credential-pointer regression guard for #829: these keys contain "apikey" but
 // hold the *name* of an environment variable/header/prefix that points at a credential, not the


### PR DESCRIPTION
## Summary
- Publish the current `pilot.ai.timeoutSeconds` default of 300 in the catalog and all Properties List examples.
- Add a focused regression assertion and correct the generator path guidance.

Related to ShaftHQ/SHAFT_ENGINE#4365

## Test plan
- [x] `node tests/properties-catalog.test.js`
- [x] `node tests/properties-list-coverage.test.js`