### PR TITLE
docs(testing): Flutter BrowserStack nightly and local emulator jobs

### DIFF
--- a/docs/testing/flutter.md
+++ b/docs/testing/flutter.md
@@ -113,6 +113,49 @@ public class FlutterLoginSample {
 Without `-Dshaft.enableFlutterE2E=true`, FlutterTest throws SkipException so
 PR-gate unit jobs stay green with no emulator.
 
+## SHAFT CI jobs (after #5755)
+
+Scheduled **E2E Tests** no longer boots a local AVD for Flutter. Nightly
+`FlutterTest` tap/type/text runs on BrowserStack. The local emulator path is
+automated on **Local E2E Tests**.
+
+| Job | Workflow | When it runs | What it proves |
+| --- | --- | --- | --- |
+| `Flutter_Demo_App_Build` | E2E Tests | Nightly, and when native or Flutter BrowserStack is selected | Wired debug APK at pin `78ba97a6146091b944335d0db3330f74416f3ac7` |
+| `Android_Flutter_BrowserStack` | E2E Tests | Nightly (same `jobs=all` selector as `Android_Native_BrowserStack`) | `FlutterTest` with `-Dshaft.enableFlutterE2E=true`, `-DexecutionAddress=browserstack`, `-Dmobile_automationName=FlutterIntegration`, Pixel 7 / 13.0, empty `browserStack.appUrl` |
+| `Ubuntu_Flutter_Emulator_Local` | Local E2E Tests | Scheduled nightly local suite, or `workflow_dispatch` `jobs=Ubuntu_Flutter_Emulator_Local` (or `all`) | Same `FlutterTest` against Appium on `127.0.0.1:4723` after `scripts/ci/flutter_emulator_preflight.sh` |
+
+### Dispatch commands
+
+Nightly Flutter on BrowserStack only:
+
+```text
+gh workflow run "E2E Tests" --ref main -f jobs=Android_Flutter_BrowserStack
+```
+
+Local emulator Flutter (KVM, Android SDK licenses including the Android XR
+preview license trap, Appium flutter-integration-driver, adb):
+
+```text
+gh workflow run "Local E2E Tests" --ref main -f jobs=Ubuntu_Flutter_Emulator_Local
+```
+
+Preflight is `scripts/ci/flutter_emulator_preflight.sh`. It must pass before
+`android-emulator-runner`. Do not put the emulator job back on E2E Tests
+`needs` — AVD boot and SDK licenses must not gate the cloud nightly.
+
+### Properties and locators (AI)
+
+- Locator policy: unique author-written id via `SHAFT.GUI.Locator.flutterKey` /
+  `flutterText` / `flutterSemanticsLabel` first; then ARIA/semantics; native
+  relative xpath last and only if Flutter factories cannot name the widget.
+- Skip unless `-Dshaft.enableFlutterE2E=true`.
+- Local: `-DexecutionAddress=127.0.0.1:4723` and `-Dmobile_app=.../flutter-demo.apk`.
+- BrowserStack: omit local Appium address so `FlutterTest` uses
+  `executionAddress=browserstack`, `browserStack.appRelativeFilePath` to the
+  wired APK, empty `appUrl`.
+- Keep `.*Flutter.*` out of `GLOBAL_TESTING_SCOPE`; dedicated jobs only.
+
 ## Common pitfalls
 
 | Pitfall | Fix |
@@ -120,14 +163,17 @@ PR-gate unit jobs stay green with no emulator.
 | Release APK | Rebuild debug/profile with Integration Server target |
 | Sparse-checkout missing server | Include both demo-app and server |
 | Wrong driver package | Use appium-flutter-integration-driver + FlutterIntegration |
-| Confusing enable flags | shaft.enableFlutterE2E unskips FlutterTest; enableFlutterEmulatorE2E is a legacy workflow_dispatch input (nightly already selects the job) |
-| Flutter in GLOBAL_TESTING_SCOPE | Keep Flutter on dedicated Android_Flutter_Emulator_E2E only |
+| Confusing enable flags | `shaft.enableFlutterE2E` unskips FlutterTest; there is no nightly `enableFlutterEmulatorE2E` gate |
+| Flutter in GLOBAL_TESTING_SCOPE | Dedicated `Android_Flutter_BrowserStack` (nightly) and `Ubuntu_Flutter_Emulator_Local` (local) only |
 | Old counter-app locators | CI demo-app is the Appium Testing App login flow |
+| Android XR SDK license hang | Preflight accepts licenses non-interactively before emulator image download |
 
 ## Related
 
 - Engine sample: shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
-- Workflow: .github/workflows/e2eTests.yml (Flutter_Demo_App_Build, Android_Flutter_Emulator_E2E)
+- Nightly: `.github/workflows/e2eTests.yml` (`Flutter_Demo_App_Build`, `Android_Flutter_BrowserStack`)
+- Local emulator: `.github/workflows/e2eLocalTests.yml` (`Ubuntu_Flutter_Emulator_Local`)
 - Locator tips: [Locators and Self-Healing](/docs/reference/actions/GUI/Locators_And_Self_Healing)
-- Issue: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5638
+- Issues: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5741 https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5743
+
 


### PR DESCRIPTION
## Summary

- Nightly Flutter E2E is **Android_Flutter_BrowserStack** on E2E Tests (not a local AVD).
- Local Flutter emulator is **Ubuntu_Flutter_Emulator_Local** on Local E2E Tests, with preflight.
- Human dispatch commands, properties, and locator policy for AI consumers.

SHAFT_ENGINE #5755 / #5741 / #5743.

## Checks

- Edited `docs/testing/flutter.md` only.

## Continuation

Merge on master. No screenshots (CI job names, not a UI panel).