### PR TITLE
codex: document portable ChaosEngine installation

### DIFF
--- a/docs/agentic/chaos-engine.mdx
+++ b/docs/agentic/chaos-engine.mdx
@@ -1,0 +1,70 @@
+---
+id: chaos-engine
+title: Install ChaosEngine
+description: Install or upgrade the project-local SHAFT agent harness from the latest main commit.
+slug: /agentic/chaos-engine
+keywords: [ChaosEngine, agent harness, install, upgrade, Codex, Claude, Gemini]
+tags: [agents, skills, install]
+---
+
+# Install ChaosEngine
+
+ChaosEngine is SHAFT's project-local agent harness. It makes one canonical
+skill the entrypoint for supported coding agents, installs the matching host
+adapters, and provisions its tracked local tools without relying on a global
+machine setup.
+
+## Give the install command to your agent
+
+Open the SHAFT project that should receive the harness and give this command to
+Codex, Claude, Grok, Gemini, or another coding agent:
+
+```text
+Install or upgrade ChaosEngine in this project from the latest commit of ShaftHQ/SHAFT_ENGINE main. Fetch and inspect https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py, run it with Python 3, --project ., --repository ShaftHQ/SHAFT_ENGINE, and --branch main; then run Python 3 with .chaos-engine/install.py status --project . Do not stop until status reports the resolved 40-character commit and healthy core, host adapters, and local tools. Treat the installed ChaosEngine skill as the canonical harness and route existing agent guidance through it without deleting unrelated user content.
+```
+
+The agent chooses the available Python 3 command on Windows, macOS, or Linux.
+It must inspect the bootstrap before running it and report any network or
+permission boundary instead of bypassing it.
+
+## Verify and upgrade
+
+Run the installed status command from the project root:
+
+```shell
+python3 .chaos-engine/install.py status --project .
+```
+
+On Windows, use `py -3` in place of `python3`. Re-run the same agent command to
+upgrade. The bootstrap resolves `main` to an immutable commit, validates the
+downloaded archive, and records its repository, branch, and commit provenance.
+If resolution, download, validation, or tool setup fails, ChaosEngine preserves
+the last verified installation.
+
+The project may be a SHAFT Git checkout, another Git checkout, or a non-Git
+folder. The bootstrap uses the configured SHAFT upstream and never infers it
+from the consumer project's Git remote.
+
+## What gets installed
+
+ChaosEngine installs and owns these project-local surfaces:
+
+- the verified core and canonical skill under `.chaos-engine/`;
+- native discovery adapters for Codex, Claude, Gemini, Copilot, and compatible
+  agents;
+- a private dependency runtime for the tracked Memory, MemPalace, Graphify,
+  and supporting tools;
+- receipts and transaction state used by status, repair, rollback, and
+  uninstall.
+
+It preserves unrelated project instructions, skills, configuration, and tool
+entries. Its self-learning flow queues only privacy-screened, confirmed
+lessons and contributes them upstream as reviewable GitHub issues, never as an
+automatic pull request.
+
+## Related
+
+- [Install SHAFT agent skills](/docs/agentic/skills)
+- [Agentic testing overview](/docs/agentic/overview)
+- [Connect SHAFT MCP](/docs/agentic/mcp)
+- [SHAFT CLI](/docs/agentic/cli)

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -28,6 +28,10 @@ flowchart TD
 
 ## Install SHAFT agent tools
 
+Install the project-local [ChaosEngine harness](/docs/agentic/chaos-engine) when
+you want one canonical agent workflow plus verified host adapters and local
+Memory, MemPalace, and Graphify tooling.
+
 Install the first-party skill pack without configuring an MCP client. The
 [SHAFT agent skills guide](/docs/agentic/skills) owns the commands, supported
 routes, native directories, upgrade behavior, and packaging tradeoffs.
@@ -87,6 +91,7 @@ MCP commands live on /docs/agentic/mcp#mcp-command-reference
 
 ## Related
 
+- [ChaosEngine](/docs/agentic/chaos-engine)
 - [SHAFT agent skills](/docs/agentic/skills)
 - [MCP](/docs/agentic/mcp)
 - [Pilot](/docs/agentic/pilot)

--- a/sidebars.js
+++ b/sidebars.js
@@ -44,6 +44,7 @@ const sidebars = {
       collapsed: true,
       items: [
         'agentic/overview',
+        'agentic/chaos-engine',
         'agentic/skills',
         'agentic/mcp',
         'agentic/intellij',


### PR DESCRIPTION
## Summary

- add the canonical portable ChaosEngine install and upgrade command
- explain verification, provenance, rollback preservation, host adapters, local tools, and privacy-safe learning
- link the page from the Agentic overview and sidebar

This PR was created by Codex, not manually by the maintainer whose token opened it.

Companion to ShaftHQ/SHAFT_ENGINE#4800 and closes ShaftHQ/SHAFT_ENGINE#4798 when both PRs merge.

## Verification

- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (20 passed)
- rendered `/docs/agentic/chaos-engine` inspected
- independent review: zero release-blocking findings

## Graphify

Refresh was not run because the repository primary checkout contains unrelated uncommitted Graphify output. That user state was preserved; this documentation-only navigation change was verified from live source and the rendered build.
