### PR TITLE
fix: remediate user-guide code scanning alerts

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,6 +3,9 @@ name: PR Build Gate
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Docs Build
@@ -16,6 +19,9 @@ jobs:
 
       - name: Install
         run: yarn install --frozen-lockfile
+
+      - name: Security regressions
+        run: yarn test:security
 
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc --noEmit",
-    "test": "npm run test:docs && npm run test:homepage && npm run test:history",
+    "test": "npm run test:security && npm run test:docs && npm run test:homepage && npm run test:history",
+    "test:security": "node tests/security-regressions.test.js",
     "test:history": "node tests/chat-history.test.js",
     "test:homepage": "node tests/homepage-performance.test.js",
     "test:docs": "node tests/docs-loader.test.js && node tests/cloudflare-autobot.test.js && node tests/enhanced-instruction.test.js && node tests/properties-catalog.test.js && node tests/generate-properties-catalog-regex.test.js && node tests/properties-list-coverage.test.js && node tests/docs-quality.test.js && node tests/design-contrast.test.js && node scripts/check-doc-duplicates.mjs",
@@ -54,6 +55,7 @@
     "@playwright/test": "^1.62.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
+    "cross-spawn": "^7.0.6",
     "typescript": "^7.0.2"
   },
   "resolutions": {

--- a/scripts/run-shaft-tests.mjs
+++ b/scripts/run-shaft-tests.mjs
@@ -1,4 +1,4 @@
-import {spawn, spawnSync} from 'node:child_process';
+import crossSpawn from 'cross-spawn';
 import {readFile} from 'node:fs/promises';
 import {fileURLToPath} from 'node:url';
 import net from 'node:net';
@@ -48,18 +48,12 @@ async function waitForSite(baseUrl) {
   throw new Error(`Timed out waiting for ${baseUrl}`);
 }
 
-function commandInvocation(command, args) {
-  if (!isWindows) return {command, args};
-  return {command: 'cmd.exe', args: ['/d', '/s', '/c', command, ...args]};
-}
-
 let server;
 let baseUrl = externalBaseUrl;
 if (!baseUrl) {
   const port = await findAvailablePort(Number(process.env.SHAFT_DOCS_PORT ?? 3000));
   baseUrl = `http://${host}:${port}`;
-  const invocation = commandInvocation(yarnCommand, ['serve', '--host', host, '--port', String(port)]);
-  server = spawn(invocation.command, invocation.args, {
+  server = crossSpawn(yarnCommand, ['serve', '--host', host, '--port', String(port)], {
     cwd: repoRoot,
     shell: false,
     stdio: 'inherit',
@@ -70,15 +64,15 @@ if (!baseUrl) {
 try {
   await waitForSite(baseUrl);
 
-  const mavenInvocation = commandInvocation(mavenCommand, [
+  const result = crossSpawn.sync(mavenCommand, [
     '-f',
     'tests/shaft/pom.xml',
     'test',
     `-Dshaft.version=${shaftVersion}`,
     `-Dsite.baseUrl=${baseUrl}`,
     '-Dgpg.skip=true',
-  ]);
-  const result = spawnSync(mavenInvocation.command, mavenInvocation.args, {
+    '-Dallure.automaticallyOpen=false',
+  ], {
     cwd: repoRoot,
     shell: false,
     stdio: 'inherit',
@@ -90,7 +84,7 @@ try {
 } finally {
   if (server) {
     if (isWindows) {
-      spawnSync('taskkill', ['/pid', String(server.pid), '/t', '/f'], {stdio: 'ignore'});
+      crossSpawn.sync('taskkill', ['/pid', String(server.pid), '/t', '/f'], {stdio: 'ignore'});
     } else {
       server.kill('SIGTERM');
     }

--- a/tests/e2e/homepage.spec.js
+++ b/tests/e2e/homepage.spec.js
@@ -90,7 +90,7 @@ test('landing page exposes clear onboarding links with stable hooks', async ({pa
   await expect(pathfinder.getByRole('link', {name: /Connect MCP after the basics/})).toHaveAttribute('href', '/docs/start/quick-start#mcp-integration');
   await expect(pathfinder.getByRole('link', {name: /Add coverage beyond the browser/})).toHaveAttribute('href', '#testing-surfaces');
   await expect(page.getByTestId('landing-cta-install')).toHaveAttribute('href', '/docs/start/quick-start#new-project-generation');
-  await expect(page.getByTestId('landing-cta-slack')).toHaveAttribute('href', /join\.slack\.com\/t\/shaft-engine/);
+  await expect(page.getByTestId('landing-cta-slack')).toHaveAttribute('href', /^https:\/\/join\.slack\.com\/t\/shaft-engine\/.+$/);
 
   await page.goto('/');
   await expect(page.locator('#proof-section')).toBeVisible();

--- a/tests/security-regressions.test.js
+++ b/tests/security-regressions.test.js
@@ -1,0 +1,45 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..');
+const runner = fs.readFileSync(path.join(repoRoot, 'scripts', 'run-shaft-tests.mjs'), 'utf8');
+const homepage = fs.readFileSync(path.join(repoRoot, 'tests', 'e2e', 'homepage.spec.js'), 'utf8');
+const prBuild = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'pr-build.yml'), 'utf8');
+
+assert.match(
+  runner,
+  /from 'cross-spawn'/,
+  'SHAFT test commands must use cross-spawn so Windows .cmd launchers receive literal argument arrays.',
+);
+assert.doesNotMatch(
+  runner,
+  /node:child_process|cmd\.exe/,
+  'SHAFT test commands must not forward environment-derived arguments through a command shell.',
+);
+assert.strictEqual(
+  (runner.match(/shell: false/g) ?? []).length,
+  2,
+  'Both the server and Maven command must explicitly disable shell interpretation.',
+);
+assert.match(
+  runner,
+  /'-Dallure\.automaticallyOpen=false'/,
+  'Headless Maven verification must explicitly prevent Allure from opening a GUI.',
+);
+assert.ok(
+  homepage.includes('/^https:\\/\\/join\\.slack\\.com\\/t\\/shaft-engine\\/.+$/'),
+  'The Slack CTA assertion must anchor both ends of the trusted invite URL.',
+);
+assert.match(
+  prBuild,
+  /^permissions:\r?\n {2}contents: read$/m,
+  'The PR build workflow must explicitly grant only read access to repository contents.',
+);
+assert.match(
+  prBuild,
+  /^\s+run: yarn test:security$/m,
+  'The PR build must run the security regression before building the site.',
+);
+
+console.log('Security regression checks passed.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4793,7 +4793,7 @@ cosmiconfig@^8.1.3, cosmiconfig@^8.3.5:
     parse-json "^5.2.0"
     path-type "^4.0.0"
 
-cross-spawn@^7.0.3:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION
## Summary

- replace shell-mediated Windows command forwarding with argument-safe `cross-spawn`
- anchor the Slack invite assertion and restrict the PR workflow token to `contents: read`
- add a CI-enforced regression guard for all four CodeQL alert sites
- keep Maven/Allure verification headless

Closes #936
Related to #934
Related to #935

## Verification

- `yarn install --frozen-lockfile`
- `yarn test:security`
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` — 20 passed
- `yarn test:shaft` — Windows Yarn/Maven launch, headless server/browser, exit propagation, and cleanup were exercised; the downstream suite ran 27 tests and exposed 2 pre-existing properties-generator smoke-test failures tracked in #937

## Review

Independent adversarial review found and fixed two blocking verification gaps: pinning both `shell: false` sites and running the security regression in PR CI. The follow-up round returned zero blocking findings.