### PR TITLE
docs(testing): Flutter guide + Locator.flutter* API updates (#5638)

### DIFF
--- a/docs/reference/actions/GUI/Locators_And_Self_Healing.md
+++ b/docs/reference/actions/GUI/Locators_And_Self_Healing.md
@@ -240,3 +240,20 @@ Always call `switchToDefaultContent()` after finishing work inside an iframe —
 - [SHAFT Heal](/docs/agentic/heal)
 - [Set up local infrastructure](/docs/start/local-infrastructure#install-managed-healenium)
 - [Web](/docs/testing/web)
+
+## Flutter locator factories {/* #flutter-locators */}
+
+For Flutter Integration Driver sessions, prefer `SHAFT.GUI.Locator.flutter*` thin wrappers over Appium java-client `AppiumBy.flutter*`:
+
+| Factory | Purpose |
+| --- | --- |
+| `flutterKey` | Flutter Key / ValueKey |
+| `flutterText` / `flutterTextContaining` | Exact / partial widget text |
+| `flutterType` | Widget type name (e.g. TextField) |
+| `flutterSemanticsLabel` | Semantics label (includes Tooltip text) |
+| `flutterDescendant` / `flutterAncestor` | Hierarchy finders |
+
+The `Locators` enum (`XPATH` / `CSS`) is only the relation-builder strategy enum used by `LocatorBuilder` — not a full By factory catalog.
+
+Full Flutter guide: [Flutter testing](/docs/testing/flutter).
+

--- a/docs/testing/flutter.md
+++ b/docs/testing/flutter.md
@@ -1,0 +1,133 @@
+---
+id: flutter
+title: Flutter testing guide
+sidebar_label: Flutter
+description: SHAFT Flutter guide with Locator.flutter factories and tap/type/assert sample.
+keywords: [SHAFT, Flutter, Appium, flutterKey, FlutterIntegration, mobile]
+tags: [mobile, flutter, appium]
+---
+
+# Flutter testing guide
+
+Specialized guide for automating Flutter apps with SHAFT Engine and the
+Appium Flutter Integration driver. For broader mobile setup, see
+[Mobile and Flutter testing](/docs/testing/mobile).
+
+## Prerequisites
+
+Requires JDK 17+, Appium Flutter Integration driver, emulator or BrowserStack, and a debug APK.
+
+## Obtain or build the demo APK
+
+Prefer the SHAFT CI pin of AppiumTestDistribution/appium-flutter-server:
+
+- Repository: https://github.com/AppiumTestDistribution/appium-flutter-server
+- Pin: 78ba97a6146091b944335d0db3330f74416f3ac7
+- Sparse checkout must include both demo-app and server (gotcha)
+
+Clone that pin, build a debug APK from demo-app, then assembleDebug with the
+Integration Server dart entrypoint under integration_test/appium.dart (same
+recipe as e2eTests.yml). Copy app-debug.apk to
+shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk.
+
+Release APKs are unsupported and fail with Flutter server is not started.
+
+## Locator reference
+
+Prefer SHAFT.GUI.Locator.flutter* over raw AppiumBy.flutter* in new tests:
+
+| Factory | Finds by | Example |
+| --- | --- | --- |
+| flutterKey | Key / ValueKey | SHAFT.GUI.Locator.flutterKey("LoginButton") |
+| flutterText | Exact text | SHAFT.GUI.Locator.flutterText("Please Login") |
+| flutterTextContaining | Partial text | SHAFT.GUI.Locator.flutterTextContaining("Please") |
+| flutterType | Widget type | SHAFT.GUI.Locator.flutterType("TextField") |
+| flutterSemanticsLabel | Semantics label | SHAFT.GUI.Locator.flutterSemanticsLabel("login_button") |
+| flutterDescendant / flutterAncestor | Hierarchy | Pass AppiumBy.FlutterBy args |
+
+The Locators enum (XPATH/CSS) is only the relation-builder strategy enum, not a
+full By catalog. Cucumber ElementSteps accepts mobile/Flutter type strings such
+as flutterkey and accessibilityid; the Java API remains the primary Flutter path.
+
+## Copy-paste runnable sample
+
+Matches testPackage.appium.FlutterTest against the pinned demo-app Login screen.
+
+```java
+package testPackage.appium;
+
+import com.shaft.driver.SHAFT;
+import io.appium.java_client.remote.AutomationName;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Platform;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class FlutterLoginSample {
+    private SHAFT.GUI.WebDriver driver;
+
+    private static final By PLEASE_LOGIN = SHAFT.GUI.Locator.flutterText("Please Login");
+    private static final By USERNAME = SHAFT.GUI.Locator.flutterKey("username_text_field");
+    private static final By PASSWORD = SHAFT.GUI.Locator.flutterKey("password");
+    private static final By LOGIN = SHAFT.GUI.Locator.flutterKey("LoginButton");
+    private static final By HOME_TITLE = SHAFT.GUI.Locator.flutterText("Samples List");
+
+    @BeforeMethod
+    public void setup() {
+        SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
+        SHAFT.Properties.mobile.set().automationName(AutomationName.FLUTTER_INTEGRATION);
+        SHAFT.Properties.mobile.set().browserName("");
+        SHAFT.Properties.platform.set().executionAddress("127.0.0.1:4723");
+        SHAFT.Properties.mobile.set().app("src/test/resources/testDataFiles/apps/flutter-demo.apk");
+        driver = new SHAFT.GUI.WebDriver();
+    }
+
+    @Test
+    public void tapTypeAssertText() {
+        driver.assertThat().element(PLEASE_LOGIN).exists();
+        driver.element().type(USERNAME, "admin");
+        driver.element().type(PASSWORD, "1234");
+        driver.element().assertThat(USERNAME).text().isEqualTo("admin");
+        driver.element().click(LOGIN);
+        driver.assertThat().element(HOME_TITLE).exists();
+        driver.element().assertThat(HOME_TITLE).text().contains("Samples");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() {
+        if (driver != null) { driver.quit(); }
+    }
+}
+```
+
+### Run locally
+
+1. Start Appium on 127.0.0.1:4723 with the Flutter Integration driver available.
+2. Attach an emulator or device.
+3. From the SHAFT_ENGINE checkout, run Maven against FlutterTest with:
+   `-Dshaft.enableFlutterE2E=true`
+   `-DexecutionAddress=127.0.0.1:4723`
+   `-Dmobile_app=src/test/resources/testDataFiles/apps/flutter-demo.apk`
+
+Without `-Dshaft.enableFlutterE2E=true`, FlutterTest throws SkipException so
+PR-gate unit jobs stay green with no emulator.
+
+## Common pitfalls
+
+| Pitfall | Fix |
+| --- | --- |
+| Release APK | Rebuild debug/profile with Integration Server target |
+| Sparse-checkout missing server | Include both demo-app and server |
+| Wrong driver package | Use appium-flutter-integration-driver + FlutterIntegration |
+| Confusing enable flags | shaft.enableFlutterE2E unskips FlutterTest; enableFlutterEmulatorE2E is a legacy workflow_dispatch input (nightly already selects the job) |
+| Flutter in GLOBAL_TESTING_SCOPE | Keep Flutter on dedicated Android_Flutter_Emulator_E2E only |
+| Old counter-app locators | CI demo-app is the Appium Testing App login flow |
+
+## Related
+
+- Engine sample: shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
+- Workflow: .github/workflows/e2eTests.yml (Flutter_Demo_App_Build, Android_Flutter_Emulator_E2E)
+- Locator tips: [Locators and Self-Healing](/docs/reference/actions/GUI/Locators_And_Self_Healing)
+- Issue: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5638
+

--- a/docs/testing/mobile.md
+++ b/docs/testing/mobile.md
@@ -340,7 +340,11 @@ attachments, and provider messages do not enter the event.
 
 ## Flutter applications
 
-SHAFT Engine now supports automated testing of Flutter applications using the Appium Flutter Driver. This integration lets you test Flutter apps on both Android and iOS platforms.
+SHAFT Engine supports automated testing of Flutter applications using the Appium Flutter Integration driver. This integration lets you test Flutter apps on both Android and iOS platforms.
+
+:::tip Specialized Flutter guide
+For prerequisites, demo APK build, locator table, pitfalls, and a full tap/type/assert sample using SHAFT.GUI.Locator.flutter*, see the [Flutter testing guide](/docs/testing/flutter).
+:::
 
 ## Prerequisites
 
@@ -352,7 +356,7 @@ First, install Appium with the Flutter driver plugin:
 npm install -g appium
 
 # Install the Flutter driver plugin
-appium driver install --source npm appium-flutter-driver
+appium driver install --source npm appium-flutter-integration-driver
 ```
 
 ### 2. Verify Installation
@@ -362,7 +366,7 @@ Verify that the Flutter driver is installed:
 appium driver list --installed
 ```
 
-You should see `flutter` in the list of installed drivers.
+You should see the Flutter integration driver in the list of installed drivers.
 
 ### 3. Prepare Your Flutter App
 Your Flutter app must be built in either **debug** or **profile** mode. The Appium Flutter Driver does **not** support release mode.
@@ -410,7 +414,6 @@ locators:
 package com.example.tests;
 
 import com.shaft.driver.SHAFT;
-import io.appium.java_client.AppiumBy;
 import io.appium.java_client.remote.AutomationName;
 import org.openqa.selenium.Platform;
 import org.testng.annotations.AfterMethod;
@@ -440,12 +443,12 @@ public class FlutterAppTest {
 
     @Test
     public void testFlutterApp() {
-        driver.element().click(AppiumBy.flutterKey("loginButton"));
+        driver.element().click(SHAFT.GUI.Locator.flutterKey("LoginButton"));
         
-        driver.element().assertThat(AppiumBy.flutterText("Welcome!"))
+        driver.element().assertThat(SHAFT.GUI.Locator.flutterText("Please Login"))
                 .exists();
         
-        driver.element().assertThat(AppiumBy.flutterType("TextField"))
+        driver.element().assertThat(SHAFT.GUI.Locator.flutterType("TextField"))
                 .exists();
     }
 
@@ -498,89 +501,57 @@ SHAFT.Properties.mobile.set().platformVersion("13.0");
 
 ## Locating Flutter Elements
 
-When testing Flutter apps, use java-client's native `AppiumBy` `flutter*` factory
-methods to locate widgets. They ship with the Appium dependency SHAFT Engine
-already declares, so no additional dependency is required.
+Prefer SHAFT.GUI.Locator.flutter* factories (thin wrappers over java-client AppiumBy.flutter*). Full table and sample: [Flutter testing guide](/docs/testing/flutter).
 
 ### Common Flutter Locator Strategies
 
 ```java
-import io.appium.java_client.AppiumBy;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.By;
 
-// By value key
-WebElement element = driver.getDriver().findElement(AppiumBy.flutterKey("myButton"));
-
-// By text
-WebElement element = driver.getDriver().findElement(AppiumBy.flutterText("Submit"));
-
-// By type (widget class name)
-WebElement element = driver.getDriver().findElement(AppiumBy.flutterType("TextField"));
-
-// By semantics label (also covers what Flutter's Tooltip widget exposes as its
-// tooltip message - there is no separate "by tooltip" locator)
-WebElement element = driver.getDriver().findElement(AppiumBy.flutterSemanticsLabel("Login Button"));
-
-// Note: Refer to the java-client AppiumBy documentation for the complete list of
-// available flutter* factory methods.
-// https://github.com/appium/java-client
+By byKey = SHAFT.GUI.Locator.flutterKey("myButton");
+By byText = SHAFT.GUI.Locator.flutterText("Submit");
+By byType = SHAFT.GUI.Locator.flutterType("TextField");
+By bySemantics = SHAFT.GUI.Locator.flutterSemanticsLabel("Login Button");
+By byPartial = SHAFT.GUI.Locator.flutterTextContaining("Sub");
 ```
 
 ### Working with Located Elements
 
-Once you have located an element using a native `flutter*` locator, you can
-interact with it directly - it is a standard Selenium `WebElement`:
-
-```java
-import io.appium.java_client.AppiumBy;
-
-// Find and click a button
-WebElement incrementButton = driver.getDriver().findElement(AppiumBy.flutterKey("increment"));
-incrementButton.click();
-
-// Find and get text from an element
-WebElement counterText = driver.getDriver().findElement(AppiumBy.flutterKey("counterDisplay"));
-String text = counterText.getText();
-
-// Find by semantics label and interact
-WebElement submitButton = driver.getDriver().findElement(AppiumBy.flutterSemanticsLabel("Submit"));
-submitButton.click();
-```
+Once you have a Flutter locator from SHAFT.GUI.Locator.flutter*, use SHAFT fluent
+element actions (`type`, `click`, `assertThat`) rather than raw findElement-only
+checks. See the [Flutter testing guide](/docs/testing/flutter) for a full sample.
 
 ### Using with SHAFT's Fluent API
 
-You can integrate Flutter finders with SHAFT's fluent API:
-
 ```java
-// Build a SHAFT locator
-By loginButton = SHAFT.GUI.Locator.accessibilityId("loginButton");
-By welcomeMessage = SHAFT.GUI.Locator.accessibilityId("welcomeMessage");
+By username = SHAFT.GUI.Locator.flutterKey("username_text_field");
+By loginButton = SHAFT.GUI.Locator.flutterKey("LoginButton");
+By homeTitle = SHAFT.GUI.Locator.flutterText("Samples List");
 
-// Use with SHAFT's fluent element actions
 driver.element()
-      .type(SHAFT.GUI.Locator.accessibilityId("usernameField"), "username")
+      .type(username, "admin")
       .and().click(loginButton)
-      .and().assertThat(welcomeMessage).text().contains("Welcome");
+      .and().assertThat(homeTitle).text().contains("Samples");
 ```
 
 ## Working with Flutter Widgets
 
 ### Text Input
 ```java
-By usernameField = SHAFT.GUI.Locator.accessibilityId("usernameField");
+By usernameField = SHAFT.GUI.Locator.flutterKey("username_text_field");
 driver.element().type(usernameField, "testuser");
 ```
 
 ### Button Clicks
 ```java
-By loginButton = SHAFT.GUI.Locator.accessibilityId("loginButton");
+By loginButton = SHAFT.GUI.Locator.flutterKey("LoginButton");
 driver.element().click(loginButton);
 ```
 
 ### Scrolling
 ```java
 driver.element().touch().swipeElementIntoView(
-    SHAFT.GUI.Locator.accessibilityId("targetWidget"),
+    SHAFT.GUI.Locator.flutterKey("targetWidget"),
     "DOWN"
 );
 ```
@@ -630,7 +601,7 @@ SHAFT.Properties.mobile.set().automationName(AutomationName.FLUTTER_INTEGRATION)
 ### Common Issues
 
 1. **"Could not find Flutter driver"**
-   - Ensure the Flutter driver is installed: `appium driver install --source npm appium-flutter-driver`
+   - Ensure the Flutter driver is installed: `appium driver install --source npm appium-flutter-integration-driver`
    - Verify with: `appium driver list --installed`
 
 2. **"Flutter driver extension not found"**
@@ -708,7 +679,6 @@ Complete example with multiple tests using native `AppiumBy` `flutter*` locators
 package com.example.tests;
 
 import com.shaft.driver.SHAFT;
-import io.appium.java_client.AppiumBy;
 import io.appium.java_client.remote.AutomationName;
 import org.openqa.selenium.Platform;
 import org.testng.annotations.*;
@@ -776,7 +746,7 @@ public class FlutterAppTestSuite {
 
 - [Testing overview](/docs/start/overview)
 - [Features](/docs/features/modules)
-- [Appium Flutter Driver documentation](https://github.com/appium-userland/appium-flutter-driver)
+- [Appium Flutter Driver documentation](https://github.com/appium-userland/appium-flutter-integration-driver)
 - [Flutter testing guide](https://flutter.dev/docs/testing)
 - [Appium Java client](https://github.com/appium/java-client) for native `AppiumBy.flutter*` locators
 - [SHAFT Engine issues](https://github.com/ShaftHQ/SHAFT_ENGINE/issues)

--- a/sidebars.js
+++ b/sidebars.js
@@ -48,6 +48,7 @@ const sidebars = {
         'testing/web',
         'testing/api',
         'testing/mobile',
+        'testing/flutter',
         'testing/database',
         'testing/cli',
         'testing/contracts',


### PR DESCRIPTION
User-facing docs for SHAFT_ENGINE#5638 / engine PR https://github.com/ShaftHQ/SHAFT_ENGINE/pull/5639.

- New guide: docs/testing/flutter.md (prereqs, demo APK pin, Locator.flutter* table, tap/type/assert sample, pitfalls)
- Wired into sidebars.js under Testing next to mobile
- Updated mobile.md Flutter sections + Locators_And_Self_Healing Flutter factories
- Validated with npx docusaurus build (exit 0). Live slug: /docs/testing/flutter