### PR TITLE
docs(agent): document native Maven Tools MCP

### DIFF
--- a/docs/maintainers/agent-tooling.md
+++ b/docs/maintainers/agent-tooling.md
@@ -23,7 +23,7 @@ agent-assisted SHAFT maintenance. Repository guidance (`AGENTS.md`,
 | gbrain-ollama | Embedding backend for gbrain | Docker `ollama/ollama` + `nomic-embed-text` model |
 | graphify | Deterministic repository map (structure queries, pre-search file selection) | Repository controller using an isolated uv tool environment |
 | context7 | Post-cutoff library docs MCP | `npx @upstash/context7-mcp` (project `.mcp.json`) |
-| maven-tools-mcp | Live Maven Central facts MCP | Docker `arvindand/maven-tools-mcp` (project `.mcp.json`) |
+| maven-tools-mcp | Live Maven Central facts MCP | Optional receipt-pinned Java 25 JAR managed by the [ChaosEngine installer](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/chaos-engine/INSTALL.md#optional-native-maven-tools-mcp) |
 | Claude Code plugins | jdtls-lsp, frontend-design, mcp-server-dev | Auto-installed from `.claude/settings.json` `enabledPlugins` |
 
 The `fable` and `superpowers` plugins were removed in the 2026-07-17 harness
@@ -257,11 +257,15 @@ for the executable shared-cache contract.
 
 ## MCP servers and plugins
 
-Project-scoped servers live in SHAFT_ENGINE `.mcp.json` (context7 via npx,
-maven-tools-mcp via Docker) and need Node and Docker present. The gbrain MCP
-server is user-scoped (`~/.claude.json`): `gbrain serve` over stdio. Claude
-Code plugins install themselves from `.claude/settings.json`
-`enabledPlugins`/`extraKnownMarketplaces` on first session start.
+Context7 is project-scoped in SHAFT_ENGINE `.mcp.json` and runs through `npx`,
+so it needs Node. Maven Tools is an optional native Java 25 server: the
+[ChaosEngine installer](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/chaos-engine/INSTALL.md#optional-native-maven-tools-mcp)
+discovers a verified, receipt-pinned JAR and writes the project host entries.
+It omits those entries when no verified runtime is installed; Docker is not
+required. The gbrain MCP server is user-scoped (`~/.claude.json`): `gbrain
+serve` over stdio. Claude Code plugins install themselves from
+`.claude/settings.json` `enabledPlugins`/`extraKnownMarketplaces` on first
+session start.
 
 ## Health checklist
 


### PR DESCRIPTION
## Summary

- replace the stale Docker-based Maven Tools MCP inventory entry with the optional receipt-pinned Java 25 runtime
- explain verified-runtime discovery and omission when the runtime is absent
- separate Context7's Node prerequisite from Maven Tools and link the canonical ChaosEngine installer contract

## Verification

- `yarn test:security`
- `yarn test:a11y:contract`
- `yarn test:docs`
- `yarn test:homepage`
- `yarn test:history`
- `yarn typecheck`
- `yarn build`
- `yarn test:playwright` (22 passed)
- `git diff --check`
- independent read-only review: zero blocking findings

The Graphify-specific test and refresh were intentionally not run at the user's direction.

Closes #977
Related: ShaftHQ/SHAFT_ENGINE#4906
Related: ShaftHQ/SHAFT_ENGINE#4937