### PR TITLE
Remove every Headroom mention from the user guide

### DIFF
--- a/blog/2026-07-16-release-10.3.20260716.md
+++ b/blog/2026-07-16-release-10.3.20260716.md
@@ -51,8 +51,8 @@ for installation, configuration, privacy, troubleshooting, and usage examples.
 * Non-blocking graphify pre-check nudge; gbrain adoption spike (#3611) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3613
 * memory: gbrain PGLite embed-backfill root cause (issue 3611 follow-up) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3614
 * Non-blocking TDD nudge (R6); link enforced skills in act-as-fable by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3615
-* memory: gbrain embed-coverage resolved; headroom compression proxy adopted by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3616
-* Optimize agent guidance: dedupe, token cuts, binding act-as-fable, gbrain/headroom wiring by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3617
+* memory: gbrain embed-coverage resolved; compression proxy adopted by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3616
+* Optimize agent guidance: dedupe, token cuts, binding act-as-fable, gbrain and compression-proxy wiring by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3617
 * memory: IntelliJ plugin audit learning-loop update by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3644
 
 

--- a/blog/2026-07-18-release-10.3.20260717.md
+++ b/blog/2026-07-18-release-10.3.20260717.md
@@ -42,7 +42,7 @@ for installation, configuration, privacy, troubleshooting, and usage examples.
 
 ## What's Changed
 * intellij: Phase 1 lifecycle/threading hardening (#3619-#3623) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3646
-* Remove headroom proxy from agent guidance; record removal gotcha by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3651
+* Remove compression proxy from agent guidance; record removal gotcha by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3651
 * intellij: Phase 2 trust/status truth hardening (#3624-#3627) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3647
 * intellij: transcript & assistant ergonomics hardening (Phase 3, #3628-#3633) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3648
 * memory: stacked-branch rebase gotcha from #3647/#3648 merge session by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3652

--- a/blog/2026-07-27-release-10.3.20260727.md
+++ b/blog/2026-07-27-release-10.3.20260727.md
@@ -100,17 +100,17 @@ for installation, configuration, privacy, troubleshooting, and usage examples.
 * Fix #4071: delete redundant cucumber_testSuite.xml, add orphaned-suite-XML CI guard by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4112
 * Fix #4114: make the 20-minute stall watch two-sided by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4120
 * Memory: record six gotchas from the #4086 orchestration run by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4122
-* Fix #4121: reclaim byte headroom in act-as-fable SKILL.md by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4123
+* Fix #4121: reclaim byte budget in act-as-fable SKILL.md by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4123
 * Fix #4115: add targeted workflow_dispatch inputs to the E2E workflows by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4124
 * Fix #4116, #4118: incremental Learning Loop recording and a stall watch that covers local commands by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4125
-* Fix #4067: reclaim AGENTS.md byte headroom by moving the routing bridge list out of the budget glob by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4129
+* Fix #4067: reclaim AGENTS.md byte budget by moving the routing bridge list out of the budget glob by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4129
 * Memory: record six gotchas from the crash-recovery session (git config zeroing, squash-merge, Windows worktrees, validator split, byte-cap cycle, shared stash) by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4131
 * Fix #4083: make a delegate's refusal of orchestration commands structural, not discretionary by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4128
 * Fix #4110: unblock memory cross-links whose derived relation id exceeds the filename-length check by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4133
 * Fix #4090: keep network-event window attribution correct across tab switches by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4132
 * Fix #4119, #4097: correct the zero-scenario guard's module path and settle the BrowserStack Cucumber job by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4135
 * Fix #4091: detect Cucumber runners declared via packages, methods, or a child suite-file by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4134
-* Fix #4127: reclaim real headroom in act-as-fable SKILL.md via #4067's split by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4140
+* Fix #4127: reclaim real byte margin in act-as-fable SKILL.md via #4067's split by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4140
 * Fix screenshot helper failure reporter class by @Mochxd in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4139
 * Fix #4113: stop Gemini structured responses truncating at the output-token ceiling by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4136
 * Record two session gotchas: Bash colon-mangling and CI guard-replay technique by @MohabMohie in https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4141


### PR DESCRIPTION
## Summary
- Strip all case-insensitive `headroom` hits from the user guide repo.
- Rewrite three release blog posts so spare-bytes wording uses margin/budget and proxy bullets no longer name the product; PR links and meaning preserved.

## Test plan
- [x] `rg -i headroom` across the worktree (excluding `.git` and `node_modules`) returns empty