### PR TITLE
Make local homepage axe audits reliable

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,8 +20,14 @@ jobs:
       - name: Install
         run: yarn install --frozen-lockfile
 
+      - name: Install Chromium
+        run: yarn playwright install --with-deps chromium
+
       - name: Security regressions
         run: yarn test:security
 
       - name: Build
         run: yarn build
+
+      - name: Homepage accessibility audit
+        run: yarn test:a11y

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "a11ymcp": {
-      "command": "npx",
-      "args": ["-y", "a11y-mcp-server"]
-    }
-  }
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,7 @@
 
 ## Accessibility
 
-- UI/visual doc-page changes: run the `a11ymcp` MCP server (configured in `.mcp.json`, npm `a11y-mcp-server`, axe-core based) against the affected built pages, complementing the heuristic `accessibility-review` skill.
+- UI/visual homepage changes: run `yarn build` and then `yarn test:a11y`. The
+  command uses headless Playwright-managed Chromium and axe-core; it does not
+  use an installed browser or ChromeDriver.
 - Treat axe-core violations as review evidence for the changed pages; the heuristic skill covers what automated rules cannot (focus order, meaningful labels, reduced-motion intent).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git switch -c <short-topic-branch>
 Required:
 
 - Node.js 20.
-- Yarn.
+- Yarn 1.22.22.
 - Git.
 
 Verify the active tools:
@@ -105,8 +105,14 @@ Run the full documentation contract:
 yarn test
 yarn typecheck
 yarn build
+yarn test:a11y
 yarn test:playwright
 ```
+
+`yarn test:a11y` runs the homepage audit headlessly with Playwright-managed
+Chromium and axe-core. It does not use the machine's browser or ChromeDriver.
+Run `yarn playwright install chromium` again after changing the Playwright
+version so the browser revision matches the test runner.
 
 For visual changes, also inspect the affected built page in a browser and add
 screenshots or browser evidence to the pull request.

--- a/docs/maintainers/site-operations.md
+++ b/docs/maintainers/site-operations.md
@@ -21,10 +21,12 @@ DNS for this GitHub Pages recovery path.
 
 ## Local development
 
-Use Node.js 20 and Yarn:
+Use Node.js 20 and Yarn 1.22.22. Install the repository's version-matched
+Chromium once after installing dependencies:
 
 ```bash
 yarn install
+yarn playwright install chromium
 yarn start
 ```
 
@@ -61,12 +63,16 @@ API with CORS enabled for that origin.
 yarn test
 yarn typecheck
 yarn build
+yarn test:a11y
 yarn test:playwright
 ```
 
 The build fails on broken Markdown links and duplicated long prose or code
 blocks. The Playwright suite covers desktop and mobile rendering, canonical
-routes, code copying, and dark mode.
+routes, code copying, and dark mode. The focused accessibility command audits
+the built homepage in headless Playwright-managed Chromium with axe-core. It
+does not depend on an installed browser or ChromeDriver. After changing the
+Playwright version, run `yarn playwright install chromium` before the audit.
 
 ## Search and AutoBot
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc --noEmit",
-    "test": "npm run test:security && npm run test:docs && npm run test:homepage && npm run test:history",
+    "test": "npm run test:security && npm run test:a11y:contract && npm run test:docs && npm run test:homepage && npm run test:history",
+    "test:a11y": "playwright test tests/e2e/accessibility.spec.js --project=chromium",
+    "test:a11y:contract": "node tests/accessibility-audit-contract.test.js",
     "test:security": "node tests/security-regressions.test.js",
     "test:history": "node tests/chat-history.test.js",
     "test:homepage": "node tests/homepage-performance.test.js",
@@ -50,10 +52,11 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.13.0",
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/tsconfig": "^3.10.2",
     "@docusaurus/types": "^3.8.1",
-    "@playwright/test": "^1.62.1",
+    "@playwright/test": "1.62.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "cross-spawn": "^7.0.6",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,7 @@ html {
   --ifm-color-primary-lightest: #4b9bd6;
   --aa-primary-color-rgb: 0, 110, 192 !important;
   --ifm-code-font-size: 95%;
+  --ifm-navbar-search-input-placeholder-color: var(--ifm-color-emphasis-700);
   --docusaurus-highlighted-code-line-bg: rgba(var(--site-color-primary-rgb), 0.12);
   --site-color-primary: #006ec0;
   --site-color-primary-rgb: 0, 110, 192;
@@ -85,6 +86,7 @@ body.dark {
   --ifm-color-primary-lighter: #7bcfff;
   --ifm-color-primary-lightest: #a9dfff;
   --aa-primary-color-rgb: 76, 194, 255 !important;
+  --ifm-navbar-search-input-placeholder-color: var(--site-color-muted);
   --docusaurus-highlighted-code-line-bg: rgba(var(--site-color-primary-rgb), 0.24);
   --site-color-primary: #4cc2ff;
   --site-color-primary-rgb: 76, 194, 255;

--- a/tests/accessibility-audit-contract.test.js
+++ b/tests/accessibility-audit-contract.test.js
@@ -14,6 +14,10 @@ const prBuild = fs.readFileSync(
   path.join(repoRoot, '.github', 'workflows', 'pr-build.yml'),
   'utf8',
 );
+const accessibilityAudit = fs.readFileSync(
+  path.join(repoRoot, 'tests', 'e2e', 'accessibility.spec.js'),
+  'utf8',
+);
 
 assert.strictEqual(
   packageJson.devDependencies['@playwright/test'],
@@ -65,6 +69,11 @@ assert.match(
   prBuild,
   /^\s+run: yarn test:a11y$/m,
   'The PR gate must run the canonical accessibility audit.',
+);
+assert.match(
+  accessibilityAudit,
+  /test\.beforeEach[\s\S]*page\.emulateMedia\(\{reducedMotion: 'reduce'\}\)/,
+  'The audit must disable reveal animations so axe scans a stable rendered state.',
 );
 
 console.log('Accessibility audit contract checks passed.');

--- a/tests/accessibility-audit-contract.test.js
+++ b/tests/accessibility-audit-contract.test.js
@@ -1,0 +1,70 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..');
+const packageJson = require(path.join(repoRoot, 'package.json'));
+const agents = fs.readFileSync(path.join(repoRoot, 'AGENTS.md'), 'utf8');
+const contributing = fs.readFileSync(path.join(repoRoot, 'CONTRIBUTING.md'), 'utf8');
+const siteOperations = fs.readFileSync(
+  path.join(repoRoot, 'docs', 'maintainers', 'site-operations.md'),
+  'utf8',
+);
+const prBuild = fs.readFileSync(
+  path.join(repoRoot, '.github', 'workflows', 'pr-build.yml'),
+  'utf8',
+);
+
+assert.strictEqual(
+  packageJson.devDependencies['@playwright/test'],
+  '1.62.1',
+  'Playwright Test must be exact so its managed Chromium revision is reproducible.',
+);
+assert.strictEqual(
+  packageJson.devDependencies['@axe-core/playwright'],
+  '4.13.0',
+  'The Playwright axe adapter must be exact so local and CI audits use the same rules.',
+);
+assert.strictEqual(
+  packageJson.scripts['test:a11y'],
+  'playwright test tests/e2e/accessibility.spec.js --project=chromium',
+  'The repository must expose one focused accessibility-audit command.',
+);
+assert.ok(
+  !fs.existsSync(path.join(repoRoot, '.mcp.json')),
+  'The unsupported a11ymcp browser lifecycle must not remain configured.',
+);
+
+for (const [name, contents] of [
+  ['AGENTS.md', agents],
+  ['CONTRIBUTING.md', contributing],
+  ['docs/maintainers/site-operations.md', siteOperations],
+]) {
+  assert.match(contents, /yarn test:a11y/, `${name} must document the canonical audit command.`);
+  assert.doesNotMatch(contents, /a11ymcp|a11y-mcp-server/, `${name} must not direct contributors to the retired MCP path.`);
+}
+
+for (const [name, contents] of [
+  ['CONTRIBUTING.md', contributing],
+  ['docs/maintainers/site-operations.md', siteOperations],
+]) {
+  assert.match(contents, /Yarn 1\.22\.22/, `${name} must state the repository's supported Yarn version.`);
+  assert.match(
+    contents,
+    /yarn install[\s\S]*yarn playwright install chromium/,
+    `${name} must include the one-time Chromium install after dependency installation.`,
+  );
+}
+
+assert.match(
+  prBuild,
+  /^\s+run: yarn playwright install --with-deps chromium$/m,
+  'The PR gate must install Playwright\'s version-matched Chromium and Linux dependencies.',
+);
+assert.match(
+  prBuild,
+  /^\s+run: yarn test:a11y$/m,
+  'The PR gate must run the canonical accessibility audit.',
+);
+
+console.log('Accessibility audit contract checks passed.');

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -12,6 +12,10 @@ const wcagTags = [
 
 const scan = (page) => new AxeBuilder({page}).withTags(wcagTags).analyze();
 
+test.beforeEach(async ({page}) => {
+  await page.emulateMedia({reducedMotion: 'reduce'});
+});
+
 test('built homepage has no automatically detectable WCAG A or AA violations', async ({page}) => {
   await page.goto('/');
   await expect(page.getByTestId('landing-main')).toBeVisible();

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -1,0 +1,42 @@
+const {expect, test} = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const wcagTags = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22a',
+  'wcag22aa',
+];
+
+const scan = (page) => new AxeBuilder({page}).withTags(wcagTags).analyze();
+
+test('built homepage has no automatically detectable WCAG A or AA violations', async ({page}) => {
+  await page.goto('/');
+  await expect(page.getByTestId('landing-main')).toBeVisible();
+
+  const {violations} = await scan(page);
+
+  expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+});
+
+test('audit detects an injected unnamed button', async ({page}) => {
+  await page.goto('/');
+  await expect(page.getByTestId('landing-main')).toBeVisible();
+  await page.evaluate(() => {
+    const button = document.createElement('button');
+    button.id = 'injected-accessibility-violation';
+    document.body.append(button);
+  });
+
+  const {violations} = await scan(page);
+  const buttonNameViolation = violations.find(({id}) => id === 'button-name');
+
+  expect(buttonNameViolation, JSON.stringify(violations, null, 2)).toBeDefined();
+  expect(
+    buttonNameViolation.nodes.some(({target}) =>
+      target.some((selector) => selector.includes('injected-accessibility-violation')),
+    ),
+  ).toBe(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,13 @@
     package-manager-detector "^1.3.0"
     tinyexec "^1.0.1"
 
+"@axe-core/playwright@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.13.0.tgz#4826467c9622df26f0d75b4c1747c8d92ee599de"
+  integrity sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==
+  dependencies:
+    axe-core "~4.13.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz"
@@ -2650,7 +2657,7 @@
     tslib "^2.8.1"
     tsyringe "^4.10.0"
 
-"@playwright/test@^1.62.1":
+"@playwright/test@1.62.1":
   version "1.62.1"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.62.1.tgz#68e1aaf6e480e1923936dee6c66fae1921d3a65a"
   integrity sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==
@@ -4127,6 +4134,11 @@ autoprefixer@^10.4.19, autoprefixer@^10.4.23:
     fraction.js "^5.3.4"
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
+
+axe-core@~4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.13.0.tgz#f868ecb1bd61d982321760e51d841ab497ab86d0"
+  integrity sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==
 
 babel-loader@^9.2.1:
   version "9.2.1"


### PR DESCRIPTION
## Outcome

- replaces the unreliable a11ymcp/ChromeDriver path with pinned Playwright + axe dependencies
- adds a documented, headless `yarn test:a11y` command and runs it in pull-request CI
- proves the audit detects an injected unnamed button
- fixes the real navbar search-shortcut contrast violation uncovered by the audit
- keeps browser reports and screenshots out of git

## RED / GREEN

RED reproduction and implementation evidence are recorded in issue #952. The old MCP path could not find its pinned Chromium revision; the CLI path required an external ChromeDriver; the new audit initially exposed a 1.51:1 shortcut contrast ratio.

GREEN:
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:a11y` — 2 passed
- `yarn test:playwright` — 22 passed
- Node 20.19.5 contract check
- 1440×900 light desktop and 390×844 dark mobile visual QA

## Learning loop

Graphify refresh classified unsupported repository inputs as audit failures; tracked separately in #956. No additional durable memory update was needed because the supported audit contract is now repository guidance and executable tests.

Closes #952
