### PR TITLE
docs: explain batteries-included infrastructure setup

### DIFF
--- a/docs/agentic/cli.md
+++ b/docs/agentic/cli.md
@@ -78,6 +78,13 @@ prints the port and pid; `status` prints
 - `shaft-cli guide search` (stateless)
 - `shaft-cli doctor analyze|suggest` (stateless)
 
+**`shaft-cli setup ...`** — diagnose local prerequisites and create an exact,
+reviewable plan for SHAFT-owned tools. Setup commands run directly and do not
+require an MCP session. Follow the
+[local infrastructure setup guide](/docs/start/local-infrastructure) for the
+plan, digest approval, policy options, readiness exit codes, and current
+provider coverage.
+
 ## Examples
 
 ```text
@@ -110,6 +117,7 @@ shaft-cli call test_plan_explore targetUrl=https://example.test goal='checkout h
 ## Related
 
 - [MCP](/docs/agentic/mcp)
+- [Set up local infrastructure](/docs/start/local-infrastructure)
 - [Overview](/docs/agentic/overview)
 - [Capture](/docs/agentic/capture)
 - [Doctor](/docs/agentic/doctor)

--- a/docs/reference/properties/Programmatic_Config.md
+++ b/docs/reference/properties/Programmatic_Config.md
@@ -81,6 +81,29 @@ boolean isHeadless = SHAFT.Properties.web.headlessExecution();
 
 ---
 
+## Local Infrastructure Properties
+
+Configure setup ownership and policy before calling `SHAFT.Infrastructure`:
+
+```java title="ProgrammaticConfig.java"
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupProfile;
+
+SHAFT.Properties.infrastructure.set()
+    .profile(SetupProfile.REPORTING)
+    .mode(SetupMode.MANAGED)
+    .offline(false)
+    .autoStart(false)
+    .startupTimeout("PT2M")
+    .shutdownTimeout("PT30S");
+```
+
+The default `EXTERNAL` mode performs diagnosis without local mutation. Read
+the [local infrastructure setup guide](/docs/start/local-infrastructure)
+before approving a managed plan.
+
+---
+
 ## Complete Example
 
 ```java title="ProgrammaticConfigTest.java"
@@ -161,3 +184,4 @@ Avoid setting properties in parallel test methods without careful thread-isolati
 - [Property Types](/docs/reference/properties/PropertyTypes)
 - [Properties List](/docs/reference/properties/PropertiesList)
 - [Common Examples](/docs/reference/properties/CommonExamples)
+- [Set up local infrastructure](/docs/start/local-infrastructure)

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -295,6 +295,10 @@ Build a `.properties` file interactively instead of copying keys by hand: search
 | playwright.artifactsDirectory              | `target/playwright-artifacts` | relative or absolute path | Directory for Playwright traces and artifacts. |
 | playwright.downloadsDirectory              | ` `                           | relative or absolute path | Optional downloads directory. Empty uses Playwright defaults. |
 | playwright.acceptDownloads                 | `true`                        | `true`, `false` | Allow Playwright browser contexts to accept downloads. |
+| playwright.timezoneId                      | ` `                           | IANA time zone identifier | Optional time zone for new browser contexts. Empty uses the browser default. |
+| playwright.locale                          | ` `                           | locale identifier | Optional locale for new browser contexts. Empty uses the browser default. |
+| playwright.userAgent                       | ` `                           | user-agent string | Optional user agent for new browser contexts. Empty uses the browser or device default. |
+| playwright.javaScriptEnabled               | `true`                        | `true`, `false` | Enables JavaScript in new browser contexts. |
 | playwright.tracing.enabled                 | `false`                       | `true`, `false` | Start Playwright tracing for the session. |
 | playwright.tracing.onRetryOnly             | `true`                        | `true`, `false` | Enable tracing automatically only during SHAFT retry evidence capture. |
 | playwright.tracing.screenshots             | `true`                        | `true`, `false` | Include screenshots in trace artifacts. |
@@ -1090,6 +1094,106 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
   </TabItem>
 </Tabs>
 
+## Infrastructure
+
+- These properties select the local setup profile and bind the ownership,
+  storage, network, reuse, and lifecycle policy reviewed in a setup plan.
+
+<Tabs groupId="PropertyTypes" queryString="Infrastructure">
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  import com.shaft.driver.SHAFT;
+  import com.shaft.infrastructure.SetupMode;
+  import com.shaft.infrastructure.SetupProfile;
+
+  SHAFT.Properties.infrastructure.set()
+    .profile(SetupProfile.REPORTING)
+    .mode(SetupMode.EXTERNAL)
+    .offline(false)
+    .autoStart(false);
+  ```
+
+  </TabItem>
+  <TabItem value="cli-based" label="CLI-based">
+
+  ```powershell
+  mvn test "-Dinfrastructure.profile=REPORTING" "-Dinfrastructure.mode=EXTERNAL"
+  ```
+
+  </TabItem>
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  infrastructure.mode=EXTERNAL
+  infrastructure.profile=REPORTING
+  infrastructure.cacheDirectory=
+  infrastructure.offline=false
+  infrastructure.autoStart=false
+  infrastructure.preferSystemTools=true
+  infrastructure.reuseOwnedProcesses=true
+  infrastructure.startupTimeout=PT2M
+  infrastructure.shutdownTimeout=PT30S
+  ```
+
+  </TabItem>
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name | Default Value | Possible Values | Description |
+| --- | --- | --- | --- |
+| infrastructure.mode | `EXTERNAL` | `EXTERNAL`, `MANAGED`, `HYBRID` | Selects setup ownership; `EXTERNAL` is non-mutating. |
+| infrastructure.profile | `REPORTING` | setup profile name | Selects the profile used by `SHAFT.Infrastructure`. |
+| infrastructure.cacheDirectory | ` ` | absolute path | Overrides SHAFT-owned setup storage when non-empty. |
+| infrastructure.offline | `false` | `true`, `false` | Requires verified cached artifacts and disables network access. |
+| infrastructure.autoStart | `false` | `true`, `false` | Requests startup for providers that own a service. |
+| infrastructure.preferSystemTools | `true` | `true`, `false` | Allows supporting providers to prefer compatible host tools. |
+| infrastructure.reuseOwnedProcesses | `true` | `true`, `false` | Allows supporting providers to reuse compatible SHAFT-owned processes. |
+| infrastructure.startupTimeout | `PT2M` | positive ISO-8601 duration | Sets the startup timeout for supporting lifecycle providers. |
+| infrastructure.shutdownTimeout | `PT30S` | positive ISO-8601 duration | Sets the shutdown timeout for supporting lifecycle providers. |
+
+  </TabItem>
+</Tabs>
+
+## Ocr
+
+- These properties control the SHAFT-owned OCR runtime cache and whether a
+  missing verified runtime may be downloaded.
+
+<Tabs groupId="PropertyTypes" queryString="Ocr">
+  <TabItem value="code-based" label="Code-based">
+
+  ```java showLineNumbers
+  SHAFT.Properties.ocr.set()
+    .cacheDirectory("")
+    .downloadEnabled(true);
+  ```
+
+  </TabItem>
+  <TabItem value="cli-based" label="CLI-based">
+
+  ```powershell
+  mvn test "-Dshaft.ocr.downloadEnabled=true"
+  ```
+
+  </TabItem>
+  <TabItem value="file-based" label="File-based">
+
+  ```properties showLineNumbers title="src/main/resources/properties/custom.properties"
+  shaft.ocr.cacheDirectory=
+  shaft.ocr.downloadEnabled=true
+  ```
+
+  </TabItem>
+  <TabItem value="defaults" label="Default Values">
+
+| Property Name | Default Value | Possible Values | Description |
+| --- | --- | --- | --- |
+| shaft.ocr.cacheDirectory | ` ` | absolute path or empty | Optional OCR runtime cache override. Empty uses the platform default. |
+| shaft.ocr.downloadEnabled | `true` | `true`, `false` | Allows a missing verified OCR runtime to be downloaded. |
+
+  </TabItem>
+</Tabs>
+
 ## Pilot
 
 - These properties control SHAFT's optional Pilot AI provider integrations
@@ -1282,6 +1386,9 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | pilot.ai.ollama.apiKeyEnvironmentVariable        | ` `            |                   | Optional environment variable containing an on-prem Ollama gateway credential. |
 | pilot.ai.ollama.apiKeyHeader                     | `Authorization` |                  | Optional Ollama gateway credential header. |
 | pilot.ai.ollama.apiKeyPrefix                     | `Bearer `      |                   | Optional Ollama gateway credential prefix. |
+| pilot.ai.lmstudio.endpoint                       | `http://127.0.0.1:1234/v1/responses` | | LM Studio OpenAI-compatible Responses endpoint. |
+| pilot.ai.lmstudio.model                          | ` `            |                   | Configured LM Studio model. |
+| pilot.ai.lmstudio.apiKeyEnvironmentVariable      | ` `            |                   | Optional environment variable containing an LM Studio gateway credential. |
 
   </TabItem>
 </Tabs>

--- a/docs/start/installation.mdx
+++ b/docs/start/installation.mdx
@@ -118,5 +118,6 @@ fails.
 ## Related
 
 - [Quick start](/docs/start/quick-start)
+- [Set up local infrastructure](/docs/start/local-infrastructure)
 - [Upgrade an existing project](/docs/start/upgrade)
 - [Features and modules](/docs/features/modules)

--- a/docs/start/local-infrastructure.mdx
+++ b/docs/start/local-infrastructure.mdx
@@ -1,0 +1,229 @@
+---
+id: local-infrastructure
+title: Set up local infrastructure
+description: Diagnose, plan, approve, and install SHAFT-owned local tools through shaft-cli or Java.
+slug: /start/local-infrastructure
+tags: [installation, infrastructure, cli, allure, reporting]
+---
+
+# Set up local infrastructure
+
+Use SHAFT's setup surface to inspect external prerequisites or install supported
+tools into SHAFT-owned user directories. The safe default is `EXTERNAL`: SHAFT
+diagnoses the host without downloading, installing, or starting anything.
+
+The setup catalog includes web, mobile, Grid, reporting, OCR, agent-tool, and
+local-AI profiles. Managed installation is currently available for
+`REPORTING`. It installs SHA-256-verified portable Node and Allure 3 artifacts.
+The other profiles are cataloged for the shared contract but currently return
+unsupported from provider-backed diagnosis and lifecycle commands.
+
+## Inspect the catalog and host
+
+Install `shaft-cli` through the
+[shaft-cli installation flow](/docs/agentic/cli#install), then list the setup
+profiles:
+
+```bash
+shaft-cli setup catalog
+shaft-cli setup doctor --profile REPORTING
+shaft-cli setup status --profile REPORTING
+```
+
+Add `--json` to `catalog`, `doctor`, `status`, or `verify` when a script needs a
+versioned machine-readable result. Readiness commands exit with `0` when ready
+and `3` when the profile is missing or degraded.
+
+## Review and approve an installation
+
+Create an exact plan before allowing any mutation. Use an absolute path for
+the plan file:
+
+```bash
+shaft-cli setup plan \
+  --profile REPORTING \
+  --mode MANAGED \
+  --output /absolute/path/reporting-plan.json
+```
+
+Review the JSON plan and copy the printed `sha256:` digest. Apply that exact
+plan with the same policy options used to create it:
+
+```bash
+shaft-cli setup install \
+  --plan /absolute/path/reporting-plan.json \
+  --approve sha256:<digest>
+
+shaft-cli setup verify --profile REPORTING
+```
+
+`apply` and `update` are aliases for `install`. SHAFT rejects a changed or stale
+plan, a mismatched policy, a missing license acceptance, or an artifact whose
+checksum does not match before publishing it as installed.
+
+:::warning
+Treat the plan digest as a one-plan approval, not a general consent switch.
+Changing a version, source, checksum, destination, timeout, or policy option
+changes the digest and requires a new review.
+:::
+
+## Keep policy options identical
+
+Plan and install accept the same execution policy:
+
+| Option | Default | Effect |
+|---|---:|---|
+| `--offline` | `false` | Require verified cached artifacts and disable network access. |
+| `--auto-start` | `false` | Bind a startup request for providers that own a service. |
+| `--prefer-system-tools=true\|false` | `true` | Bind whether a provider may prefer a compatible host tool. |
+| `--reuse-owned-processes=true\|false` | `true` | Bind whether a provider may reuse compatible SHAFT-owned processes. |
+| `--startup-timeout <duration>` | `PT2M` | Bind a positive ISO-8601 startup timeout for providers with lifecycle support. |
+| `--shutdown-timeout <duration>` | `PT30S` | Bind a positive ISO-8601 shutdown timeout for providers with lifecycle support. |
+
+Pass any non-default option to both commands. You may also pass an absolute
+`--cache-root` and `--data-root` pair to both commands; SHAFT rejects a single
+root or a relative path.
+
+The current `REPORTING` provider enforces `--offline`. It has no owned service,
+so auto-start, process reuse, and lifecycle timeouts are policy-bound for
+provider parity but do not change a reporting install. Reporting installs
+SHAFT-owned portable tools rather than adopting system Node or Allure.
+
+:::warning
+Custom roots become mutable SHAFT-owned storage. Use dedicated, user-scoped
+directories. Do not point them at a repository, shared or system directory, or
+a path reached through a symlink alias.
+:::
+
+## Use the Java API
+
+Configure the same policy through `SHAFT.Properties.infrastructure`, then plan
+and explicitly approve the immutable result:
+
+```java title="ReportingInfrastructure.java"
+import com.shaft.driver.SHAFT;
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupPlan;
+import com.shaft.infrastructure.SetupPlanStore;
+import com.shaft.infrastructure.SetupProfile;
+
+import java.nio.file.Path;
+
+public final class ReportingInfrastructure {
+    public static void main(String[] args) throws Exception {
+        SHAFT.Properties.infrastructure.set()
+            .profile(SetupProfile.REPORTING)
+            .mode(SetupMode.MANAGED)
+            .offline(false)
+            .autoStart(false);
+
+        SetupPlan plan = SHAFT.Infrastructure.plan();
+        SetupPlanStore.write(Path.of(args[0]).toAbsolutePath(), plan);
+
+        // Stop this phase and review the written JSON plus this digest.
+        System.out.println(plan.digest());
+    }
+}
+```
+
+Run the mutation in a separate phase. Supply the digest you reviewed instead
+of deriving it from a newly generated plan:
+
+```java title="InstallReviewedReportingPlan.java"
+import com.shaft.driver.SHAFT;
+import com.shaft.infrastructure.SetupApproval;
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupPlan;
+import com.shaft.infrastructure.SetupPlanStore;
+import com.shaft.infrastructure.SetupProfile;
+import com.shaft.infrastructure.SetupReceipt;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Set;
+
+public final class InstallReviewedReportingPlan {
+    public static void main(String[] args) throws Exception {
+        SetupPlan plan = SetupPlanStore.read(Path.of(args[0]).toAbsolutePath());
+        String reviewedDigest = System.getenv("SHAFT_APPROVED_SETUP_DIGEST");
+
+        // Recreate every policy value used by the planning phase.
+        SHAFT.Properties.infrastructure.set()
+            .profile(SetupProfile.REPORTING)
+            .mode(SetupMode.MANAGED)
+            .offline(false)
+            .autoStart(false);
+
+        if (!plan.executionPolicyDigest().equals(
+                SHAFT.Infrastructure.options().policyDigest())) {
+            throw new IllegalStateException(
+                "Current setup policy differs from the reviewed plan");
+        }
+
+        SetupApproval approval = new SetupApproval(
+            reviewedDigest, Instant.now(), Set.of());
+        SetupReceipt receipt = SHAFT.Infrastructure.install(plan, approval);
+        System.out.println(receipt.planDigest());
+    }
+}
+```
+
+Use `SHAFT.Infrastructure.catalog()`, `doctor()`, `status()`, and `verify()` for
+read-only inspection. `install(...)` and `start(...)` require both the exact
+plan and its approval; there is no unapproved mutation overload.
+
+Use an absolute plan path in both Java phases. Reproduce every property and
+path from the planning phase before installation; schema 3 rejects even a
+single policy or destination difference.
+
+The configuration defaults are:
+
+```properties
+infrastructure.mode=EXTERNAL
+infrastructure.profile=REPORTING
+infrastructure.cacheDirectory=
+infrastructure.offline=false
+infrastructure.autoStart=false
+infrastructure.preferSystemTools=true
+infrastructure.reuseOwnedProcesses=true
+infrastructure.startupTimeout=PT2M
+infrastructure.shutdownTimeout=PT30S
+```
+
+Set `infrastructure.cacheDirectory` only to an absolute path. An empty value
+uses the platform-specific SHAFT cache and application-data locations.
+
+## Understand remote precedence
+
+An explicit remote execution address keeps endpoint-backed profiles external,
+even when `infrastructure.mode=MANAGED`. This applies to web, Selenium Grid,
+mobile, and Healenium profiles, so a remote test configuration cannot
+unexpectedly provision local infrastructure. It does not change unrelated
+profiles such as `REPORTING`.
+
+## Interpret CLI failures
+
+| Exit code | Meaning |
+|---:|---|
+| `0` | Ready or successful. |
+| `2` | Invalid input, policy, or approval. |
+| `3` | Missing or degraded readiness. |
+| `4` | No provider supports the requested operation. |
+| `5` | Execution or integrity failure. |
+
+An install is atomic per action, not across the entire plan. If a later action
+fails, an earlier verified action can remain installed while the final profile
+receipt is absent. Fix the failure and retry the same approved plan; SHAFT
+re-verifies compatible completed state before continuing.
+
+`start` and `stop` return unsupported for profiles without an owned service.
+SHAFT does not adopt or stop an unknown process. Use
+`shaft-cli setup logs --profile REPORTING` to read an existing provider log;
+it returns `3` when no owned log exists.
+
+## Related
+
+- [Install SHAFT](/docs/start/installation)
+- [shaft-cli command line](/docs/agentic/cli)
+- [Programmatic properties configuration](/docs/reference/properties/Programmatic_Config)
+- [Reporting](/docs/features/reporting)

--- a/scripts/generate-properties-catalog.mjs
+++ b/scripts/generate-properties-catalog.mjs
@@ -59,7 +59,7 @@ const SECTION_NAME_OVERRIDES = {
 // yet -- see design/properties-generator.md §2/§6 and the follow-up issue filed alongside this).
 const SECTION_ORDER = [
   'Platform', 'Web', 'Playwright', 'Mobile', 'API', 'Capture', 'Flags', 'Reporting', 'Allure',
-  'Timeouts', 'Visuals', 'Jira', 'Cucumber', 'Healenium', 'Healing', 'Natural Actions', 'Pilot',
+  'Timeouts', 'Visuals', 'Jira', 'Cucumber', 'Healenium', 'Healing', 'Natural Actions', 'Infrastructure', 'Ocr', 'Pilot',
   'Paths', 'Pattern', 'Tinkey', 'Internal', 'BrowserStack', 'LambdaTest', 'Performance', 'TestNG',
   'Log4j',
 ];
@@ -87,6 +87,15 @@ const DEFAULT_VALUE_CONSTANTS = {
 // Keys with neither an mdx "Default Values" row nor Javadoc to source a description from.
 // Kept intentionally small -- each one is a real coverage gap in PropertiesList.mdx today.
 const MANUAL_DESCRIPTIONS = {
+  'infrastructure.mode': 'Ownership mode for setup operations; EXTERNAL is the non-mutating default.',
+  'infrastructure.profile': 'Local infrastructure profile selected by SHAFT.Infrastructure.',
+  'infrastructure.cacheDirectory': 'Optional absolute root for SHAFT-owned setup cache and durable data.',
+  'infrastructure.offline': 'Requires setup to use verified cached artifacts without network access.',
+  'infrastructure.autoStart': 'Requests startup after verification for providers that own a service.',
+  'infrastructure.preferSystemTools': 'Allows supporting providers to prefer compatible tools already on the host.',
+  'infrastructure.reuseOwnedProcesses': 'Allows supporting providers to reuse compatible SHAFT-owned processes.',
+  'infrastructure.startupTimeout': 'Positive ISO-8601 timeout for providers that start owned services.',
+  'infrastructure.shutdownTimeout': 'Positive ISO-8601 timeout for providers that stop owned services.',
   'recovery-tries': 'Number of Healenium self-healing recovery attempts before giving up on a broken locator.',
   'score-cap': 'Minimum Healenium similarity score (0.0-1.0) required to accept a healed locator candidate.',
   'heal-enabled': 'Enables the Healenium self-healing proxy for this run.',
@@ -265,7 +274,7 @@ function capitalizeSentence(text) {
 // `\s*`, since `\s*` also matches `\r?\n` and would reopen the same kind of overlap with this
 // group's own newline-consuming loop, which showed up as quadratic -- not exponential, but still
 // avoidable -- blowup on long comment-free blank-line runs during verification).
-const propertyRe = /@Key\(\s*"((?:\\.|[^"\\])*)"\s*\)\s*\r?\n\s*@DefaultValue\(\s*(?:"((?:\\.|[^"\\])*)"|([A-Za-z_][\w.]*))\s*\)((?:[ \t]*(?:\/\/[^\r\n]*)?\r?\n)*)[ \t]*(?:@\w+(?:\([^)]*\))?[ \t]*\r?\n[ \t]*)*(?:private\s+)?(boolean|Boolean|int|Integer|long|Long|double|float|String)\s+([A-Za-z_]\w*)\s*\(\s*\)\s*;/gu;
+const propertyRe = /@Key\(\s*"((?:\\.|[^"\\])*)"\s*\)[ \t]*(?:\r?\n[ \t]*)?@DefaultValue\(\s*(?:"((?:\\.|[^"\\])*)"|([A-Za-z_][\w.]*))\s*\)((?:[ \t]*(?:\/\/[^\r\n]*)?\r?\n)*)[ \t]*(?:@\w+(?:\([^)]*\))?[ \t]*\r?\n[ \t]*)*(?:private\s+)?([A-Za-z_]\w*)\s+([A-Za-z_]\w*)\s*\(\s*\)\s*;/gu;
 
 /** Parses one interface file's `@Key`/`@DefaultValue` getters, in source order (pure -- no I/O). */
 export function parseJavaSource(content) {
@@ -310,7 +319,7 @@ export function parseJavaSource(content) {
       key,
       defaultValue: rawDefault,
       type: returnType === 'boolean' || returnType === 'Boolean' ? 'boolean'
-        : returnType === 'String' ? 'text' : 'number',
+        : ['int', 'Integer', 'long', 'Long', 'double', 'float'].includes(returnType) ? 'number' : 'text',
       javadocDescription: descriptionFromJavadoc(javadoc),
       sourceOrder: matchStart,
     });

--- a/sidebars.js
+++ b/sidebars.js
@@ -19,6 +19,7 @@ const sidebars = {
         // category (issue #842 architecture note).
         'start/overview',
         'start/installation',
+        'start/local-infrastructure',
         'start/quick-start',
         'features/reporting',
         'reference/guides/CI_CD_Integration',

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -361,6 +361,42 @@
   },
   {
     "section": "Playwright",
+    "key": "playwright.timezoneId",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "IANA time zone identifier",
+    "description": "Optional time zone for new browser contexts. Empty uses the browser default."
+  },
+  {
+    "section": "Playwright",
+    "key": "playwright.locale",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "locale identifier",
+    "description": "Optional locale for new browser contexts. Empty uses the browser default."
+  },
+  {
+    "section": "Playwright",
+    "key": "playwright.userAgent",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "user-agent string",
+    "description": "Optional user agent for new browser contexts. Empty uses the browser or device default."
+  },
+  {
+    "section": "Playwright",
+    "key": "playwright.javaScriptEnabled",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Enables JavaScript in new browser contexts."
+  },
+  {
+    "section": "Playwright",
     "key": "playwright.tracing.enabled",
     "targetFile": "custom.properties",
     "type": "boolean",
@@ -2171,6 +2207,105 @@
     "description": "Restricts which action categories natural actions may execute."
   },
   {
+    "section": "Infrastructure",
+    "key": "infrastructure.mode",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "EXTERNAL",
+    "possibleValues": "EXTERNAL, MANAGED, HYBRID",
+    "description": "Selects setup ownership; EXTERNAL is non-mutating."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.profile",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "REPORTING",
+    "possibleValues": "setup profile name",
+    "description": "Selects the profile used by SHAFT.Infrastructure."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.cacheDirectory",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "absolute path",
+    "description": "Overrides SHAFT-owned setup storage when non-empty."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.offline",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "false",
+    "possibleValues": "true, false",
+    "description": "Requires verified cached artifacts and disables network access."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.autoStart",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "false",
+    "possibleValues": "true, false",
+    "description": "Requests startup for providers that own a service."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.preferSystemTools",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Allows supporting providers to prefer compatible host tools."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.reuseOwnedProcesses",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Allows supporting providers to reuse compatible SHAFT-owned processes."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.startupTimeout",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "PT2M",
+    "possibleValues": "positive ISO-8601 duration",
+    "description": "Sets the startup timeout for supporting lifecycle providers."
+  },
+  {
+    "section": "Infrastructure",
+    "key": "infrastructure.shutdownTimeout",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "PT30S",
+    "possibleValues": "positive ISO-8601 duration",
+    "description": "Sets the shutdown timeout for supporting lifecycle providers."
+  },
+  {
+    "section": "Ocr",
+    "key": "shaft.ocr.cacheDirectory",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "absolute path or empty",
+    "description": "Optional OCR runtime cache override. Empty uses the platform default."
+  },
+  {
+    "section": "Ocr",
+    "key": "shaft.ocr.downloadEnabled",
+    "targetFile": "custom.properties",
+    "type": "boolean",
+    "defaultValue": "true",
+    "possibleValues": "true, false",
+    "description": "Allows a missing verified OCR runtime to be downloaded."
+  },
+  {
     "section": "Pilot",
     "key": "pilot.ai.enabled",
     "targetFile": "custom.properties",
@@ -2549,6 +2684,33 @@
     "description": "Optional Ollama gateway credential prefix."
   },
   {
+    "section": "Pilot",
+    "key": "pilot.ai.lmstudio.endpoint",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "http://127.0.0.1:1234/v1/responses",
+    "possibleValues": "",
+    "description": "LM Studio OpenAI-compatible Responses endpoint."
+  },
+  {
+    "section": "Pilot",
+    "key": "pilot.ai.lmstudio.model",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "",
+    "description": "Configured LM Studio model."
+  },
+  {
+    "section": "Pilot",
+    "key": "pilot.ai.lmstudio.apiKeyEnvironmentVariable",
+    "targetFile": "custom.properties",
+    "type": "text",
+    "defaultValue": "",
+    "possibleValues": "",
+    "description": "Optional environment variable containing an LM Studio gateway credential."
+  },
+  {
     "section": "Paths",
     "key": "propertiesFolderPath",
     "targetFile": "custom.properties",
@@ -2753,7 +2915,7 @@
     "key": "shaftEngineVersion",
     "targetFile": "internal.properties",
     "type": "text",
-    "defaultValue": "10.3.20260801",
+    "defaultValue": "10.3.20260809",
     "possibleValues": "version string",
     "description": "Engine version used by update checks, telemetry metadata, and internal tooling."
   },
@@ -2780,7 +2942,7 @@
     "key": "nodeLtsVersion",
     "targetFile": "internal.properties",
     "type": "text",
-    "defaultValue": "24.18.1",
+    "defaultValue": "24.19.0",
     "possibleValues": "Node.js version",
     "description": "Portable Node.js version downloaded when neither allure nor npx is available on PATH."
   },
@@ -2816,7 +2978,7 @@
     "key": "appiumXcuitestDriverVersion",
     "targetFile": "internal.properties",
     "type": "text",
-    "defaultValue": "12.1.4",
+    "defaultValue": "12.3.0",
     "possibleValues": "Appium driver version",
     "description": "Appium XCUITest driver version used by SHAFT MCP for iOS."
   },

--- a/tests/generate-properties-catalog-regex.test.js
+++ b/tests/generate-properties-catalog-regex.test.js
@@ -106,14 +106,16 @@ public interface TestSection extends EngineProperties<TestSection> {
     @Key("browser.name")
     @DefaultValue("chrome")
     String browserName();
+
+    @Key("infrastructure.mode") @DefaultValue("EXTERNAL") SetupMode infrastructureMode();
 }
 `;
 
   const {interfaceName, properties} = parseJavaSource(snippet);
   assert.strictEqual(interfaceName, 'TestSection', `Expected interface name 'TestSection', got '${interfaceName}'`);
-  assert.strictEqual(properties.length, 3, `Expected 3 extracted properties, got ${properties.length}: ${JSON.stringify(properties.map((p) => p.key))}`);
+  assert.strictEqual(properties.length, 4, `Expected 4 extracted properties, got ${properties.length}: ${JSON.stringify(properties.map((p) => p.key))}`);
 
-  const [headless, retry, browser] = properties;
+  const [headless, retry, browser, infrastructureMode] = properties;
 
   assert.strictEqual(headless.key, 'headlessExecution');
   assert.strictEqual(headless.defaultValue, 'false');
@@ -129,6 +131,11 @@ public interface TestSection extends EngineProperties<TestSection> {
   assert.strictEqual(browser.key, 'browser.name');
   assert.strictEqual(browser.defaultValue, 'chrome');
   assert.strictEqual(browser.type, 'text');
+
+  assert.strictEqual(infrastructureMode.key, 'infrastructure.mode');
+  assert.strictEqual(infrastructureMode.defaultValue, 'EXTERNAL');
+  assert.strictEqual(infrastructureMode.type, 'text',
+    'Same-line annotations and enum-returning getters must be included in the property catalog');
 
   // --- ReDoS regression guard: CodeQL's exact adversarial shapes must resolve in linear time,
   // not blow up exponentially. The unfixed regex took ~400ms at n=20 reps and >8s at n=25; a


### PR DESCRIPTION
## Outcome
Documents the batteries-included setup surface introduced by ShaftHQ/SHAFT_ENGINE#4872.

## What changed
- adds the canonical local-infrastructure guide for CLI and Java workflows
- documents safe defaults, exact plan approval, provider coverage, paths, remote precedence, failure recovery, and exit codes
- links setup from installation, shaft-cli, properties, and the Start navigation
- updates the property generator to recognize same-line annotations and enum getters
- refreshes the complete property catalog/reference against the live engine source

## Verification
- `node scripts/generate-properties-catalog.mjs --engine-path=<live-engine-properties> --check`
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (20/20)
- three independent adversarial reviews: zero blockers

Closes #955
Related to ShaftHQ/SHAFT_ENGINE#4872 and ShaftHQ/SHAFT_ENGINE#4849.