### PR TITLE
docs(lighthouse): document managed setup and report flow

### DIFF
--- a/docs/reference/actions/GUI/Browser_Actions.md
+++ b/docs/reference/actions/GUI/Browser_Actions.md
@@ -7,6 +7,8 @@ keywords: [SHAFT, browser actions, navigation, window management, cookies, scree
 tags: [web, browser, actions, navigation]
 ---
 
+import {LighthouseSetupCommands} from '@site/src/components/DocSnippets';
+
 ## Getting Started
 
 To interact with web pages, create an instance of `SHAFT.GUI.WebDriver`:
@@ -294,14 +296,45 @@ Captures and serializes the current page DOM data and attaches it to the Allure 
 
 ### generateLightHouseReport()
 
+:::warning[Managed setup is not released]
+The managed flow below depends on
+[SHAFT Engine issue #4884](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4884).
+It is not yet available on `SHAFT_ENGINE` `main` or in a published SHAFT
+release. Keep using the current Lighthouse flow until a release that contains
+the managed `LIGHTHOUSE` provider is available.
+:::
+
+Install and verify the managed Lighthouse profile before running the test. The
+report action does not install tools or use a global Node or npm command. Use
+the default SHAFT roots for this preview so the setup CLI and Browser Actions
+resolve the same managed installation.
+
+<LighthouseSetupCommands />
+
+See [Set up local infrastructure](/docs/start/local-infrastructure#install-managed-lighthouse)
+for the canonical plan, install, policy, and offline-cache instructions.
+
 ```java title="LightHouseReport.java"
+SHAFT.Properties.performance.set().isEnabled(true);
 driver.browser().generateLightHouseReport();
 ```
 
-Triggers a Google Lighthouse performance audit on the currently open page. The generated report is attached to the Allure output. Useful for catching performance regressions in CI/CD pipelines.
+Run a desktop performance audit on the currently open page. SHAFT invokes its
+managed Lighthouse 13.4.1 CLI with managed Node 24.19.0 and connects to the
+debugging port of the local Chromium browser owned by WebDriver. SHAFT does not
+install Chromium as part of the `LIGHTHOUSE` profile.
 
-:::tip
-Configure `openLighthouseReportWhileExecution=true` in your properties file to automatically open the Lighthouse report during test execution.
+The action writes a validated HTML file under `lighthouse-reports/` and attaches
+its contents to the Allure output. It creates no executable JavaScript in the
+project. A missing or degraded managed toolchain stops the action with the
+setup command needed to repair it.
+
+:::warning[Report opening is opt-in]
+`openLighthouseReportWhileExecution` defaults to `false`, which is suitable for
+headless and CI runs. Set `openLighthouseReportWhileExecution=true` only when
+you want a desktop test run to open the generated HTML report and Java has a
+supported desktop/default-browser handler. If the handler is unavailable or
+opening fails, the report action fails before attaching the HTML to Allure.
 :::
 
 ## Wait Actions

--- a/docs/start/local-infrastructure.mdx
+++ b/docs/start/local-infrastructure.mdx
@@ -3,8 +3,10 @@ id: local-infrastructure
 title: Set up local infrastructure
 description: Diagnose, plan, approve, and install SHAFT-owned local tools through shaft-cli or Java.
 slug: /start/local-infrastructure
-tags: [installation, infrastructure, cli, allure, reporting]
+tags: [installation, infrastructure, cli, allure, reporting, lighthouse]
 ---
+
+import {LighthouseSetupCommands} from '@site/src/components/DocSnippets';
 
 # Set up local infrastructure
 
@@ -13,9 +15,9 @@ tools into SHAFT-owned user directories. The safe default is `EXTERNAL`: SHAFT
 diagnoses the host without downloading, installing, or starting anything.
 
 The setup catalog includes web, mobile, Grid, reporting, OCR, agent-tool, and
-local-AI profiles. Managed installation is currently available for
-`REPORTING`. It installs SHA-256-verified portable Node and Allure 3 artifacts.
-The other profiles are cataloged for the shared contract but currently return
+local-AI profiles. Managed installation is currently available for `REPORTING`.
+It uses SHAFT's pinned, SHA-256-verified portable Node and adds Allure 3. The
+other profiles are cataloged for the shared contract but currently return
 unsupported from provider-backed diagnosis and lifecycle commands.
 
 ## Inspect the catalog and host
@@ -65,6 +67,39 @@ checksum does not match before publishing it as installed.
 Treat the plan digest as a one-plan approval, not a general consent switch.
 Changing a version, source, checksum, destination, timeout, or policy option
 changes the digest and requires a new review.
+:::
+
+## Install managed Lighthouse
+
+:::warning[Not released]
+This workflow depends on
+[SHAFT Engine issue #4884](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4884).
+It is not yet available on `SHAFT_ENGINE` `main` or in a published SHAFT
+release. Keep using the current Lighthouse flow until a release that contains
+the managed `LIGHTHOUSE` provider is available.
+
+Install the `LIGHTHOUSE` profile before a test calls
+`generateLightHouseReport()`. SHAFT manages its own Node 24.19.0 and Lighthouse
+13.4.1 under the configured tool root. It does not use a global Node or npm
+installation.
+
+<LighthouseSetupCommands />
+
+Stop after `plan` and review the JSON plus its printed digest before running
+`install`. The plan binds the exact Node artifact, Lighthouse package archive,
+bundled dependency lock, destinations, and policy. Report generation only uses
+an already verified installation; it never installs a missing toolchain.
+
+For a cold offline install, pass `--offline` to both `plan` and `install`. The
+SHAFT cache must already contain the verified Node and Lighthouse artifacts
+and the complete transitive npm cache required by the bundled lock. An already
+verified managed installation can be reused without those cached downloads. A
+missing or corrupt entry needed by a cold install fails without network access
+or a partially published Lighthouse installation.
+
+Use the default SHAFT roots for this preview. The CLI can bind separate custom
+cache and data roots, but the Browser Actions runtime currently exposes only
+`infrastructure.cacheDirectory` and cannot reproduce every such layout.
 :::
 
 <!-- managed-ocr-preview:start -->
@@ -117,7 +152,8 @@ root or a relative path.
 The current `REPORTING` provider enforces `--offline`. It has no owned service,
 so auto-start, process reuse, and lifecycle timeouts are policy-bound for
 provider parity but do not change a reporting install. Reporting installs
-SHAFT-owned portable tools rather than adopting system Node or Allure.
+SHAFT-owned portable tools rather than adopting system Node or Allure. The
+unreleased `LIGHTHOUSE` provider follows the same lifecycle shape.
 
 :::warning
 Custom roots become mutable SHAFT-owned storage. Use dedicated, user-scoped
@@ -229,7 +265,7 @@ An explicit remote execution address keeps endpoint-backed profiles external,
 even when `infrastructure.mode=MANAGED`. This applies to web, Selenium Grid,
 mobile, and Healenium profiles, so a remote test configuration cannot
 unexpectedly provision local infrastructure. It does not change unrelated
-profiles such as `REPORTING`.
+profiles such as `REPORTING` or `LIGHTHOUSE`.
 
 ## Interpret CLI failures
 

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -62,6 +62,14 @@ export function BrowserSelectionProperties(): JSX.Element {
   );
 }
 
+export function LighthouseSetupCommands(): JSX.Element {
+  return (
+    <CodeBlock language="bash" title="Prepare managed Lighthouse">
+      {snippets.lighthouseSetupCommands}
+    </CodeBlock>
+  );
+}
+
 export function AllureReportPath(): JSX.Element {
   return <code>{snippets.allureReportPath}</code>;
 }

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -3,6 +3,7 @@
   "firstRunNoOpenCommand": "mvn test -Dallure.automaticallyOpen=false -Dallure.open=false",
   "allureReportPath": "allure-results and the generated Allure report under the project target output",
   "browserSelectionProperties": "targetBrowserName=CHROME\nheadlessExecution=true\ncreateAnimatedGif=true\nallure.singleFile=true",
+  "lighthouseSetupCommands": "shaft-cli setup status --profile LIGHTHOUSE\nshaft-cli setup plan \\\n  --profile LIGHTHOUSE \\\n  --mode MANAGED \\\n  --output /absolute/path/lighthouse-plan.json\nshaft-cli setup install \\\n  --plan /absolute/path/lighthouse-plan.json \\\n  --approve sha256:<reviewed-digest>\nshaft-cli setup verify --profile LIGHTHOUSE",
   "githubRepository": "https://github.com/ShaftHQ/SHAFT_ENGINE",
   "skillsInstaller": {
     "windows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.ps1 | iex; Install-ShaftMcp -Arguments @('--install-shaft-skills')\"",


### PR DESCRIPTION
## Summary
- document the unreleased, pinned Node 24.19.0 and Lighthouse 13.4.1 managed setup
- describe reviewed plan/install/verify and cold offline-cache behavior
- document Browser Actions use of the managed CLI against WebDriver Chromium's debugger port
- keep report opening explicitly opt-in and warn about desktop-handler failure
- render one canonical Lighthouse setup command snippet on both pages

## Dependency
This documentation must not merge before the SHAFT Engine implementation for #4884. Both pages carry a Not released warning until that implementation ships.

## Checks
- yarn test
- yarn typecheck
- yarn build
- yarn test:playwright (22 passed)
- Graphify refresh from the primary docs checkout
- independent adversarial review: zero blocking findings

Closes #970
Related to ShaftHQ/SHAFT_ENGINE#4884