### PR TITLE
fix(graphify): make community labels deterministic

### DIFF
--- a/docs/maintainers/agent-tooling.md
+++ b/docs/maintainers/agent-tooling.md
@@ -189,15 +189,27 @@ that Graphify indexed. A failed build, audit, or cluster stage leaves no
 current marker, so readers cannot accept a partial cache. Linked worktrees must
 not refresh or record the shared cache.
 
-The controller runs Graphify through this isolated uv tool invocation:
+The controller pins Graphify and runs it through an isolated uv tool invocation:
 
 ```powershell
-uv tool run --with tree-sitter-sql --from graphifyy graphify
+uv tool run --with tree-sitter-sql --from graphifyy==0.9.42 graphify
 ```
 
 `graphifyy` is the distribution name, while `graphify` is its command. The
 ephemeral `tree-sitter-sql` dependency enables SQL parsing without changing a
 persistent global tool installation.
+
+Accepted caches use Graphify's deterministic hub-derived community labels.
+Before clustering, the controller removes saved label and membership-signature
+sidecars, clears Graphify's ambient backend selectors for that subprocess, and
+uses an isolated home inside the ignored cache. This prevents user or repository
+provider configuration, an API key, or a local endpoint from silently turning
+refresh into a networked, model-dependent labeling run. It also prevents a
+previous semantic label from being reused after community membership changes.
+
+Semantic labels are optional and are not part of cache freshness. Run
+`graphify label .` separately when you want an ephemeral model-generated view;
+the next accepted refresh replaces those names with current hub-derived labels.
 
 Audit an existing cache without modifying it:
 

--- a/tests/graphify-maintenance.test.js
+++ b/tests/graphify-maintenance.test.js
@@ -160,7 +160,7 @@ const refreshSource = controllerSource.slice(
 );
 const build = refreshSource.indexOf('"build"');
 const audit = refreshSource.indexOf('run_audit(');
-const cluster = refreshSource.indexOf('run_stage("cluster"');
+const cluster = refreshSource.indexOf('"cluster",');
 const record = refreshSource.indexOf('"record"');
 assert.ok(build >= 0 && build < audit && audit < cluster && cluster < record,
   'refresh must preserve build -> audit -> cluster -> marker ordering');
@@ -171,5 +171,80 @@ assert.match(maintainerGuide, /root `\.graphifyignore`/);
 assert.match(maintainerGuide, /YAML, plain-text, standalone HTML, SVG, and raster media/);
 assert.match(maintainerGuide, /credential-free code\/configuration corpus/);
 assert.match(maintainerGuide, /clean tracked sources/);
+assert.match(maintainerGuide, /deterministic hub-derived community labels/);
+assert.match(maintainerGuide, /Semantic labels are optional and are not part of cache freshness/);
+
+const labelingContract = String.raw`
+import contextlib
+import importlib.util
+import os
+import pathlib
+import tempfile
+
+controller_path = pathlib.Path(r"${CONTROLLER.replace(/\\/g, '\\\\')}")
+spec = importlib.util.spec_from_file_location("shaft_graphify_maintenance", controller_path)
+controller = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(controller)
+
+backend_selectors = (
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "MOONSHOT_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "OLLAMA_BASE_URL",
+    "OLLAMA_HOST",
+    "OLLAMA_API_KEY",
+    "GRAPHIFY_ALLOW_LOCAL_PROVIDERS",
+)
+for key in backend_selectors:
+    os.environ[key] = "must-not-reach-labeling"
+
+stages = []
+@contextlib.contextmanager
+def unlocked(_common_dir):
+    yield
+
+def fake_stage(name, command, root, env=None):
+    stages.append(name)
+    graph_out = root / "graphify-out"
+    if name == "build":
+        graph_out.mkdir(parents=True, exist_ok=True)
+        (graph_out / "manifest.json").write_text("{}", encoding="utf-8")
+        (graph_out / "graph.json").write_text('{"nodes": [], "links": []}', encoding="utf-8")
+        (graph_out / ".graphify_labels.json").write_text('{"0": "Stale semantic label"}', encoding="utf-8")
+        (graph_out / ".graphify_labels.json.sig").write_text('{"0": "stale-members"}', encoding="utf-8")
+    elif name == "cluster":
+        assert not (graph_out / ".graphify_labels.json").exists(), "cluster must not reuse stale labels"
+        assert not (graph_out / ".graphify_labels.json.sig").exists(), "cluster must not reuse stale signatures"
+        assert env is not None, "cluster must receive a deterministic environment"
+        leaked = [key for key in backend_selectors if key in env and env[key]]
+        assert not leaked, f"cluster inherited label backend selectors: {leaked}"
+        isolated_home = str(graph_out / ".shaft-home")
+        assert env.get("HOME") == isolated_home, "cluster must not load user-level custom providers"
+        assert env.get("USERPROFILE") == isolated_home, "Windows cluster must isolate user-level custom providers"
+        assert "graphifyy==0.9.42" in command, "hub-label behavior must be pinned to its verified Graphify release"
+
+controller.require_primary_checkout = lambda root: root / ".git"
+controller.require_clean_tracked_sources = lambda _root: None
+controller.refresh_lock = unlocked
+controller.run_audit = lambda _root, _out: {}
+controller.run_stage = fake_stage
+controller.shutil.which = lambda command: command
+
+with tempfile.TemporaryDirectory(prefix="shaft-guide-label-contract-") as temporary:
+    controller.refresh(pathlib.Path(temporary), pathlib.Path("graphify-out"))
+
+assert stages == ["build", "cluster", "record"], stages
+`;
+const labelingResult = runPython('-c', [labelingContract]);
+assert.strictEqual(labelingResult.status, 0,
+  `Graphify deterministic labeling contract failed:\n${labelingResult.stdout}${labelingResult.stderr}`);
 
 console.log('Graphify maintenance contract passed');

--- a/tools/repository-map/graphify_maintenance.py
+++ b/tools/repository-map/graphify_maintenance.py
@@ -20,6 +20,24 @@ CLASSIFICATIONS = (
     "unexpected_parser_gap",
 )
 DEFAULT_GRAPH_OUT = Path("graphify-out")
+GRAPHIFY_VERSION = "0.9.42"
+LABEL_BACKEND_ENV = (
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "MOONSHOT_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "OLLAMA_BASE_URL",
+    "OLLAMA_HOST",
+    "OLLAMA_API_KEY",
+    "GRAPHIFY_ALLOW_LOCAL_PROVIDERS",
+)
 
 
 def normalized_source(value: str) -> str:
@@ -79,10 +97,12 @@ def audit_graph(root: Path, graph_out: Path) -> dict[str, object]:
     return result
 
 
-def run_stage(name: str, command: list[str], root: Path) -> None:
+def run_stage(
+    name: str, command: list[str], root: Path, env: dict[str, str] | None = None
+) -> None:
     """Run one refresh stage and preserve its failure as a named error."""
     try:
-        subprocess.run(command, cwd=root, check=True)  # nosec B603
+        subprocess.run(command, cwd=root, check=True, env=env)  # nosec B603
     except subprocess.CalledProcessError as error:
         raise RuntimeError(f"Graphify {name} stage failed with exit {error.returncode}") from error
 
@@ -198,7 +218,7 @@ def refresh(root: Path, graph_out: Path) -> None:
         "--with",
         "tree-sitter-sql",
         "--from",
-        "graphifyy",
+        f"graphifyy=={GRAPHIFY_VERSION}",
         "graphify",
     ]
     resolver = Path(__file__).with_name("resolve_graph_out.py")
@@ -210,7 +230,22 @@ def refresh(root: Path, graph_out: Path) -> None:
             root,
         )
         run_audit(root, graph_out)
-        run_stage("cluster", [uv, *graphify[1:], "cluster-only", "."], root)
+        for name in (".graphify_labels.json", ".graphify_labels.json.sig"):
+            (requested_output / name).unlink(missing_ok=True)
+        cluster_env = {
+            name: value
+            for name, value in os.environ.items()
+            if name not in LABEL_BACKEND_ENV
+        }
+        isolated_home = requested_output / ".shaft-home"
+        cluster_env["HOME"] = str(isolated_home)
+        cluster_env["USERPROFILE"] = str(isolated_home)
+        run_stage(
+            "cluster",
+            [uv, *graphify[1:], "cluster-only", ".", "--no-viz"],
+            root,
+            env=cluster_env,
+        )
         run_stage("record", [sys.executable, str(resolver), "--record-current"], root)
 
 


### PR DESCRIPTION
## Summary

- pin the verified Graphify release that supplies local hub-derived community names
- discard stale label sidecars and isolate clustering from ambient model backends and provider configuration
- document semantic labels as optional and outside accepted cache freshness
- add focused positive and negative controller contracts

## Verification

- `yarn test:graphify` with observed RED/GREEN and deletion/backend/home/version mutations
- `yarn test`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (22 passed)
- independent increment review: zero blocking findings

Closes #969