### PR TITLE
docs(locators): align leftover ranking with generated policy

### DIFF
--- a/docs/features/test-automation-pillars.mdx
+++ b/docs/features/test-automation-pillars.mdx
@@ -156,7 +156,7 @@ public class LoginTest {
         driver.element()
                 .type(SHAFT.GUI.Locator.hasAnyTagName().hasId("email").build(), users.getTestData("valid.email"))
                 .type(SHAFT.GUI.Locator.hasAnyTagName().hasId("password").build(), users.getTestData("valid.password"))
-                .click(SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Log in").build());
+                .click(SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Log in").build());
         driver.assertThat().browser().url().contains("/dashboard");
     }
 

--- a/docs/reference/actions/GUI/Element_Identification.md
+++ b/docs/reference/actions/GUI/Element_Identification.md
@@ -21,10 +21,10 @@ SHAFT Engine supports all standard Selenium locator strategies through the `By` 
 
 ### 1. ID
 
-Locates elements by their unique `id` attribute - the most reliable and fastest method when available.
+Existing locators may still use Selenium `By.id`. Generated and repository code emit a unique author-written id through the SHAFT locator builder:
 
 ```java
-By elementLocator = By.id("username");
+By elementLocator = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
 ```
 
 ### 2. Name
@@ -62,11 +62,10 @@ By elementLocator = By.cssSelector("#login-form > input.username");
 
 ### 6. XPath
 
-Locates elements using XPath expressions. Generated and repository code use native relative `By.xpath(...)` only when the element has neither a unique author-written id nor a usable ARIA role.
+Locates elements using XPath expressions. Generated and repository code use native relative `By.xpath(...)` only when the element has neither a unique author-written id nor a usable ARIA role. Do not target an id that should have taken the first rung.
 
 ```java
-By elementLocator = By.xpath("//input[@id='username']");
-By elementLocator = By.xpath("//button[contains(text(),'Submit')]");
+By elementLocator = By.xpath(".//form//button[@type='submit']");
 ```
 
 ### 7. Link Text
@@ -110,13 +109,9 @@ By button = By.xpath("//button[@data-test='submit']");
 
 **SHAFT Locator Builder Approach:**
 ```java
-// More readable and self-documenting
-By button = SHAFT.GUI.Locator.hasTagName("button")
-    .hasAttribute("data-test", "submit")
-    .build();
+By button = SHAFT.GUI.Locator.hasAnyTagName().hasId("submit-btn").build();
 
-// Or using ID
-By button = SHAFT.GUI.Locator.hasId("submit-btn").build();
+By button = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Submit").build();
 ```
 
 ### Example 2: Complex Element
@@ -157,8 +152,8 @@ By button = By.cssSelector("button.action-button"); // Can't filter by text with
 
 **SHAFT Locator Builder Approach:**
 ```java
-By button = SHAFT.GUI.Locator.hasTagName("button")
-    .containsText("Add to Cart")
+By button = SHAFT.GUI.Locator.hasRole(Role.BUTTON)
+    .hasNormalizedText("Add to Cart")
     .build();
 ```
 
@@ -183,8 +178,8 @@ SHAFT.GUI.Locator.hasAttribute("data-test").build();
 // Element with attribute and value
 SHAFT.GUI.Locator.hasAttribute("data-test", "add-to-cart").build();
 
-// Element with ID
-SHAFT.GUI.Locator.hasId("username").build();
+// Unique author-written id (generated and repository form)
+SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
 
 // Element containing a class
 SHAFT.GUI.Locator.containsClass("btn-primary").build();
@@ -570,7 +565,7 @@ driver.element().switchToDefaultContent();
 
 ```java
 By shadowHost = SHAFT.GUI.Locator.hasTagName("custom-component").build();
-By referenceElement = SHAFT.GUI.Locator.hasId("reference")
+By referenceElement = SHAFT.GUI.Locator.hasAnyTagName().hasId("reference")
     .insideShadowDom(shadowHost)
     .build();
 
@@ -682,7 +677,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.Role;
 
 // Locate a submit button by role and visible text
-By submitButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Submit").build();
+By submitButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Submit").build();
 
 // Locate a search input by role
 By searchInput = SHAFT.GUI.Locator.hasRole(Role.SEARCHBOX).build();
@@ -773,11 +768,13 @@ Sometimes a locator depends on runtime data — a product name, a row index, or 
 
 ```java title="DynamicLocators.java"
 public By getProductAddToCartButton(String productName) {
-    return By.cssSelector("div[data-product='" + productName + "'] button.add-to-cart");
+    return SHAFT.GUI.Locator.hasRole(Role.BUTTON)
+        .hasAttribute("data-product", productName)
+        .build();
 }
 
 public By getTableCell(int row, int col) {
-    return By.cssSelector("table tr:nth-child(" + row + ") td:nth-child(" + col + ")");
+    return By.xpath(".//table//tr[" + row + "]//td[" + col + "]");
 }
 ```
 

--- a/docs/reference/actions/GUI/Element_Identification.md
+++ b/docs/reference/actions/GUI/Element_Identification.md
@@ -17,7 +17,7 @@ for exact locator syntax.
 
 ## Supported Locator Types
 
-SHAFT Engine supports all standard Selenium locator strategies through the `By` class:
+SHAFT Engine supports all standard Selenium locator strategies through the `By` class. Raw Selenium `By` syntax below is a reference for existing locators. Generated and repository code follow the [generated locator policy](/docs/reference/actions/GUI/Locators_And_Self_Healing#generated-locator-policy): unique author-written id via the SHAFT locator builder, then ARIA role, then native relative xpath only.
 
 ### 1. ID
 
@@ -62,7 +62,7 @@ By elementLocator = By.cssSelector("#login-form > input.username");
 
 ### 6. XPath
 
-Locates elements using XPath expressions - very powerful but can be slower than CSS selectors.
+Locates elements using XPath expressions. Generated and repository code use native relative `By.xpath(...)` only when the element has neither a unique author-written id nor a usable ARIA role.
 
 ```java
 By elementLocator = By.xpath("//input[@id='username']");
@@ -756,12 +756,14 @@ The `@FindBy` annotation (from Selenium's `PageFactory`) has several drawbacks c
 Define your locators as `By` constants in your Page Object class instead:
 
 ```java title="LoginPage.java"
+import com.shaft.driver.SHAFT;
+import com.shaft.enums.internal.Role;
 import org.openqa.selenium.By;
 
 public class LoginPage {
-    private final By usernameInput = By.id("username");
-    private final By passwordInput = By.id("password");
-    private final By loginButton = By.cssSelector("button[type='submit']");
+    private final By usernameInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
+    private final By passwordInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("password").build();
+    private final By loginButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Log In").build();
 }
 ```
 
@@ -816,14 +818,14 @@ For a cleaner approach, centralize platform-specific locators in a constants fil
 
 ## Best Practices
 
-1. **Prefer ID locators** when available - they're the fastest and most reliable
-2. **Use SHAFT Locator Builder** for complex locators - it's more readable and maintainable
-3. **Avoid XPath when possible** - CSS selectors are generally faster
-4. **Use relative locators** for dynamic layouts where absolute positions might change
-5. **Keep locators simple** - complex locators are fragile and hard to maintain
-6. **Use data attributes** (e.g., `data-test`) specifically for testing when you control the HTML
-7. **Document complex locators** - add comments explaining why a particular strategy was chosen
-8. **Test locators in isolation** - verify your locators work before building tests around them
+1. **Use a unique author-written id** through `SHAFT.GUI.Locator.hasAnyTagName().hasId(...)` when one exists. Never a framework-recycled id such as `:r1:`, `mat-input-3`, or `cdk-overlay-0`.
+2. **Then use an ARIA role** through `hasRole(...)`, chained with `hasNormalizedText`, `hasAttribute`, or context until unique.
+3. **Use native relative `By.xpath(...)` only** when the element has neither. Do not prefer CSS over that fallback, and do not emit `SHAFT.GUI.Locator.xpath(...)`.
+4. **Keep Smart Locators for human exploration only.** Generated and repository code must not use `inputField` or `clickableField`.
+5. **Keep locators simple** - complex locators are fragile and hard to maintain.
+6. **Use data attributes** (e.g., `data-test`) specifically for testing when you control the HTML.
+7. **Document complex locators** - add comments explaining why a particular strategy was chosen.
+8. **Test locators in isolation** - verify your locators work before building tests around them.
 
 ## Related
 

--- a/docs/reference/actions/GUI/Locators_And_Self_Healing.md
+++ b/docs/reference/actions/GUI/Locators_And_Self_Healing.md
@@ -203,7 +203,7 @@ By login = SHAFT.GUI.Locator.clickableField("Log In");
 | Approach | Example | Generated or repository rank |
 |---|---|---|
 | Author-written id | `SHAFT.GUI.Locator.hasAnyTagName().hasId("login-submit").build()` | First, when unique and not recycled |
-| ARIA role | `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Log In").build()` | Second |
+| ARIA role | `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Log In").build()` | Second |
 | Native relative xpath | `By.xpath(".//form//button[@type='submit']")` | Third, only when the element has neither |
 | Smart Locator | `clickableField("Log In")` | Human exploration only; never generated or repository code |
 

--- a/docs/reference/actions/GUI/Locators_And_Self_Healing.md
+++ b/docs/reference/actions/GUI/Locators_And_Self_Healing.md
@@ -62,7 +62,7 @@ shaft-cli call verify_run_focused
 import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.Role;
 
-By submitButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Submit").build();
+By submitButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Submit").build();
 By searchInput = SHAFT.GUI.Locator.hasRole(Role.SEARCHBOX).build();
 By errorAlert = SHAFT.GUI.Locator.hasRole(Role.ALERT).containsText("error").build();
 
@@ -71,8 +71,9 @@ driver.element().type(searchInput, "test query");
 ```
 
 :::tip
-For generated or repository code, chain `hasRole(...)` with text or attributes
-until the match is unique. Do not pair it with a Smart Locator.
+For generated or repository code, chain `hasRole(...)` with
+`hasNormalizedText`, `hasAttribute`, or context until the match is unique.
+Do not pair it with a Smart Locator.
 :::
 
 ## Self-healing locators {/* #self-healing-locators */}

--- a/docs/reference/guides/Solution_Design.md
+++ b/docs/reference/guides/Solution_Design.md
@@ -21,9 +21,9 @@ import org.openqa.selenium.By;
 
 public class LoginPage {
     private final SHAFT.GUI.WebDriver driver;
-    private final By usernameInput = By.id("username");
-    private final By passwordInput = By.id("password");
-    private final By loginButton = By.id("login-btn");
+    private final By usernameInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
+    private final By passwordInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("password").build();
+    private final By loginButton = SHAFT.GUI.Locator.hasAnyTagName().hasId("login-btn").build();
 
     public LoginPage(SHAFT.GUI.WebDriver driver) {
         this.driver = driver;
@@ -67,9 +67,9 @@ import org.openqa.selenium.By;
 
 public class FluentLoginPage {
     private final SHAFT.GUI.WebDriver driver;
-    private final By usernameInput = By.id("username");
-    private final By passwordInput = By.id("password");
-    private final By loginButton = By.id("login-btn");
+    private final By usernameInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
+    private final By passwordInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("password").build();
+    private final By loginButton = SHAFT.GUI.Locator.hasAnyTagName().hasId("login-btn").build();
 
     public FluentLoginPage(SHAFT.GUI.WebDriver driver) {
         this.driver = driver;

--- a/docs/testing/flakiness.mdx
+++ b/docs/testing/flakiness.mdx
@@ -41,7 +41,7 @@ unique author-written id, then ARIA role, then native relative xpath only.
 
 - `SHAFT.GUI.Locator.hasAnyTagName().hasId("email").build()` is the first
   generated-code rung when the product owns a stable author-written id.
-- `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Sign in").build()` targets
+- `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Sign in").build()` targets
   semantic roles and text instead of brittle markup structure.
 - `SHAFT.GUI.Locator.inputField("Email")` and
   `SHAFT.GUI.Locator.clickableField("Sign in")` are Smart Locators for a
@@ -58,7 +58,7 @@ unique author-written id, then ARIA role, then native relative xpath only.
 import com.shaft.enums.internal.Role;
 
 By email = SHAFT.GUI.Locator.hasAnyTagName().hasId("email").build();
-By apply = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Apply filter").build();
+By apply = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Apply filter").build();
 
 driver.element()
         .type(email, "qa@example.com")

--- a/docs/testing/web.mdx
+++ b/docs/testing/web.mdx
@@ -77,7 +77,7 @@ ladder:
    Never a framework-recycled id such as `:r1:`, `mat-input-3`,
    `cdk-overlay-0`, `ember1234`, `j_idt42`, `ctl00_...`, or `sc-bdVaJa`.
 2. The same builder's ARIA role, chained until unique:
-   `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Create Account").build()`.
+   `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText("Create Account").build()`.
 3. Native relative `By.xpath(...)` only when the element has neither an
    eligible id nor a usable role.
 

--- a/tests/docs-quality.test.js
+++ b/tests/docs-quality.test.js
@@ -277,7 +277,17 @@ const officialLocatorPages = {
   web: readFileSync(join(docsRoot, 'testing/web.mdx'), 'utf8'),
   pillars: readFileSync(join(docsRoot, 'features/test-automation-pillars.mdx'), 'utf8'),
   solutionDesign: readFileSync(join(docsRoot, 'reference/guides/Solution_Design.md'), 'utf8'),
+  flakiness: readFileSync(join(docsRoot, 'testing/flakiness.mdx'), 'utf8'),
 };
+
+const generatedHasTextForm = /hasRole\([^)]*\)\.hasText\(/;
+for (const {fullPath, relativePath} of docs) {
+  const content = readFileSync(fullPath, 'utf8');
+  assert(
+    !generatedHasTextForm.test(content),
+    `${relativePath} must not teach hasRole(...).hasText( as the generated/repo form; use hasNormalizedText.`,
+  );
+}
 
 function titledJavaFences(content, titlePattern) {
   return content.match(new RegExp('```java title="' + titlePattern + '"[\\s\\S]*?```', 'g')) || [];
@@ -390,6 +400,40 @@ assert(
 assert(
   /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log In"\)/.test(officialLocatorPages.locatorsAndSelfHealing),
   'Locators_And_Self_Healing.md ranking table must show hasNormalizedText.',
+);
+
+const ariaLocators = titledJavaFences(
+  officialLocatorPages.locatorsAndSelfHealing,
+  'ARIALocators\\.java',
+);
+assert(
+  ariaLocators.length === 1,
+  'Locators_And_Self_Healing.md must keep a titled ARIALocators.java sample.',
+);
+assert(
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Submit"\)/.test(ariaLocators[0]),
+  'ARIALocators.java must use hasNormalizedText as the generated second rung.',
+);
+assert(
+  !generatedHasTextForm.test(ariaLocators[0]),
+  'ARIALocators.java must not teach hasRole(...).hasText( as the generated form.',
+);
+
+const semanticLocators = titledJavaFences(
+  officialLocatorPages.flakiness,
+  'SemanticLocators\\.java',
+);
+assert(
+  semanticLocators.length === 1,
+  'flakiness.mdx must keep a titled SemanticLocators.java sample.',
+);
+assert(
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Apply filter"\)/.test(semanticLocators[0]),
+  'SemanticLocators.java must use hasNormalizedText as the generated second rung.',
+);
+assert(
+  !generatedHasTextForm.test(semanticLocators[0]),
+  'SemanticLocators.java must not teach hasRole(...).hasText( as the generated form.',
 );
 
 console.log('Documentation quality checks passed.');

--- a/tests/docs-quality.test.js
+++ b/tests/docs-quality.test.js
@@ -265,4 +265,45 @@ assert(
   'The maintainer overview must link repository-local operational README files.',
 );
 
+const elementIdentification = readFileSync(
+  join(docsRoot, 'reference/actions/GUI/Element_Identification.md'),
+  'utf8',
+);
+const locatorsAndSelfHealing = readFileSync(
+  join(docsRoot, 'reference/actions/GUI/Locators_And_Self_Healing.md'),
+  'utf8',
+);
+
+assert(
+  !/Prefer ID locators/i.test(elementIdentification),
+  'Element_Identification.md Best Practices must not prefer raw ID locators over the generated locator policy.',
+);
+assert(
+  !/Avoid XPath when possible/i.test(elementIdentification),
+  'Element_Identification.md must not tell readers to prefer CSS over native relative xpath.',
+);
+assert(
+  !/CSS selectors are generally faster/i.test(elementIdentification),
+  'Element_Identification.md must not rank CSS faster than native relative xpath.',
+);
+assert(
+  /hasAnyTagName\(\)\.hasId\("username"\)/.test(elementIdentification),
+  'Element_Identification.md LoginPage must use the SHAFT locator builder for a unique author-written id.',
+);
+assert(
+  !/private final By loginButton = By\.cssSelector/.test(elementIdentification),
+  'Element_Identification.md LoginPage must not recommend raw By.cssSelector as the generated form.',
+);
+
+assert(
+  !/ARIA role \| `SHAFT\.GUI\.Locator\.hasRole\(Role\.BUTTON\)\.hasText\("Log In"\)\.build\(\)`/.test(
+    locatorsAndSelfHealing,
+  ),
+  'Locators_And_Self_Healing.md ranking table must not teach hasText as the official second rung.',
+);
+assert(
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log In"\)/.test(locatorsAndSelfHealing),
+  'Locators_And_Self_Healing.md ranking table must show hasNormalizedText.',
+);
+
 console.log('Documentation quality checks passed.');

--- a/tests/docs-quality.test.js
+++ b/tests/docs-quality.test.js
@@ -265,44 +265,130 @@ assert(
   'The maintainer overview must link repository-local operational README files.',
 );
 
-const elementIdentification = readFileSync(
-  join(docsRoot, 'reference/actions/GUI/Element_Identification.md'),
-  'utf8',
-);
-const locatorsAndSelfHealing = readFileSync(
-  join(docsRoot, 'reference/actions/GUI/Locators_And_Self_Healing.md'),
-  'utf8',
-);
+const officialLocatorPages = {
+  elementIdentification: readFileSync(
+    join(docsRoot, 'reference/actions/GUI/Element_Identification.md'),
+    'utf8',
+  ),
+  locatorsAndSelfHealing: readFileSync(
+    join(docsRoot, 'reference/actions/GUI/Locators_And_Self_Healing.md'),
+    'utf8',
+  ),
+  web: readFileSync(join(docsRoot, 'testing/web.mdx'), 'utf8'),
+  pillars: readFileSync(join(docsRoot, 'features/test-automation-pillars.mdx'), 'utf8'),
+  solutionDesign: readFileSync(join(docsRoot, 'reference/guides/Solution_Design.md'), 'utf8'),
+};
+
+function titledJavaFences(content, titlePattern) {
+  return content.match(new RegExp('```java title="' + titlePattern + '"[\\s\\S]*?```', 'g')) || [];
+}
+
+for (const [name, content] of Object.entries(officialLocatorPages)) {
+  assert(
+    !/Prefer ID locators|most reliable and fastest/i.test(content),
+    `${name} must not rank raw ID as fastest or preferred over the generated locator policy.`,
+  );
+}
 
 assert(
-  !/Prefer ID locators/i.test(elementIdentification),
-  'Element_Identification.md Best Practices must not prefer raw ID locators over the generated locator policy.',
-);
-assert(
-  !/Avoid XPath when possible/i.test(elementIdentification),
+  !/Avoid XPath when possible/i.test(officialLocatorPages.elementIdentification),
   'Element_Identification.md must not tell readers to prefer CSS over native relative xpath.',
 );
 assert(
-  !/CSS selectors are generally faster/i.test(elementIdentification),
+  !/CSS selectors are generally faster/i.test(officialLocatorPages.elementIdentification),
   'Element_Identification.md must not rank CSS faster than native relative xpath.',
 );
 assert(
-  /hasAnyTagName\(\)\.hasId\("username"\)/.test(elementIdentification),
-  'Element_Identification.md LoginPage must use the SHAFT locator builder for a unique author-written id.',
+  !/SHAFT\.GUI\.Locator\.hasId\(/.test(officialLocatorPages.elementIdentification),
+  'Element_Identification.md must start unique ids at hasAnyTagName().hasId(...), not Locator.hasId(.',
 );
 assert(
-  !/private final By loginButton = By\.cssSelector/.test(elementIdentification),
+  !/By\.xpath\("\/\/input\[@id='username'\]"\)/.test(officialLocatorPages.elementIdentification),
+  'Element_Identification.md must not show xpath-by-id after saying use xpath only when there is no unique id.',
+);
+assert(
+  !/By elementLocator = By\.id\("username"\)/.test(officialLocatorPages.elementIdentification),
+  'Element_Identification.md catalog must not present By.id("username") as the generated form.',
+);
+
+const elementIdentificationLoginPages = titledJavaFences(
+  officialLocatorPages.elementIdentification,
+  'LoginPage\\.java',
+);
+assert(
+  elementIdentificationLoginPages.length === 1,
+  'Element_Identification.md must keep one titled LoginPage.java sample.',
+);
+assert(
+  /private final By loginButton = SHAFT\.GUI\.Locator\.hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log In"\)\.build\(\);/.test(
+    elementIdentificationLoginPages[0],
+  ),
+  'Element_Identification.md LoginPage loginButton must use hasRole + hasNormalizedText.',
+);
+assert(
+  !/private final By loginButton = By\.cssSelector/.test(elementIdentificationLoginPages[0]),
   'Element_Identification.md LoginPage must not recommend raw By.cssSelector as the generated form.',
+);
+assert(
+  /hasAnyTagName\(\)\.hasId\("username"\)/.test(elementIdentificationLoginPages[0]),
+  'Element_Identification.md LoginPage must use the SHAFT locator builder for a unique author-written id.',
+);
+
+const dynamicLocators = titledJavaFences(
+  officialLocatorPages.elementIdentification,
+  'DynamicLocators\\.java',
+);
+assert(dynamicLocators.length === 1, 'Element_Identification.md must keep a DynamicLocators.java sample.');
+assert(
+  !/By\.cssSelector/.test(dynamicLocators[0]),
+  'Element_Identification.md DynamicLocators.java must not lead with By.cssSelector.',
 );
 
 assert(
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Create Account"\)/.test(officialLocatorPages.web),
+  'web.mdx official second rung must use hasNormalizedText.',
+);
+assert(
+  !/hasRole\(Role\.BUTTON\)\.hasText\("Create Account"\)/.test(officialLocatorPages.web),
+  'web.mdx official second rung must not teach hasText.',
+);
+
+assert(
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log in"\)/.test(officialLocatorPages.pillars),
+  'test-automation-pillars.mdx login click must use hasNormalizedText.',
+);
+assert(
+  !/hasRole\(Role\.BUTTON\)\.hasText\("Log in"\)/.test(officialLocatorPages.pillars),
+  'test-automation-pillars.mdx login click must not teach hasText.',
+);
+
+const solutionLoginPages = titledJavaFences(
+  officialLocatorPages.solutionDesign,
+  '[^"]*LoginPage\\.java',
+);
+assert(
+  solutionLoginPages.length >= 1,
+  'Solution_Design.md must keep a titled LoginPage.java sample.',
+);
+for (const fence of solutionLoginPages) {
+  assert(
+    !/\bBy\.id\(/.test(fence),
+    'Solution_Design.md titled LoginPage.java samples must not teach raw By.id as the generated/repo form.',
+  );
+  assert(
+    /hasAnyTagName\(\)\.hasId\(/.test(fence),
+    'Solution_Design.md titled LoginPage.java samples must use the SHAFT locator builder for unique author-written ids.',
+  );
+}
+
+assert(
   !/ARIA role \| `SHAFT\.GUI\.Locator\.hasRole\(Role\.BUTTON\)\.hasText\("Log In"\)\.build\(\)`/.test(
-    locatorsAndSelfHealing,
+    officialLocatorPages.locatorsAndSelfHealing,
   ),
   'Locators_And_Self_Healing.md ranking table must not teach hasText as the official second rung.',
 );
 assert(
-  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log In"\)/.test(locatorsAndSelfHealing),
+  /hasRole\(Role\.BUTTON\)\.hasNormalizedText\("Log In"\)/.test(officialLocatorPages.locatorsAndSelfHealing),
   'Locators_And_Self_Healing.md ranking table must show hasNormalizedText.',
 );
 


### PR DESCRIPTION
## Summary

Closes #992
Closes #993
Related to ShaftHQ/SHAFT_ENGINE#5147.

Leftover teaching after #989 still ranked raw `By.id` / CSS over native relative xpath, and official locator-strategy pages taught `hasText` as the generated second rung.

- Best Practices and titled `LoginPage.java` samples now follow unique author-written id via `hasAnyTagName().hasId(...)`, then ARIA role with `hasNormalizedText`, then native relative `By.xpath(...)` only.
- Official first-link ladder on `docs/testing/web.mdx` now uses `hasNormalizedText`.
- `test-automation-pillars.mdx` login click uses `hasNormalizedText`.
- Titled `LoginPage.java` samples on `Solution_Design.md` use the SHAFT locator builder.
- Element_Identification leftover catalog / `hasId(` start / xpath-by-id / dynamic CSS samples now follow generated policy.
- Titled `ARIALocators.java` and `flakiness.mdx` Semantic Locators ladder / `SemanticLocators.java` now use `hasNormalizedText`.
- Raw Selenium `By` stays a reference for existing locators, not the generated-code default.
- Smart Locators stay human-exploration only.
- Ranking table now matches `LocatorPolicy` / the official policy section: `hasNormalizedText`.
- Method catalog still documents `hasText` as an existing builder method.
- `tests/docs-quality.test.js` fails if any public docs page teaches `hasRole(...).hasText(` as the generated form, and binds the titled `ARIALocators.java` / `SemanticLocators.java` fences.

## Checks

- RED then GREEN: `node tests/docs-quality.test.js`
- Repo-wide hunt: `hasRole(.*).hasText(` leftovers remain only in the quality-test assertion strings.
- Isolated worktree from fetched PR branch (`docs/locator-leftovers-992-993`). Primary checkout was not used.
- No browsers. No new screenshots. No SHAFT_ENGINE code edits.

## Continuation

- Head: `062bf8d8b831603396ca25d19b2a626429ea2a0c`
- State: Review 4963577044 F1-F2 patched on this SHA. Writer stopped.
- Blockers: none for this patch. Do not merge until orchestrator review of this exact head.
- Next action: independent review of `062bf8d8b831603396ca25d19b2a626429ea2a0c`. Writer does not merge.