### PR TITLE
docs(ocr): correct unreleased setup guidance

### DIFF
--- a/docs/features/modules.md
+++ b/docs/features/modules.md
@@ -28,7 +28,6 @@ capability they own.
 | `shaft-browserstack` | Tests need BrowserStack SDK interception, YAML expansion, or SDK orchestration. |
 | `shaft-video` | Local non-headless desktop runs need FFmpeg video recording. |
 | `shaft-visual` | Tests need OpenCV, Applitools Eyes, Shutterbug, or reference-image behavior. |
-| `shaft-ocr` | Tests need local Tesseract recognition, visible-text actions, or OCR assertions. It consumes verified tessdata provisioned by the shared infrastructure module. |
 | `shaft-sikulix` | Desktop tests need SikuliX image-based automation. |
 | `shaft-bom` | A project uses more than one published SHAFT library and needs aligned versions. |
 
@@ -36,6 +35,10 @@ capability they own.
 normal consumer entry point. `report-aggregate` builds reactor-wide reports
 but is not deployed as a consumer dependency. `legacy-shaft-engine` is a
 relocation POM for older coordinates, not a new-project dependency.
+
+`shaft-ocr` is present in `SHAFT_ENGINE` source as an unreleased preview. It is
+not part of the current published BOM; wait for a containing release before
+adding it as a project dependency.
 
 ## Feature-to-module map
 

--- a/docs/integrations/ocr.md
+++ b/docs/integrations/ocr.md
@@ -9,11 +9,23 @@ tags: [ocr, tesseract, text-recognition, image-assertion]
 
 # OCR and visible-text automation
 
-Add `io.github.shafthq:shaft-ocr` when you need to recognize text from pixels. The module runs Tesseract locally through bundled native JavaCPP libraries; it does not require a system Tesseract installation or a cloud OCR service.
+:::warning[Preview: module not released]
+`shaft-ocr` is available in `SHAFT_ENGINE` source but is not included in the
+current published SHAFT release. Do not add the dependency below to a released
+BOM project yet. Build the current source reactor only when you are evaluating
+this preview, and wait for a containing release before using it in a released
+project.
+:::
+
+Use `io.github.shafthq:shaft-ocr` in a source-build preview when you need to
+recognize text from pixels. The module runs Tesseract locally through bundled
+native JavaCPP libraries; it does not require a system Tesseract installation
+or a cloud OCR service.
 
 ## Add the module
 
-Import the SHAFT BOM, then add `shaft-engine` and `shaft-ocr` without module versions:
+After a containing release is published, import its SHAFT BOM, then add
+`shaft-engine` and `shaft-ocr` without module versions:
 
 ```xml
 <dependencyManagement>
@@ -195,7 +207,41 @@ text, a single block, line, or word, and sparse text.
 
 ## Configure language models
 
-English and Arabic are the default recognition languages. Provision the verified models before recognition through SHAFT's reviewed setup flow. Every supported Tesseract language is pinned to one `tessdata_fast` revision and SHA-256; downloads also stop at the setup artifact safety ceiling.
+English and Arabic are the default languages. Pass Tesseract three-letter model
+codes or supported human-readable names for other languages. SHAFT downloads
+missing models on first use from a pinned `tessdata_fast` revision, verifies
+their integrity, and stores them in the user cache.
+
+Configure provisioning through the typed property namespace:
+
+```java
+SHAFT.Properties.ocr.set()
+    .cacheDirectory("build/shaft-ocr-models")
+    .downloadEnabled(false)
+    .documentRenderDpi(300)
+    .documentMaximumPages(500)
+    .documentMaximumInFlightRasterBytes(256L * 1024 * 1024);
+```
+
+Use the matching `shaft.ocr.*` keys in `custom.properties` or as system properties when code configuration is not appropriate. Document options passed to `process(...)` override the defaults for that call.
+
+:::warning
+When downloads are disabled, every requested language model must already exist
+in the configured cache and pass integrity verification. SHAFT fails before
+recognition if a model is missing or altered.
+:::
+
+<!-- managed-ocr-preview:start -->
+## Preview: managed OCR setup
+
+:::warning[Not released]
+The selection-aware managed setup workflow below is not yet available on
+`SHAFT_ENGINE` `main` or in a published SHAFT release. Do not run these commands
+or compile against these overloads until a containing release is available.
+
+The planned provider pins every supported Tesseract language to one
+`tessdata_fast` revision and SHA-256 checksum. It also applies the setup
+artifact safety ceiling. Create and review an immutable plan before install:
 
 ```bash
 shaft-cli setup plan --profile OCR --mode MANAGED \
@@ -209,24 +255,24 @@ shaft-cli setup verify --profile OCR \
   --language eng --language ara
 ```
 
-Omit `--language` for the baseline `eng` and `ara` bundle. Repeat it with three-letter Tesseract codes such as `fra` and `deu` to provision another exact set. Java callers can pass `new SetupSelection(List.of("fra", "deu"))` to the selection-aware `SHAFT.Infrastructure.plan`, `status`, `verify`, and `install` overloads (or the equivalent low-level service overloads). CLI install recovers the selection from the reviewed actions; repeating `--language` is optional and must match when supplied.
-
-Configure provisioning through the typed property namespace:
+Omit `--language` for the baseline `eng` and `ara` bundle. Repeat it with
+three-letter Tesseract codes such as `fra` and `deu` to provision another exact
+set. Java callers will be able to pass
 
 ```java
-SHAFT.Properties.ocr.set()
-    .cacheDirectory(Path.of("build/shaft-ocr-models").toAbsolutePath().toString())
-    .downloadEnabled(false)
-    .documentRenderDpi(300)
-    .documentMaximumPages(500)
-    .documentMaximumInFlightRasterBytes(256L * 1024 * 1024);
+new SetupSelection(List.of("fra", "deu"))
 ```
 
-Use the matching `shaft.ocr.*` keys in `custom.properties` or as system properties when code configuration is not appropriate. Document options passed to `process(...)` override the defaults for that call.
-
-:::warning
-`shaft.ocr.downloadEnabled` is retained for compatibility, but it never bypasses setup approval. Missing models always fail before native recognition with the exact `shaft-cli setup plan --profile OCR --language ...` remediation. A configured custom cache must be absolute. SHAFT prefers it only when the complete requested set verifies there; otherwise it uses the platform-native shared setup cache when that complete set verifies. This safely covers empty, partial, or corrupt legacy custom caches without reading an unverified model.
+to the selection-aware `SHAFT.Infrastructure.plan`,
+`SHAFT.Infrastructure.status`, `SHAFT.Infrastructure.verify`, and
+`SHAFT.Infrastructure.install` overloads (or the equivalent low-level service
+overloads). CLI install recovers the selection from the reviewed actions; repeating
+`--language` is optional and must match when supplied. A custom cache must be
+absolute. The provider will prefer it only when the complete requested set
+verifies there, otherwise it will use the platform-native shared setup cache
+when that complete set verifies.
 :::
+<!-- managed-ocr-preview:end -->
 
 ## Choose OCR for pixel-only text
 

--- a/docs/reference/properties/PropertiesList.mdx
+++ b/docs/reference/properties/PropertiesList.mdx
@@ -1156,8 +1156,8 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 
 ## Ocr
 
-- These properties control the SHAFT-owned OCR runtime cache and preserve the
-  legacy download-consent setting; missing models still require reviewed setup.
+- These properties control the SHAFT-owned OCR runtime cache and whether a
+  missing verified runtime may be downloaded.
 
 <Tabs groupId="PropertyTypes" queryString="Ocr">
   <TabItem value="code-based" label="Code-based">
@@ -1189,7 +1189,7 @@ This section lists all configurable properties related to Swagger/OpenAPI contra
 | Property Name | Default Value | Possible Values | Description |
 | --- | --- | --- | --- |
 | shaft.ocr.cacheDirectory | ` ` | absolute path or empty | Optional OCR runtime cache override. Empty uses the platform default. |
-| shaft.ocr.downloadEnabled | `true` | `true`, `false` | Compatibility consent flag; missing models still require an explicitly reviewed setup plan. |
+| shaft.ocr.downloadEnabled | `true` | `true`, `false` | Allows a missing verified OCR runtime to be downloaded. |
 
   </TabItem>
 </Tabs>

--- a/docs/start/local-infrastructure.mdx
+++ b/docs/start/local-infrastructure.mdx
@@ -14,7 +14,7 @@ diagnoses the host without downloading, installing, or starting anything.
 
 The setup catalog includes web, mobile, Grid, reporting, OCR, agent-tool, and
 local-AI profiles. Managed installation is currently available for
-`REPORTING` and `OCR`. Reporting installs SHA-256-verified portable Node and Allure 3 artifacts. OCR installs a reviewed set of pinned tessdata models; its default bundle is `eng` and `ara`.
+`REPORTING`. It installs SHA-256-verified portable Node and Allure 3 artifacts.
 The other profiles are cataloged for the shared contract but currently return
 unsupported from provider-backed diagnosis and lifecycle commands.
 
@@ -28,7 +28,6 @@ profiles:
 shaft-cli setup catalog
 shaft-cli setup doctor --profile REPORTING
 shaft-cli setup status --profile REPORTING
-shaft-cli setup status --profile OCR
 ```
 
 Add `--json` to `catalog`, `doctor`, `status`, or `verify` when a script needs a
@@ -68,7 +67,18 @@ Changing a version, source, checksum, destination, timeout, or policy option
 changes the digest and requires a new review.
 :::
 
-For OCR, omit `--language` to use the baseline bundle, or repeat exact Tesseract codes on plan and selected status/verify commands. Install recovers them from the reviewed plan:
+<!-- managed-ocr-preview:start -->
+## Preview: managed OCR setup
+
+:::warning[Not released]
+This workflow is not yet available on `SHAFT_ENGINE` `main` or in a published
+SHAFT release. Keep using the [current OCR first-use model flow](../integrations/ocr.md#configure-language-models)
+until a release that contains the complete setup stack is available.
+
+The preview defaults to the `eng` and `ara` model bundle. Omit `--language` to
+use that bundle, or repeat exact Tesseract codes on plan and selected
+status/verify commands. Install recovers the selected languages from the
+reviewed plan:
 
 ```bash
 shaft-cli setup plan --profile OCR --mode MANAGED \
@@ -79,7 +89,13 @@ shaft-cli setup install --plan /absolute/path/ocr-plan.json \
 shaft-cli setup verify --profile OCR --language fra --language deu
 ```
 
-The reviewed actions bind the normalized component set. Repeating `--language` during install is optional and must match when supplied. OCR has no start, stop, or logs lifecycle.
+The reviewed actions bind the normalized component set. Repeating `--language`
+during install is optional and must match when supplied. The planned OCR
+provider enforces `--offline`: it can accept a verified installed model, legacy
+model, or artifact-cache entry without network access. It has no start, stop,
+or logs lifecycle.
+:::
+<!-- managed-ocr-preview:end -->
 
 ## Keep policy options identical
 
@@ -98,7 +114,7 @@ Pass any non-default option to both commands. You may also pass an absolute
 `--cache-root` and `--data-root` pair to both commands; SHAFT rejects a single
 root or a relative path.
 
-The `REPORTING` and `OCR` providers enforce `--offline`. OCR accepts an already verified installed model, a verified legacy model, or a verified artifact-cache entry without network access. Reporting has no owned service,
+The current `REPORTING` provider enforces `--offline`. It has no owned service,
 so auto-start, process reuse, and lifecycle timeouts are policy-bound for
 provider parity but do not change a reporting install. Reporting installs
 SHAFT-owned portable tools rather than adopting system Node or Allure.

--- a/docs/testing/mobile.md
+++ b/docs/testing/mobile.md
@@ -111,7 +111,12 @@ context inspection.
 
 ## Scroll to screenshot or OCR targets
 
-CI jobs that use OCR should prewarm the exact model set through `shaft-cli setup plan/install/verify --profile OCR`, then run tests without relying on first-use network access. Repeat selected languages for readiness checks; install recovers them from the reviewed plan.
+The unreleased source-preview OCR runtime downloads missing pinned models on first use when
+`shaft.ocr.downloadEnabled` is `true`. For CI, run a representative OCR smoke
+step while network access is available, retain its model cache, then run the
+test job with downloads disabled. Use this only for source-build evaluation
+until a containing SHAFT release is published. Every requested model must exist
+in that cache and pass integrity verification.
 
 Use typed targets when native accessibility identifiers are unavailable. SHAFT
 checks the current screenshot before every gesture and supports vertical and

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:security": "node tests/security-regressions.test.js",
     "test:history": "node tests/chat-history.test.js",
     "test:homepage": "node tests/homepage-performance.test.js",
-    "test:docs": "node tests/docs-loader.test.js && node tests/cloudflare-autobot.test.js && node tests/enhanced-instruction.test.js && node tests/properties-catalog.test.js && node tests/generate-properties-catalog-regex.test.js && node tests/properties-list-coverage.test.js && node tests/docs-quality.test.js && node tests/design-contrast.test.js && node scripts/check-doc-duplicates.mjs",
+    "test:docs": "node tests/docs-loader.test.js && node tests/cloudflare-autobot.test.js && node tests/enhanced-instruction.test.js && node tests/properties-catalog.test.js && node tests/generate-properties-catalog-regex.test.js && node tests/properties-list-coverage.test.js && node tests/ocr-docs-release-contract.test.js && node tests/docs-quality.test.js && node tests/design-contrast.test.js && node scripts/check-doc-duplicates.mjs",
     "test:api": "node tests/chatbot-api.test.js",
     "test:e2e": "npm run test:shaft",
     "test:playwright": "npx playwright test",

--- a/src/data/properties-catalog.json
+++ b/src/data/properties-catalog.json
@@ -2303,7 +2303,7 @@
     "type": "boolean",
     "defaultValue": "true",
     "possibleValues": "true, false",
-    "description": "Compatibility consent flag; missing models still require an explicitly reviewed setup plan."
+    "description": "Allows a missing verified OCR runtime to be downloaded."
   },
   {
     "section": "Pilot",

--- a/tests/ocr-docs-release-contract.test.js
+++ b/tests/ocr-docs-release-contract.test.js
@@ -1,0 +1,122 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const managedPreviewStart = '<!-- managed-ocr-preview:start -->';
+const managedPreviewEnd = '<!-- managed-ocr-preview:end -->';
+const managedPreviewPages = [
+  'docs/start/local-infrastructure.mdx',
+  'docs/integrations/ocr.md',
+];
+const currentGuidanceFiles = [
+  'docs/features/modules.md',
+  'docs/integrations/ocr.md',
+  'docs/reference/properties/PropertiesList.mdx',
+  'docs/start/local-infrastructure.mdx',
+  'docs/testing/mobile.md',
+  'src/data/properties-catalog.json',
+];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function splitPreview(relativePath) {
+  const content = read(relativePath);
+  const start = content.indexOf(managedPreviewStart);
+  const end = content.indexOf(managedPreviewEnd);
+  assert(start >= 0 && end > start,
+    `${relativePath} must bound unavailable managed OCR setup guidance with preview markers.`);
+  return {
+    current: content.slice(0, start) + content.slice(end + managedPreviewEnd.length),
+    preview: content.slice(start + managedPreviewStart.length, end),
+  };
+}
+
+const splitPages = new Map(managedPreviewPages.map((file) => [file, splitPreview(file)]));
+const currentByFile = new Map(currentGuidanceFiles.map((file) => {
+  const content = splitPages.has(file) ? splitPages.get(file).current : read(file);
+  return [file, content];
+}));
+const currentGuidance = currentGuidanceFiles.map((file) => {
+  const content = currentByFile.get(file);
+  return `\n<!-- ${file} -->\n${content}`;
+}).join('\n');
+
+assert(!/--profile\s+OCR/.test(currentGuidance),
+  'Executable OCR setup commands must not appear in current guidance before release.');
+assert(!/SetupSelection/.test(currentGuidance),
+  'The unreleased selection-aware Java API must appear only inside marked preview guidance.');
+assert(!/Managed installation is currently available[^.]*\bOCR\b/s.test(currentGuidance),
+  'Current guidance must not claim that managed OCR installation is available.');
+assert(!/missing models? (?:still )?require(?:s)? (?:an )?(?:explicitly )?reviewed setup/i.test(currentGuidance),
+  'Current OCR property guidance must retain the released first-use download behavior.');
+
+const ocrGuide = currentByFile.get('docs/integrations/ocr.md');
+assert.match(ocrGuide, /:::warning\[Preview: module not released\]/,
+  'The OCR guide must visibly identify the module itself as unreleased.');
+assert.match(ocrGuide, /not included in the\s+current published SHAFT release/i,
+  'The OCR guide must state that no current release contains shaft-ocr.');
+assert(ocrGuide.indexOf('Preview: module not released') < ocrGuide.indexOf('## Add the module'),
+  'The module-release warning must appear before dependency instructions.');
+
+const moduleGuide = currentByFile.get('docs/features/modules.md');
+const publishedArtifactMap = moduleGuide.slice(
+  moduleGuide.indexOf('## Published artifact map'),
+  moduleGuide.indexOf('## Feature-to-module map'));
+assert(!publishedArtifactMap.includes('| `shaft-ocr` |'),
+  'The published artifact map must not list unreleased shaft-ocr.');
+assert.match(moduleGuide, /shaft-ocr[^\n]*unreleased preview/i,
+  'The module guide must label shaft-ocr as an unreleased preview.');
+
+for (const [file, {preview}] of splitPages) {
+  assert.match(preview, /^## Preview: managed OCR setup$/m,
+    `${file} must render a dedicated managed OCR preview heading.`);
+  assert.match(preview, /:::warning\[Not released\]/,
+    `${file} must render the preview in a warning titled "Not released".`);
+  assert.match(preview, /not (?:yet )?(?:available|released)/i,
+    `${file} must state that its commands and APIs are not currently available.`);
+  assert.match(preview, /shaft-cli setup plan --profile OCR/,
+    `${file} must retain the future CLI planning workflow inside its preview.`);
+  assert.match(preview, /shaft-cli setup install --plan/,
+    `${file} must retain the future reviewed CLI installation workflow inside its preview.`);
+  assert.match(preview, /shaft-cli setup verify --profile OCR/,
+    `${file} must retain the future CLI verification workflow inside its preview.`);
+}
+
+const ocrPreview = splitPages.get('docs/integrations/ocr.md').preview;
+assert.match(ocrPreview, /SetupSelection/,
+  'The future selection-aware Java workflow must remain documented inside the preview.');
+const selectionWorkflow = ocrPreview.slice(ocrPreview.indexOf('SetupSelection'));
+for (const operation of ['plan', 'status', 'verify', 'install']) {
+  assert(selectionWorkflow.includes(`SHAFT.Infrastructure.${operation}`),
+    `The future selection-aware Java workflow must retain SHAFT.Infrastructure.${operation}.`);
+}
+assert.match(splitPages.get('docs/start/local-infrastructure.mdx').preview,
+  /current OCR first-use model flow/,
+  'The infrastructure preview must route current users to executable OCR guidance.');
+
+assert.match(ocrGuide,
+  /downloads?\s+missing\s+models?\s+on\s+first\s+use/i,
+  'The OCR guide must explain the current first-use model download behavior.');
+const mobileGuide = currentByFile.get('docs/testing/mobile.md');
+assert.match(mobileGuide,
+  /downloads?\s+missing\s+pinned\s+models?\s+on\s+first\s+use/i,
+  'The mobile guide must retain an executable current OCR cache-warmup path.');
+assert.match(mobileGuide, /unreleased source-preview OCR runtime/i,
+  'The mobile guide must label its OCR runtime workflow as an unreleased source preview.');
+assert.match(mobileGuide, /only for source-build evaluation[\s\S]*containing SHAFT release is published/i,
+  'The mobile guide must prevent released-project use before a containing release.');
+assert.match(currentByFile.get('docs/reference/properties/PropertiesList.mdx'),
+  /shaft\.ocr\.downloadEnabled[^\n]*Allows[^\n]*download/i,
+  'The property reference must describe current download consent accurately.');
+
+const catalog = JSON.parse(currentByFile.get('src/data/properties-catalog.json'));
+const downloadProperty = catalog.find((property) =>
+  property.section === 'Ocr' && property.key === 'shaft.ocr.downloadEnabled');
+assert(downloadProperty, 'The generated catalog must include shaft.ocr.downloadEnabled.');
+assert.match(downloadProperty.description, /Allows[^.]*download/i,
+  'The generated catalog must describe current download consent accurately.');
+
+console.log('OCR documentation release contract checks passed.');


### PR DESCRIPTION
## Summary
- mark `shaft-ocr` itself as an unreleased source preview because the current BOM does not publish the artifact
- restore current `SHAFT_ENGINE main` first-use model download/cache semantics
- preserve selection-aware managed OCR setup as a separate, explicit not-released preview
- add a sibling-aware documentation release contract with omission and owner mutations

## Evidence
- RED: missing preview markers failed `node tests/ocr-docs-release-contract.test.js`
- reviewer mutations now fail for missing per-page warning/heading, plan/install/verify, exact `SHAFT.Infrastructure` owner operations, property/catalog behavior, module release warning, published-artifact map, and mobile release qualifier
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (22 passed)
- desktop and 390x844 rendered checks on OCR and infrastructure preview warnings; zero horizontal overflow
- Graphify refreshed from the primary checkout at `be0556510`

Closes #964