### PR TITLE
docs: explain portable ChaosEngine lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,14 @@
 
 ## Graphify
 
-- Before PRs, refresh Graphify for every changed repository from that
-  repository's primary checkout. Use the repository-owned maintenance
-  controller with an explicit, relative `--root`; linked worktrees only read
-  the shared cache. Report tool, parser, and cache blockers.
+- Query Graphify only when it answers a concrete structure question. Treat a
+  shared cache as an untrusted lead, verify returned paths in live files, and
+  use targeted `rg` before concluding blast radius.
+- Missing, stale, timed-out, or inaccessible caches never block ordinary task
+  work or completion. Do not refresh, repair, poll, or watch Graphify per task.
+- Explicit maintenance runs from the repository's primary checkout through
+  the repository-owned controller with a relative `--root`. Linked worktrees
+  only read the shared cache. Maintenance and doctor failures remain strict.
 
 ## Validation
 

--- a/docs/agentic/chaos-engine.mdx
+++ b/docs/agentic/chaos-engine.mdx
@@ -45,6 +45,30 @@ The project may be a SHAFT Git checkout, another Git checkout, or a non-Git
 folder. The bootstrap uses the configured SHAFT upstream and never infers it
 from the consumer project's Git remote.
 
+## Read health and ownership
+
+Both `status` and `doctor` report each component's health with four capability
+fields:
+
+| Field | Values | Meaning |
+|---|---|---|
+| `owner` | `installer`, `project`, `user` | Who may change or remove the component |
+| `scope` | `project`, `repository`, `user` | Where the component is shared |
+| `lifecycle` | `receipt-owned`, `persistent-data`, `derived-single-writer`, `user-managed-cache` | How the component is maintained |
+| `taskImpact` | `required`, `advisory`, `optional` | Whether its health affects ordinary task work |
+
+Memory, MemPalace, and Graphify have advisory task impact. An ordinary task can
+continue when any of them is missing, stale, corrupt, timed out, or
+inaccessible. Use one scoped query only when it answers a concrete question,
+verify any returned path against live files, and use targeted repository search
+before deciding impact. Do not retry, repair, refresh, poll, or watch a store as
+part of task completion.
+
+Installation, upgrade, explicit maintenance, `status`, and `doctor` remain
+strict. An unhealthy selected component makes requested `status` or `doctor`
+health `recovery-required`. Advisory task impact does not weaken those operator
+checks.
+
 ## What gets installed
 
 ChaosEngine installs and owns these project-local surfaces:
@@ -61,6 +85,12 @@ It preserves unrelated project instructions, skills, configuration, and tool
 entries. Its self-learning flow queues only privacy-screened, confirmed
 lessons and contributes them upstream as reviewable GitHub issues, never as an
 automatic pull request.
+
+The optional Maven Tools MCP uses an immutable user-managed cache. Multiple
+projects can reuse one verified JAR and receipt, and uninstalling ChaosEngine
+from a project never removes that cache. See the [agent tooling cache
+runbook](/docs/maintainers/agent-tooling#maven-tools-mcp-cache) for status,
+purge, and manual population commands.
 
 ## Related
 

--- a/docs/maintainers/agent-tooling.md
+++ b/docs/maintainers/agent-tooling.md
@@ -23,7 +23,7 @@ agent-assisted SHAFT maintenance. Repository guidance (`AGENTS.md`,
 | gbrain-ollama | Embedding backend for gbrain | Docker `ollama/ollama` + `nomic-embed-text` model |
 | graphify | Deterministic repository map (structure queries, pre-search file selection) | Repository controller using an isolated uv tool environment |
 | context7 | Post-cutoff library docs MCP | `npx @upstash/context7-mcp` (project `.mcp.json`) |
-| maven-tools-mcp | Live Maven Central facts MCP | Optional receipt-pinned Java 25 JAR managed by the [ChaosEngine installer](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/chaos-engine/INSTALL.md#optional-native-maven-tools-mcp) |
+| maven-tools-mcp | Live Maven Central facts MCP | Optional receipt-pinned Java 25 JAR in a user-managed cache discovered by the [ChaosEngine installer](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/chaos-engine/INSTALL.md#optional-native-maven-tools-mcp) |
 | Claude Code plugins | jdtls-lsp, frontend-design, mcp-server-dev | Auto-installed from `.claude/settings.json` `enabledPlugins` |
 
 The `fable` and `superpowers` plugins were removed in the 2026-07-17 harness
@@ -35,6 +35,28 @@ UI evidence gathering moved from `webapp-testing`/`accessibility-review`/
 config (`~/.claude`) now deploys from the source-controlled
 `.claude/user-harness/` via `scripts/agents/sync_user_harness.py`
 (`--check`/`--apply`) instead of being hand-maintained.
+
+## Task-time knowledge retrieval
+
+Treat Memory, MemPalace, and Graphify as advisory for ordinary implementation
+tasks. Keep session-start summaries best effort, and make one task-specific
+query only when it answers a concrete question. Verify retrieved paths and
+claims against current files, then use targeted `rg` to confirm callers and
+blast radius.
+
+A missing, stale, corrupt, timed-out, or inaccessible store never blocks
+ordinary task work or completion. Do not retry, repair, refresh, mine,
+checkpoint, poll, or watch a store per task. The scheduled or explicitly
+requested maintenance owner updates derived stores. Installation, upgrade,
+explicit maintenance, `status`, and `doctor` remain strict. An unhealthy
+selected component makes requested `status` or `doctor` health
+`recovery-required`.
+
+Installed `status` and `doctor` output also identifies each component's
+`owner`, `scope`, `lifecycle`, and `taskImpact`. Use those fields to distinguish
+installer-owned project files, persistent project data, single-writer derived
+repository data, and the optional user-managed Maven cache. Do not infer
+cleanup authority from a health key alone.
 
 ## memory CLI
 
@@ -167,6 +189,16 @@ Deterministic repository map, complementary to gbrain — graphify answers
 *structure* (which files/modules relate, zero DB locking, works offline);
 gbrain answers *meaning* (semantic retrieval). Both stay.
 
+For an ordinary task, query an available shared cache only as an untrusted
+lead. Check it once when a concrete structure question justifies the query,
+verify every returned path against live files, and supplement caller searches
+with targeted `rg`. Never infer completeness or "no callers" from the graph.
+An absent, stale, or inaccessible cache is a non-blocking degraded result; do
+not refresh or watch it from the task.
+
+The following refresh command is for the explicit maintenance owner, not a
+per-task or pre-PR requirement:
+
 ```powershell
 py -3 tools/repository-map/graphify_maintenance.py refresh --root .
 ```
@@ -243,12 +275,13 @@ marker recording. A contender fails before cache mutation. The operating
 system releases the lock if the process exits or is killed, so there is no
 stale lock file to delete.
 
-Agents check the shared cache with
-`py -3 tools/repository-map/resolve_graph_out.py --check`. The command exits
-successfully only when the marker matches the revision being inspected.
+When a concrete task question needs it, agents can check the shared cache once
+with `py -3 tools/repository-map/resolve_graph_out.py --check`. The command
+exits successfully only when the marker matches the revision being inspected.
 Missing caches report `absent`; unmarked, changed, or revision-mismatched
-caches report `stale`. In either degraded mode, use targeted `rg` and Memory
-instead of treating the map as current evidence.
+caches report `stale`. In either degraded mode, continue with live files and
+targeted `rg` instead of treating the map as current evidence or starting
+maintenance.
 
 The daily `graphify-refresh` Scheduled Task uses the same controller and safety
 rules. See the
@@ -266,6 +299,36 @@ required. The gbrain MCP server is user-scoped (`~/.claude.json`): `gbrain
 serve` over stdio. Claude Code plugins install themselves from
 `.claude/settings.json` `enabledPlugins`/`extraKnownMarketplaces` on first
 session start.
+
+### Maven Tools MCP cache
+
+The Maven Tools MCP version directory is an immutable, user-managed cache.
+Parallel projects may reuse the same verified JAR and `install-receipt.json`
+pair without mutation. Project install and uninstall change only project host
+configuration; they never install, reference-count, purge, or remove the shared
+cache automatically.
+
+Inspect the selected cache or purge exactly version `3.2.0`:
+
+```text
+python .chaos-engine/install.py cache status --component maven-tools-mcp
+python .chaos-engine/install.py cache purge --component maven-tools-mcp --version 3.2.0
+```
+
+`cache status` validates the path, reparse points, receipt, version, pinned
+commit, and SHA-256, then reports `healthy`, `absent`, `invalid`, or `busy`.
+`cache purge` takes a non-waiting user-cache lock and removes only the exact
+verified version's receipt-owned files. It refuses modified, unknown, linked,
+broad, or busy targets. An absent version is already a successful result.
+
+Populate the cache manually only after building the pinned upstream source.
+Create a fresh unique version staging directory on the same filesystem as the
+user data directory, place the JAR and exact receipt in it, then publish it with
+a no-overwrite rename. Ignore incomplete or invalid pairs. Do not add automatic
+download, build, installation, reference counting, or cache removal. Use the
+[portable ChaosEngine manual population
+sequence](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/chaos-engine/INSTALL.md#optional-native-maven-tools-mcp)
+for the pinned version, commit, receipt shape, and platform-specific commands.
 
 ## Health checklist
 


### PR DESCRIPTION
## Summary

- document advisory task-time Memory, MemPalace, and Graphify retrieval with live verification and no per-task refresh/watch work
- document strict operator health behavior and the new capability ownership metadata
- document the immutable user-managed Maven Tools MCP cache, status/purge commands, and manual no-overwrite population
- align repository Graphify guidance with the merged portable harness lifecycle

Companion documentation for ShaftHQ/SHAFT_ENGINE#4995 and merged ShaftHQ/SHAFT_ENGINE#4997.

## Validation

- `node tests/cloudflare-autobot.test.js` (exact test after restoring locked dependencies)
- `yarn typecheck`
- `yarn build`
- `npx playwright test tests/e2e/composited-contrast.spec.js --grep "section eyebrow labels clear"` (exact rerun of the only transient failure)
- `git diff --check`
- independent read-only review: zero remaining findings

`yarn test` reached the docs tests but initially stopped because this fresh checkout had no `node_modules`; the exact failing test passed after `yarn install --frozen-lockfile --non-interactive`. The full Playwright run passed 21/22 and its sole unrelated contrast failure passed on the exact isolated rerun.