### PR TITLE
docs(agentic): explain reflection checkpoints

### DIFF
--- a/docs/agentic/chaos-engine.mdx
+++ b/docs/agentic/chaos-engine.mdx
@@ -7,6 +7,8 @@ keywords: [ChaosEngine, agent harness, install, upgrade, Codex, Claude, Gemini]
 tags: [agents, skills, install]
 ---
 
+import {ReflectionReceiptCommand} from '@site/src/components/DocSnippets';
+
 # Install ChaosEngine
 
 ChaosEngine is SHAFT's project-local agent harness. It makes one canonical
@@ -68,6 +70,37 @@ Installation, upgrade, explicit maintenance, `status`, and `doctor` remain
 strict. An unhealthy selected component makes requested `status` or `doctor`
 health `recovery-required`. Advisory task impact does not weaken those operator
 checks.
+
+## Respond to reflection checkpoints
+
+ChaosEngine pauses implementation mutation after two attempted failures in one
+task. Different failure fingerprints require task-level reflection; the same
+fingerprint twice requires deep reflection. Read-only diagnosis, tracker
+updates, and a changed diagnostic check remain available, but an unchanged
+retry or third speculative fix does not.
+
+Copy each hash after `Sanitized fingerprints:` in the checkpoint message. Use
+the session token printed by the lifecycle hook to append the bounded receipt:
+
+<ReflectionReceiptCommand />
+
+On Windows, use `py -3` instead of `python3` and quote the JSON for your shell.
+The receipt accepts bounded conclusions, not raw logs, prompts, credentials, or
+host paths. Knowledge stores and GitHub remain optional for this local control
+flow.
+
+After more than one hour, finish implementation and delivery first. Then record
+the terminal receipt and use these exact labels in the final summary:
+
+- `elapsed estimate`
+- `main time consumer`
+- `repeated failures or corrections`
+- `changed assumption or approach`
+- `successful proof`
+- `remaining risk or follow-up`
+- `learning loop disposition`
+
+Later work or failure invalidates an earlier terminal receipt.
 
 ## What gets installed
 

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -50,6 +50,10 @@ export function FirstRunCommand(): JSX.Element {
   return <CodeBlock language="bash">{snippets.firstRunCommand}</CodeBlock>;
 }
 
+export function ReflectionReceiptCommand(): JSX.Element {
+  return <CodeBlock language="bash">{snippets.reflectionReceiptCommand}</CodeBlock>;
+}
+
 export function FirstRunNoOpenCommand(): JSX.Element {
   return <CodeBlock language="bash">{snippets.firstRunNoOpenCommand}</CodeBlock>;
 }

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,5 +1,6 @@
 {
   "firstRunCommand": "mvn test",
+  "reflectionReceiptCommand": "python3 .chaos-engine/hooks/reflection.py receipt \\\n  --session-id SESSION_ID \\\n  --session-token SESSION_TOKEN \\\n  --json '{\"schemaVersion\":1,\"taskId\":\"issue-123\",\"trigger\":\"repeated-fingerprint\",\"failureFingerprints\":[\"COPY_HASH_FROM_CHECKPOINT\"],\"failedAssumption\":\"The unchanged retry would add evidence.\",\"approachesCompared\":[\"Inspect the bounded state\",\"Change one diagnostic input\"],\"chosenExperiment\":\"Run the changed diagnostic check.\",\"changedApproach\":\"Stopped the unchanged retry.\",\"proofCommandOrCheck\":\"focused check\",\"proofOutcome\":\"The focused check passed.\",\"durableDisposition\":\"nothing-durable\"}'",
   "firstRunNoOpenCommand": "mvn test -Dallure.automaticallyOpen=false -Dallure.open=false",
   "allureReportPath": "allure-results and the generated Allure report under the project target output",
   "browserSelectionProperties": "targetBrowserName=CHROME\nheadlessExecution=true\ncreateAnimatedGif=true\nallure.singleFile=true",


### PR DESCRIPTION
## Summary
- document task, deep, and terminal reflection checkpoints
- show the installed receipt flow using the shared documentation snippet
- list the exact terminal reflection labels and receipt invalidation behavior

Related to ShaftHQ/SHAFT_ENGINE#5000
Related to ShaftHQ/SHAFT_ENGINE#5004

## Checks
- yarn test
- yarn typecheck
- yarn build
- yarn test:playwright (22 passed)
- git diff --check
- independent adversarial review: no findings
