### PR TITLE
docs: explain ChaosEngine lifecycle and recovery

### DIFF
--- a/docs/agentic/chaos-engine.mdx
+++ b/docs/agentic/chaos-engine.mdx
@@ -1,15 +1,15 @@
 ---
 id: chaos-engine
-title: Install ChaosEngine
-description: Install or upgrade the project-local SHAFT agent harness from the latest main commit.
+title: Install and operate ChaosEngine
+description: Install, inspect, recover, and understand the project-local SHAFT agent harness.
 slug: /agentic/chaos-engine
-keywords: [ChaosEngine, agent harness, install, upgrade, Codex, Claude, Gemini]
+keywords: [ChaosEngine, agent harness, install, upgrade, Codex, Claude, Gemini, Grok, Copilot]
 tags: [agents, skills, install]
 ---
 
-import {ReflectionReceiptCommand} from '@site/src/components/DocSnippets';
+import {ChaosEngineOperatorCommands, ReflectionReceiptCommand} from '@site/src/components/DocSnippets';
 
-# Install ChaosEngine
+# Install and operate ChaosEngine
 
 ChaosEngine is SHAFT's project-local agent harness. It makes one canonical
 skill the entrypoint for supported coding agents, installs the matching host
@@ -31,17 +31,17 @@ permission boundary instead of bypassing it.
 
 ## Verify and upgrade
 
-Run the installed status command from the project root:
+Run the operator commands from the project root. `status --json` and
+`explain <event> --json` emit deterministic, secret-free schema v1 objects.
+Use `explain` to inspect one normalized host event without executing it.
 
-```shell
-python3 .chaos-engine/install.py status --project .
-```
+<ChaosEngineOperatorCommands />
 
-On Windows, use `py -3` in place of `python3`. Re-run the same agent command to
-upgrade. The bootstrap resolves `main` to an immutable commit, validates the
-downloaded archive, and records its repository, branch, and commit provenance.
-If resolution, download, validation, or tool setup fails, ChaosEngine preserves
-the last verified installation.
+Re-run the same agent install command to upgrade. The bootstrap resolves
+`main` to an immutable commit, validates the downloaded archive, and records
+its repository, branch, and commit provenance. If resolution, download,
+validation, or tool setup fails, ChaosEngine preserves the last verified
+installation.
 
 The project may be a SHAFT Git checkout, another Git checkout, or a non-Git
 folder. The bootstrap uses the configured SHAFT upstream and never infers it
@@ -70,6 +70,58 @@ Installation, upgrade, explicit maintenance, `status`, and `doctor` remain
 strict. An unhealthy selected component makes requested `status` or `doctor`
 health `recovery-required`. Advisory task impact does not weaken those operator
 checks.
+
+## Understand startup and retrieval
+
+Session startup loads compact tracked locators, not full companion skill bodies.
+Each SessionStart payload stays at or below 4 KiB, while aggregate always-loaded
+guidance stays at or below 16 KiB. Startup never calls Memory, MemPalace, or
+Graphify synchronously.
+
+For ordinary work, ask Memory, MemPalace, or Graphify one bounded question only
+when it can shorten the task. Verify every useful result against current files.
+A missing, stale, timed-out, or inaccessible store becomes a non-blocking
+degraded result; do not repair, refresh, poll, or retry it during the task.
+
+## Follow the installed topology
+
+All five host adapters normalize their native lifecycle events into one
+provider-neutral kernel. Codex, Claude, Gemini, Grok, and GitHub Copilot keep
+their native configuration shapes and preserve foreign handlers. Copilot CLI
+hooks run live; Copilot cloud and IDE configuration receive static validation.
+
+```mermaid
+flowchart LR
+    Codex[Codex] --> Kernel[ChaosEngine kernel]
+    Claude[Claude] --> Kernel
+    Gemini[Gemini] --> Kernel
+    Grok[Grok] --> Kernel
+    Copilot[GitHub Copilot] --> Kernel
+    Kernel --> Runtime[Immutable active generation]
+    Runtime --> Memory[Memory]
+    Runtime --> MemPalace[MemPalace]
+    Runtime --> Graphify[Graphify]
+```
+
+The installer provisions missing Memory, MemPalace, Graphify, uv, and managed
+Python dependencies automatically. It repairs a damaged managed runtime by
+building and verifying a complete candidate generation before switching the
+active pointer. The prior verified generation remains available for rollback.
+Foreign files and foreign host handlers stay outside installer ownership.
+
+## Use the final-batch lifecycle
+
+Complete implementation as one coherent batch. Do not run tests, reviews,
+commits, or hooks after every edit. After the final scope commit, clear CI
+failures, annotations, bot findings, and review comments in batches, then run
+no more than two selected terminal adversarial reviews and consolidated tests.
+
+Do not run final holistic acceptance until the exact pull request head is fully
+green and no bot finding, comment, annotation, or review thread remains
+unresolved. Map that acceptance to the approved plan and every closing ticket,
+then arm merge-commit auto-merge immediately. A changed head or new remote
+feedback makes the acceptance stale; unchanged state never triggers another
+acceptance run.
 
 ## Respond to reflection checkpoints
 

--- a/src/components/DocSnippets/index.tsx
+++ b/src/components/DocSnippets/index.tsx
@@ -54,6 +54,19 @@ export function ReflectionReceiptCommand(): JSX.Element {
   return <CodeBlock language="bash">{snippets.reflectionReceiptCommand}</CodeBlock>;
 }
 
+export function ChaosEngineOperatorCommands(): JSX.Element {
+  return (
+    <>
+      <CodeBlock language="powershell" title="Windows">
+        {snippets.chaosEngineOperatorCommands.windows}
+      </CodeBlock>
+      <CodeBlock language="bash" title="macOS and Linux">
+        {snippets.chaosEngineOperatorCommands.posix}
+      </CodeBlock>
+    </>
+  );
+}
+
 export function FirstRunNoOpenCommand(): JSX.Element {
   return <CodeBlock language="bash">{snippets.firstRunNoOpenCommand}</CodeBlock>;
 }

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,6 +1,10 @@
 {
   "firstRunCommand": "mvn test",
   "reflectionReceiptCommand": "python3 .chaos-engine/hooks/reflection.py receipt \\\n  --session-id SESSION_ID \\\n  --session-token SESSION_TOKEN \\\n  --json '{\"schemaVersion\":1,\"taskId\":\"issue-123\",\"trigger\":\"repeated-fingerprint\",\"failureFingerprints\":[\"COPY_HASH_FROM_CHECKPOINT\"],\"failedAssumption\":\"The unchanged retry would add evidence.\",\"approachesCompared\":[\"Inspect the bounded state\",\"Change one diagnostic input\"],\"chosenExperiment\":\"Run the changed diagnostic check.\",\"changedApproach\":\"Stopped the unchanged retry.\",\"proofCommandOrCheck\":\"focused check\",\"proofOutcome\":\"The focused check passed.\",\"durableDisposition\":\"nothing-durable\"}'",
+  "chaosEngineOperatorCommands": {
+    "windows": "py -3 .chaos-engine/install.py status --project . --json\npy -3 .chaos-engine/install.py explain SessionStart --project . --host codex --json\npy -3 .chaos-engine/install.py rollback --project .",
+    "posix": "python3 .chaos-engine/install.py status --project . --json\npython3 .chaos-engine/install.py explain SessionStart --project . --host codex --json\npython3 .chaos-engine/install.py rollback --project ."
+  },
   "firstRunNoOpenCommand": "mvn test -Dallure.automaticallyOpen=false -Dallure.open=false",
   "allureReportPath": "allure-results and the generated Allure report under the project target output",
   "browserSelectionProperties": "targetBrowserName=CHROME\nheadlessExecution=true\ncreateAnimatedGif=true\nallure.singleFile=true",


### PR DESCRIPTION
## Summary

- document ChaosEngine schema v1 status and event explanation commands
- explain five-host normalization, automatic Memory/MemPalace/Graphify provisioning, immutable generations, repair, and rollback
- document startup budgets, bounded retrieval-first behavior, and the final-batch lifecycle that gates final acceptance on exact-head green CI and zero unresolved feedback
- centralize recurring operator commands in `DocSnippets`

## Checks

- `node tests/docs-quality.test.js`
- `node tests/docs-loader.test.js`
- `node scripts/check-doc-duplicates.mjs`
- `git diff --check`

## Screenshots

Not applicable. This changes documentation prose, code snippets, and a Mermaid topology diagram; no product UI or site styling changed.

## Engine delivery

Companion documentation for ShaftHQ/SHAFT_ENGINE#5307 and ShaftHQ/SHAFT_ENGINE#5306.
